### PR TITLE
Phase 1: CPU optimizations - FMA, restrict, batch API

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -50,10 +50,11 @@ cc_library(
         "-Wextra",
         "-O3",
         "-march=native",
-        "-fopenmp-simd",
+        "-fopenmp",  # Full OpenMP support for parallel for
         "-ftree-vectorize",
         "-DHAVE_SYSTEMTAP_SDT",  # Enable USDT by default
     ],
+    linkopts = ["-fopenmp"],  # Link OpenMP runtime
     deps = [":pde_solver"],
     visibility = ["//visibility:public"],
 )

--- a/src/american_option.h
+++ b/src/american_option.h
@@ -45,6 +45,17 @@ typedef struct {
 AmericanOptionResult american_option_price(const OptionData *option_data,
                                           const AmericanOptionGrid *grid_params);
 
+// Batch API: Price multiple American options in parallel
+// option_data: Array of n_options option specifications
+// grid_params: Grid parameters (shared across all options)
+// results: Output array of n_options results (caller allocated)
+// Returns: 0 on success, -1 on failure
+// Note: Caller must call pde_solver_destroy() on each result[i].solver
+int american_option_price_batch(const OptionData *option_data,
+                                 const AmericanOptionGrid *grid_params,
+                                 size_t n_options,
+                                 AmericanOptionResult *results);
+
 // Callback functions (exposed for advanced usage)
 // These match the PDE solver callback signatures
 


### PR DESCRIPTION
Implements Phase 1 quick wins from issue #14:
- Add restrict pointers to hot functions for better compiler optimization
- Replace arithmetic with fused multiply-add (FMA) operations
- Add __builtin_assume_aligned hints for SIMD vectorization
- Implement batch processing API with OpenMP parallelization
- Add full OpenMP support to american_option library

Changes:
- src/pde_solver.c: FMA in RHS/residual loops, restrict pointers, alignment hints in pde_solver_step_internal
- src/american_option.h/c: Add american_option_price_batch() API
- src/BUILD.bazel: Enable -fopenmp for parallel processing

Performance:
- Single option: ~24-25ms (baseline was 21.7ms, slight regression)
- FMA/restrict provide marginal gains, main benefit is batch API
- Batch API enables multi-core parallelization (tested separately)

All 7 tests passing.

Related: #14 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)