### PR TITLE
Remove Bazel symlinks from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Bazel build artifacts
+bazel-*
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+Thumbs.db

--- a/bazel-bin
+++ b/bazel-bin
@@ -1,1 +1,0 @@
-/home/kai/.cache/bazel/_bazel_kai/13aa886d35e6563235a1a1534894dcdf/execroot/_main/bazel-out/k8-fastbuild/bin

--- a/bazel-iv_calc
+++ b/bazel-iv_calc
@@ -1,1 +1,0 @@
-/home/kai/.cache/bazel/_bazel_kai/13aa886d35e6563235a1a1534894dcdf/execroot/_main

--- a/bazel-out
+++ b/bazel-out
@@ -1,1 +1,0 @@
-/home/kai/.cache/bazel/_bazel_kai/13aa886d35e6563235a1a1534894dcdf/execroot/_main/bazel-out

--- a/bazel-testlogs
+++ b/bazel-testlogs
@@ -1,1 +1,0 @@
-/home/kai/.cache/bazel/_bazel_kai/13aa886d35e6563235a1a1534894dcdf/execroot/_main/bazel-out/k8-fastbuild/testlogs


### PR DESCRIPTION
Bazel creates symlinks (bazel-bin, bazel-out, bazel-testlogs, bazel-iv_calc) that point to machine-specific cache directories. These should not be tracked in version control as they:
- Are build artifacts regenerated on each build
- Contain absolute paths specific to each developer's machine
- Can cause confusion when cloning on different systems

Added .gitignore to prevent these and other build artifacts from being accidentally committed in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)