### PR TITLE
Normalize coding style across codebase

### DIFF
--- a/src/american_option.c
+++ b/src/american_option.c
@@ -35,6 +35,7 @@ void american_option_terminal_condition(const double *x, size_t n_points,
     const OptionData *data = ext_data->option_data;
     const double K = data->strike;
 
+    #pragma omp simd
     for (size_t i = 0; i < n_points; i++) {
         // x = ln(S/K), so S = K*exp(x)
         double S = K * exp(x[i]);
@@ -231,6 +232,7 @@ AmericanOptionResult american_option_price(const OptionData *option_data,
         }
 
         const double T = option_data->time_to_maturity;
+        #pragma omp simd
         for (size_t i = 0; i < option_data->n_dividends; i++) {
             div_times_solver[i] = T - option_data->dividend_times[i];
         }
@@ -338,12 +340,12 @@ void american_option_free_result(AmericanOptionResult *result) {
 
 // Temporal event callback for discrete dividends
 // Called by solver when dividend events are crossed
-static void american_option_dividend_event(double t, const double *x_grid,
+static void american_option_dividend_event([[maybe_unused]] double t,
+                                           const double *x_grid,
                                            size_t n_points, double *V,
                                            const size_t *event_indices,
                                            size_t n_events_triggered,
                                            void *user_data) {
-    (void)t; // Unused: time is implicit in event indices
     ExtendedOptionData *ext_data = (ExtendedOptionData *)user_data;
     const OptionData *option_data = ext_data->option_data;
 
@@ -363,6 +365,7 @@ static void american_option_dividend_event(double t, const double *x_grid,
                                       option_data->strike);
 
         // Copy adjusted solution back
+        #pragma omp simd
         for (size_t j = 0; j < n_points; j++) {
             V[j] = V_temp[j];
         }

--- a/src/pde_solver.c
+++ b/src/pde_solver.c
@@ -322,6 +322,7 @@ SpatialGrid pde_create_grid(double x_min, double x_max, size_t n_points) {
     grid.dx = (x_max - x_min) / (n_points - 1);
     grid.x = malloc(n_points * sizeof(double));
 
+    #pragma omp simd
     for (size_t i = 0; i < n_points; i++) {
         grid.x[i] = x_min + i * grid.dx;
     }

--- a/src/price_table.c
+++ b/src/price_table.c
@@ -97,6 +97,7 @@ OptionPriceTable* price_table_create_with_strategy(
     }
 
     // Initialize prices to NaN
+    #pragma omp simd
     for (size_t i = 0; i < n_points; i++) {
         table->prices[i] = NAN;
     }
@@ -168,13 +169,11 @@ void price_table_destroy(OptionPriceTable *table) {
 
 // ---------- Pre-computation ----------
 
-int price_table_precompute(OptionPriceTable *table,
-                            const void *pde_solver_template) {
+int price_table_precompute([[maybe_unused]] OptionPriceTable *table,
+                            [[maybe_unused]] const void *pde_solver_template) {
     // Note: This is a placeholder for Phase 2
     // In Phase 2, we'll implement the actual FDM-based pre-computation
     // with OpenMP parallelization
-    (void)table;
-    (void)pde_solver_template;
     return -1;  // Not yet implemented
 }
 


### PR DESCRIPTION
Replace all (void) parameter suppressions with C23 [[maybe_unused]] attribute for better type safety and compiler diagnostics. This modernizes the codebase to use standard C23 features instead of legacy void casts.

Add Unicode symbols to mathematical expressions in code comments (e.g., ∂, ², ³, τ, σ) to improve readability and match standard mathematical notation. This makes the relationship between code and mathematical formulas more apparent.

Add OpenMP SIMD pragmas to numerical computation loops for better compiler vectorization. These annotations enable AVX2/AVX-512 optimizations without changing algorithm logic:
- Interpolation stage calculations in multilinear interpolation
- Grid initialization and array operations in PDE solver
- Cubic spline coefficient computations
- American option terminal condition and dividend adjustments

Changes affect: interp_cubic.c, interp_multilinear.c, price_table.c, american_option.c, pde_solver.c, cubic_spline.c

🤖 Generated with [Claude Code](https://claude.com/claude-code)