### PR TITLE
Add -fopenmp-simd flag to libraries using OpenMP pragmas

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -11,6 +11,8 @@ cc_library(
         "-Wall",
         "-Wextra",
         "-O3",
+        "-fopenmp-simd",
+        "-ftree-vectorize",
         "-DHAVE_SYSTEMTAP_SDT",  # Enable USDT by default (gracefully falls back if sys/sdt.h missing)
     ],
     visibility = ["//visibility:public"],
@@ -111,6 +113,7 @@ cc_library(
         "-Wextra",
         "-O3",
         "-march=native",
+        "-fopenmp-simd",
         "-ftree-vectorize",
     ],
     visibility = ["//visibility:public"],
@@ -136,6 +139,7 @@ cc_library(
         "-Wextra",
         "-O3",
         "-march=native",
+        "-fopenmp-simd",
         "-ftree-vectorize",
     ],
     deps = [":cubic_spline"],
@@ -171,6 +175,8 @@ cc_library(
         "-Wall",
         "-Wextra",
         "-O3",
+        "-fopenmp-simd",
+        "-ftree-vectorize",
     ],
     deps = [
         ":interp_multilinear",


### PR DESCRIPTION
Several libraries use #pragma omp simd for SIMD vectorization but were missing the -fopenmp-simd compiler flag, causing CI to report "unknown pragma" warnings.

Added -fopenmp-simd and -ftree-vectorize flags to:
- cubic_spline (used in tridiagonal.h, cubic_spline.c)
- interp_cubic (used in interp_cubic.c)
- interp_multilinear (used in interp_multilinear.c)
- price_table (used in price_table.c)

This matches the configuration already present in pde_solver and american_option libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)