### PR TITLE
Rename tracing prefix from ivcalc to mango

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ mango-iv/
 │   ├── iv_surface.{h,c}           # 2D implied volatility surfaces
 │   ├── brent.h                    # Brent's method (root-finding)
 │   ├── tridiagonal.h              # Tridiagonal solver
-│   └── ivcalc_trace.h             # USDT tracing probes
+│   └── mango_trace.h             # USDT tracing probes
 │
 ├── examples/                      # Demonstration programs
 │   ├── example_implied_volatility.c
@@ -236,7 +236,7 @@ mango-iv/
 │   └── QUICK_REFERENCE.md         # Developer quick-start
 │
 ├── scripts/                       # Utilities
-│   ├── ivcalc-trace               # USDT tracing helper
+│   ├── mango-trace               # USDT tracing helper
 │   └── tracing/                   # bpftrace scripts
 │
 ├── CLAUDE.md                      # Instructions for Claude Code
@@ -260,13 +260,13 @@ The library includes **zero-overhead tracing** via USDT (User Statically-Defined
 
 ```bash
 # Monitor all library activity
-sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_american_option
+sudo ./scripts/mango-trace monitor ./bazel-bin/examples/example_american_option
 
 # Watch convergence behavior
-sudo ./scripts/ivcalc-trace monitor ./my_program --preset=convergence
+sudo ./scripts/mango-trace monitor ./my_program --preset=convergence
 
 # Debug failures
-sudo ./scripts/ivcalc-trace monitor ./my_program --preset=debug
+sudo ./scripts/mango-trace monitor ./my_program --preset=debug
 ```
 
 Tracing provides:

--- a/TRACING_QUICKSTART.md
+++ b/TRACING_QUICKSTART.md
@@ -1,6 +1,6 @@
 # USDT Tracing Quick Start (5 Minutes)
 
-Get started with zero-overhead tracing of the ivcalc library in under 5 minutes.
+Get started with zero-overhead tracing of the mango library in under 5 minutes.
 
 ## What is USDT Tracing?
 
@@ -43,13 +43,13 @@ The binaries automatically include USDT probes (gracefully falls back if systemt
 
 ```bash
 # Check if probes are present
-sudo ./scripts/ivcalc-trace check ./bazel-bin/examples/example_heat_equation
+sudo ./scripts/mango-trace check ./bazel-bin/examples/example_heat_equation
 ```
 
 Expected output:
 ```
 ✓ USDT notes found in binary
-✓ Found 15 ivcalc probes
+✓ Found 15 mango probes
 ✓ bpftrace can attach to probes
 
 USDT support: OK
@@ -61,16 +61,16 @@ USDT support: OK
 
 ```bash
 # Monitor all library activity
-sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation
+sudo ./scripts/mango-trace monitor ./bazel-bin/examples/example_heat_equation
 
 # Watch convergence behavior
-sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation --preset=convergence
+sudo ./scripts/mango-trace monitor ./bazel-bin/examples/example_heat_equation --preset=convergence
 
 # Debug failures
-sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation --preset=debug
+sudo ./scripts/mango-trace monitor ./bazel-bin/examples/example_heat_equation --preset=debug
 
 # Profile performance
-sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation --preset=performance
+sudo ./scripts/mango-trace monitor ./bazel-bin/examples/example_heat_equation --preset=performance
 ```
 
 **Option B: Use bpftrace directly**
@@ -88,7 +88,7 @@ sudo bpftrace scripts/tracing/convergence_watch.bt -c './bazel-bin/examples/exam
 ### Debug Convergence Issues
 
 ```bash
-sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation --preset=debug
+sudo ./scripts/mango-trace monitor ./bazel-bin/examples/example_heat_equation --preset=debug
 ```
 
 Shows:
@@ -146,16 +146,16 @@ All scripts are in `scripts/tracing/`:
 
 ```bash
 # List all available probes
-sudo ./scripts/ivcalc-trace list ./bazel-bin/examples/example_heat_equation
+sudo ./scripts/mango-trace list ./bazel-bin/examples/example_heat_equation
 
 # Validate USDT support
-sudo ./scripts/ivcalc-trace check ./bazel-bin/examples/example_heat_equation
+sudo ./scripts/mango-trace check ./bazel-bin/examples/example_heat_equation
 
 # Monitor with preset
-sudo ./scripts/ivcalc-trace monitor <binary> --preset=<name>
+sudo ./scripts/mango-trace monitor <binary> --preset=<name>
 
 # Run specific script
-sudo ./scripts/ivcalc-trace run convergence_watch.bt <binary>
+sudo ./scripts/mango-trace run convergence_watch.bt <binary>
 ```
 
 ## Attach to Running Process
@@ -196,7 +196,7 @@ bazel build //examples:example_heat_equation
 
 Solution: bpftrace requires root privileges
 ```bash
-sudo ./scripts/ivcalc-trace monitor <binary>
+sudo ./scripts/mango-trace monitor <binary>
 ```
 
 **Problem: "bpftrace: command not found"**
@@ -224,11 +224,11 @@ sudo yum install bpftrace
 bazel build //examples:example_heat_equation
 
 # 2. Check USDT
-sudo ./scripts/ivcalc-trace check ./bazel-bin/examples/example_heat_equation
+sudo ./scripts/mango-trace check ./bazel-bin/examples/example_heat_equation
 # ✓ USDT support: OK
 
 # 3. Monitor
-sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation --preset=convergence
+sudo ./scripts/mango-trace monitor ./bazel-bin/examples/example_heat_equation --preset=convergence
 
 # Output shows:
 # - Convergence iterations per step
@@ -239,7 +239,7 @@ sudo ./scripts/ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation -
 
 ## That's It!
 
-You're now tracing the ivcalc library. Use the scripts to:
+You're now tracing the mango library. Use the scripts to:
 - ✅ Debug convergence issues
 - ✅ Profile performance
 - ✅ Monitor production systems

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1665,7 +1665,7 @@ bazel build //benchmarks:quantlib_benchmark
 | **Brent's Method** | Root finding for IV | brent.h | `brent_find_root()` |
 | **Cubic Spline** | Off-grid PDE interpolation | cubic_spline.{h,c} | `pde_spline_create()` (malloc), `pde_spline_init()` (workspace), `pde_spline_eval()` |
 | **Tridiagonal Solver** | O(n) matrix solve | tridiagonal.h | `solve_tridiagonal()` |
-| **USDT Tracing** | Diagnostic probes | ivcalc_trace.h | `IVCALC_TRACE_*` macros |
+| **USDT Tracing** | Diagnostic probes | ivcalc_trace.h | `MANGO_TRACE_*` macros |
 
 ---
 

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -207,7 +207,7 @@ mango-iv/
 │   ├── pde_solver.{h,c}           # General PDE solver (FDM)
 │   ├── cubic_spline.{h,c}         # Interpolation
 │   ├── brent.h                    # Root-finding
-│   └── ivcalc_trace.h             # USDT tracing probes
+│   └── mango_trace.h             # USDT tracing probes
 │
 ├── examples/                      # Demonstration programs
 │   ├── example_implied_volatility.c
@@ -230,7 +230,7 @@ mango-iv/
 │   └── QUICK_REFERENCE.md         # Developer quick-start
 │
 ├── scripts/                       # Utilities
-│   ├── ivcalc-trace               # USDT tracing helper
+│   ├── mango-trace               # USDT tracing helper
 │   └── tracing/                   # bpftrace scripts
 │
 ├── CLAUDE.md                      # Instructions for Claude Code

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -311,15 +311,15 @@ The library includes USDT probes for zero-overhead tracing.
 
 ```bash
 # List available probes
-readelf -x .stapsdt.base ./binary | grep ivcalc
+readelf -x .stapsdt.base ./binary | grep mango
 
 # Simple trace with bpftrace
-sudo bpftrace -e 'usdt::ivcalc:convergence_iter { 
+sudo bpftrace -e 'usdt::mango:convergence_iter { 
     printf("Module %d, step %d, error %g\n", arg0, arg1, arg2);
 }'
 
 # Or use provided scripts
-sudo ./scripts/ivcalc-trace monitor ./binary --preset=convergence
+sudo ./scripts/mango-trace monitor ./binary --preset=convergence
 ```
 
 ---
@@ -419,7 +419,7 @@ double gamma = (price_up + price_down - 2*price) / (ds * ds);
 | Root finding | `src/brent.h` |
 | Interpolation | `src/cubic_spline.h/.c` |
 | Linear solver | `src/tridiagonal.h` |
-| Tracing | `src/ivcalc_trace.h` |
+| Tracing | `src/mango_trace.h` |
 
 ---
 

--- a/scripts/mango-trace
+++ b/scripts/mango-trace
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# ivcalc-trace - Helper tool for tracing ivcalc library with bpftrace
+# mango-trace - Helper tool for tracing mango library with bpftrace
 #
 # Usage:
-#   ./ivcalc-trace list <binary>             - List available USDT probes
-#   ./ivcalc-trace check <binary>            - Validate USDT support
-#   ./ivcalc-trace monitor <binary> [args]   - Quick monitor with preset
-#   ./ivcalc-trace run <script> <binary>     - Run specific bpftrace script
+#   ./mango-trace list <binary>             - List available USDT probes
+#   ./mango-trace check <binary>            - Validate USDT support
+#   ./mango-trace monitor <binary> [args]   - Quick monitor with preset
+#   ./mango-trace run <script> <binary>     - Run specific bpftrace script
 #
 
 set -e
@@ -23,13 +23,13 @@ NC='\033[0m' # No Color
 
 usage() {
     cat << EOF
-ivcalc-trace - Helper tool for tracing ivcalc library
+mango-trace - Helper tool for tracing mango library
 
 Usage:
-    ivcalc-trace list <binary>                    List available USDT probes
-    ivcalc-trace check <binary>                   Validate USDT support
-    ivcalc-trace monitor <binary> [--preset=<p>]  Monitor with preset
-    ivcalc-trace run <script> <binary> [args]     Run specific script
+    mango-trace list <binary>                    List available USDT probes
+    mango-trace check <binary>                   Validate USDT support
+    mango-trace monitor <binary> [--preset=<p>]  Monitor with preset
+    mango-trace run <script> <binary> [args]     Run specific script
 
 Commands:
     list          List all USDT probes in binary
@@ -47,22 +47,22 @@ Monitor Presets:
 
 Examples:
     # Check USDT support
-    ivcalc-trace check ./bazel-bin/examples/example_heat_equation
+    mango-trace check ./bazel-bin/examples/example_heat_equation
 
     # List available probes
-    ivcalc-trace list ./bazel-bin/examples/example_heat_equation
+    mango-trace list ./bazel-bin/examples/example_heat_equation
 
     # Quick monitoring
-    ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation
+    mango-trace monitor ./bazel-bin/examples/example_heat_equation
 
     # Watch convergence
-    ivcalc-trace monitor ./bazel-bin/examples/example_heat_equation --preset=convergence
+    mango-trace monitor ./bazel-bin/examples/example_heat_equation --preset=convergence
 
     # Run specific script
-    ivcalc-trace run convergence_watch.bt ./bazel-bin/examples/example_heat_equation
+    mango-trace run convergence_watch.bt ./bazel-bin/examples/example_heat_equation
 
     # Monitor with binary arguments
-    ivcalc-trace monitor ./my_program --preset=debug -- --my-arg value
+    mango-trace monitor ./my_program --preset=debug -- --my-arg value
 
 Requirements:
     - bpftrace (v0.12+)
@@ -112,7 +112,7 @@ list_probes() {
     echo -e "${BLUE}USDT probes in $binary:${NC}"
     echo
 
-    if ! bpftrace -l "usdt:$binary:ivcalc:*" 2>/dev/null; then
+    if ! bpftrace -l "usdt:$binary:mango:*" 2>/dev/null; then
         echo -e "${RED}No USDT probes found!${NC}"
         echo "This binary may not have been built with USDT support."
         echo "Verify with: readelf -n $binary | grep NT_STAPSDT"
@@ -136,11 +136,11 @@ check_usdt() {
         echo -e "${GREEN}✓ USDT notes found in binary${NC}"
 
         # Count probes
-        local probe_count=$(bpftrace -l "usdt:$binary:ivcalc:*" 2>/dev/null | wc -l)
-        echo -e "${GREEN}✓ Found $probe_count ivcalc probes${NC}"
+        local probe_count=$(bpftrace -l "usdt:$binary:mango:*" 2>/dev/null | wc -l)
+        echo -e "${GREEN}✓ Found $probe_count mango probes${NC}"
 
         # Check bpftrace can see them
-        if bpftrace -l "usdt:$binary:ivcalc:*" &>/dev/null; then
+        if bpftrace -l "usdt:$binary:mango:*" &>/dev/null; then
             echo -e "${GREEN}✓ bpftrace can attach to probes${NC}"
         else
             echo -e "${YELLOW}⚠ bpftrace cannot list probes (may need newer version)${NC}"

--- a/scripts/tracing/README.md
+++ b/scripts/tracing/README.md
@@ -1,6 +1,6 @@
-# ivcalc Tracing Scripts
+# mango Tracing Scripts
 
-This directory contains ready-to-use bpftrace scripts for monitoring and debugging the ivcalc library.
+This directory contains ready-to-use bpftrace scripts for monitoring and debugging the mango library.
 
 ## Quick Start
 
@@ -149,7 +149,7 @@ sudo bpftrace performance_profile.bt -c './example' > trace_output.txt
 
 **No probes found:**
 - Ensure binary was built with USDT support (should be default)
-- Verify probes exist: `sudo bpftrace -l 'usdt:./your_binary:ivcalc:*'`
+- Verify probes exist: `sudo bpftrace -l 'usdt:./your_binary:mango:*'`
 
 **Permission denied:**
 - bpftrace requires root privileges: use `sudo`

--- a/scripts/tracing/convergence_watch.bt
+++ b/scripts/tracing/convergence_watch.bt
@@ -18,7 +18,7 @@ BEGIN
 }
 
 /* Track convergence iterations */
-usdt::ivcalc:convergence_iter
+usdt::mango:convergence_iter
 {
     // Only print every Nth iteration to avoid flooding
     if (arg2 % 5 == 0 || arg3 < arg4 * 10.0) {
@@ -38,7 +38,7 @@ usdt::ivcalc:convergence_iter
 }
 
 /* Convergence success */
-usdt::ivcalc:convergence_success
+usdt::mango:convergence_success
 {
     if (arg0 == 1) { @mod = "PDE_SOLVER"; }
     else if (arg0 == 2) { @mod = "AMERICAN_OPTION"; }
@@ -56,7 +56,7 @@ usdt::ivcalc:convergence_success
 }
 
 /* Convergence failure */
-usdt::ivcalc:convergence_failed
+usdt::mango:convergence_failed
 {
     if (arg0 == 1) { @mod = "PDE_SOLVER"; }
     else if (arg0 == 2) { @mod = "AMERICAN_OPTION"; }

--- a/scripts/tracing/debug_failures.bt
+++ b/scripts/tracing/debug_failures.bt
@@ -17,7 +17,7 @@ BEGIN
 }
 
 /* Convergence failure - detailed diagnostics */
-usdt::ivcalc:convergence_failed
+usdt::mango:convergence_failed
 {
     if (arg0 == 1) { @mod = "PDE_SOLVER"; }
     else if (arg0 == 2) { @mod = "AMERICAN_OPTION"; }
@@ -37,7 +37,7 @@ usdt::ivcalc:convergence_failed
 }
 
 /* Validation error - detailed diagnostics */
-usdt::ivcalc:validation_error
+usdt::mango:validation_error
 {
     if (arg0 == 1) { @mod = "PDE_SOLVER"; }
     else if (arg0 == 2) { @mod = "AMERICAN_OPTION"; }
@@ -70,7 +70,7 @@ usdt::ivcalc:validation_error
 }
 
 /* Runtime error - detailed diagnostics */
-usdt::ivcalc:runtime_error
+usdt::mango:runtime_error
 {
     if (arg0 == 1) { @mod = "PDE_SOLVER"; }
     else if (arg0 == 2) { @mod = "AMERICAN_OPTION"; }
@@ -89,7 +89,7 @@ usdt::ivcalc:runtime_error
 }
 
 /* Track iterations before failure for diagnostics */
-usdt::ivcalc:convergence_iter
+usdt::mango:convergence_iter
 /arg0 == 1/  /* PDE solver */
 {
     @last_pde_step = arg1;
@@ -98,7 +98,7 @@ usdt::ivcalc:convergence_iter
 }
 
 /* Show last state before PDE convergence failure */
-usdt::ivcalc:convergence_failed
+usdt::mango:convergence_failed
 /arg0 == 1/
 {
     printf("  Last iteration details:\n");

--- a/scripts/tracing/iv_detailed.bt
+++ b/scripts/tracing/iv_detailed.bt
@@ -18,7 +18,7 @@ BEGIN
 }
 
 /* IV calculation starts */
-usdt::ivcalc:iv_start
+usdt::mango:iv_start
 {
     printf("IV Calculation Starting\n");
     printf("  Spot price: %.4f\n", arg0);
@@ -37,7 +37,7 @@ usdt::ivcalc:iv_start
 }
 
 /* Validation errors */
-usdt::ivcalc:validation_error
+usdt::mango:validation_error
 /arg0 == 3/  /* MODULE_IMPLIED_VOL */
 {
     printf("\033[31mValidation Error\033[0m\n");
@@ -65,7 +65,7 @@ usdt::ivcalc:validation_error
 }
 
 /* Brent's method starts */
-usdt::ivcalc:algo_start
+usdt::mango:algo_start
 /arg0 == 4/  /* MODULE_BRENT_ROOT */
 {
     printf("Brent's Method Starting\n");
@@ -76,7 +76,7 @@ usdt::ivcalc:algo_start
 }
 
 /* Brent iterations */
-usdt::ivcalc:brent_iter
+usdt::mango:brent_iter
 {
     $iter = arg0;
     $x = arg1;
@@ -94,7 +94,7 @@ usdt::ivcalc:brent_iter
 }
 
 /* IV calculation completes */
-usdt::ivcalc:iv_complete
+usdt::mango:iv_complete
 {
     $duration_us = (nsecs - @iv_start) / 1000;
     $iv = arg0;

--- a/scripts/tracing/monitor_all.bt
+++ b/scripts/tracing/monitor_all.bt
@@ -1,6 +1,6 @@
 #!/usr/bin/env bpftrace
 /*
- * monitor_all.bt - Monitor all ivcalc library activity
+ * monitor_all.bt - Monitor all mango library activity
  *
  * This script provides a high-level overview of all library operations.
  * Shows algorithm starts, completions, and any errors/failures.
@@ -12,14 +12,14 @@
 
 BEGIN
 {
-    printf("Monitoring ivcalc library activity...\n");
+    printf("Monitoring mango library activity...\n");
     printf("%-10s %-20s %s\n", "TIME", "MODULE", "EVENT");
     printf("-----------------------------------------------------------\n");
 }
 
 /* Module name lookup */
-usdt::ivcalc:algo_start,
-usdt::ivcalc:algo_complete
+usdt::mango:algo_start,
+usdt::mango:algo_complete
 {
     if (arg0 == 1) { @module_name = "PDE_SOLVER"; }
     else if (arg0 == 2) { @module_name = "AMERICAN_OPTION"; }
@@ -30,14 +30,14 @@ usdt::ivcalc:algo_complete
 }
 
 /* Algorithm lifecycle */
-usdt::ivcalc:algo_start
+usdt::mango:algo_start
 {
     printf("%-10u %-20s START\n", elapsed / 1000000, str(@module_name));
     @start_time[arg0] = nsecs;
     @algo_count++;
 }
 
-usdt::ivcalc:algo_complete
+usdt::mango:algo_complete
 {
     $duration_ms = (nsecs - @start_time[arg0]) / 1000000;
     printf("%-10u %-20s COMPLETE (iterations=%d, duration=%u ms)\n",
@@ -46,7 +46,7 @@ usdt::ivcalc:algo_complete
 }
 
 /* Convergence failures - ALERT */
-usdt::ivcalc:convergence_failed
+usdt::mango:convergence_failed
 {
     if (arg0 == 1) { @module_name = "PDE_SOLVER"; }
     else if (arg0 == 2) { @module_name = "AMERICAN_OPTION"; }
@@ -60,7 +60,7 @@ usdt::ivcalc:convergence_failed
 }
 
 /* Validation errors */
-usdt::ivcalc:validation_error
+usdt::mango:validation_error
 {
     if (arg0 == 1) { @module_name = "PDE_SOLVER"; }
     else if (arg0 == 2) { @module_name = "AMERICAN_OPTION"; }
@@ -74,7 +74,7 @@ usdt::ivcalc:validation_error
 }
 
 /* Runtime errors */
-usdt::ivcalc:runtime_error
+usdt::mango:runtime_error
 {
     if (arg0 == 1) { @module_name = "PDE_SOLVER"; }
     else if (arg0 == 2) { @module_name = "AMERICAN_OPTION"; }

--- a/scripts/tracing/pde_detailed.bt
+++ b/scripts/tracing/pde_detailed.bt
@@ -18,7 +18,7 @@ BEGIN
 }
 
 /* PDE solver starts */
-usdt::ivcalc:algo_start
+usdt::mango:algo_start
 /arg0 == 1/  /* MODULE_PDE_SOLVER */
 {
     printf("PDE Solver Starting\n");
@@ -32,7 +32,7 @@ usdt::ivcalc:algo_start
 }
 
 /* Track progress through time steps */
-usdt::ivcalc:algo_progress
+usdt::mango:algo_progress
 /arg0 == 1/  /* PDE solver */
 {
     $step = arg1;
@@ -47,7 +47,7 @@ usdt::ivcalc:algo_progress
 }
 
 /* Monitor implicit solver convergence per time step */
-usdt::ivcalc:convergence_iter
+usdt::mango:convergence_iter
 /arg0 == 1/  /* PDE solver */
 {
     $step = arg1;
@@ -66,7 +66,7 @@ usdt::ivcalc:convergence_iter
 }
 
 /* Implicit solver converged */
-usdt::ivcalc:convergence_success
+usdt::mango:convergence_success
 /arg0 == 1/
 {
     $step = arg1;
@@ -90,7 +90,7 @@ usdt::ivcalc:convergence_success
 }
 
 /* Implicit solver failed */
-usdt::ivcalc:convergence_failed
+usdt::mango:convergence_failed
 /arg0 == 1/
 {
     $step = arg1;
@@ -105,7 +105,7 @@ usdt::ivcalc:convergence_failed
 }
 
 /* PDE solver completes */
-usdt::ivcalc:algo_complete
+usdt::mango:algo_complete
 /arg0 == 1/
 {
     $duration_ms = (nsecs - @solve_start) / 1000000;

--- a/scripts/tracing/performance_profile.bt
+++ b/scripts/tracing/performance_profile.bt
@@ -11,18 +11,18 @@
 
 BEGIN
 {
-    printf("Profiling ivcalc library performance...\n");
+    printf("Profiling mango library performance...\n");
     printf("Collecting timing and iteration statistics...\n\n");
 }
 
 /* Track algorithm start times */
-usdt::ivcalc:algo_start
+usdt::mango:algo_start
 {
     @algo_start[arg0] = nsecs;
 }
 
 /* Measure algorithm duration on completion */
-usdt::ivcalc:algo_complete
+usdt::mango:algo_complete
 {
     if (@algo_start[arg0] > 0) {
         $duration_ns = nsecs - @algo_start[arg0];
@@ -47,7 +47,7 @@ usdt::ivcalc:algo_complete
 }
 
 /* Track PDE solver progress for step timing */
-usdt::ivcalc:algo_progress
+usdt::mango:algo_progress
 /arg0 == 1/  /* PDE solver */
 {
     if (@last_progress_time > 0) {
@@ -58,14 +58,14 @@ usdt::ivcalc:algo_progress
 }
 
 /* Track convergence performance */
-usdt::ivcalc:convergence_success
+usdt::mango:convergence_success
 {
     @convergence_iters[arg0] = hist(arg2);
     @convergence_errors[arg0] = hist(arg3);
 }
 
 /* Count Brent iterations */
-usdt::ivcalc:brent_iter
+usdt::mango:brent_iter
 {
     @brent_iter_count++;
 }

--- a/src/american_option.c
+++ b/src/american_option.c
@@ -204,7 +204,7 @@ AmericanOptionResult american_option_price(const OptionData *option_data,
     AmericanOptionResult result = {nullptr, -1, nullptr};
 
     // Trace option pricing start
-    IVCALC_TRACE_OPTION_START(option_data->option_type, option_data->strike,
+    MANGO_TRACE_OPTION_START(option_data->option_type, option_data->strike,
                               option_data->volatility, option_data->time_to_maturity);
 
     // Create spatial grid in log-price coordinates: x = ln(S/K)
@@ -314,7 +314,7 @@ AmericanOptionResult american_option_price(const OptionData *option_data,
     }
 
     // Trace option pricing completion
-    IVCALC_TRACE_OPTION_COMPLETE(status, grid_params->n_steps);
+    MANGO_TRACE_OPTION_COMPLETE(status, grid_params->n_steps);
 
     return result;
 }

--- a/src/brent.h
+++ b/src/brent.h
@@ -48,7 +48,7 @@ static inline BrentResult brent_find_root(BrentFunction f,
     BrentResult result = {0.0, 0.0, 0, false};
 
     // Trace Brent start
-    IVCALC_TRACE_BRENT_START(a, b, tolerance, max_iter);
+    MANGO_TRACE_BRENT_START(a, b, tolerance, max_iter);
 
     double fa = f(a, user_data);
     double fb = f(b, user_data);
@@ -56,7 +56,7 @@ static inline BrentResult brent_find_root(BrentFunction f,
     // Check if root is bracketed
     if (fa * fb > 0.0) {
         // Root not bracketed - return failure
-        IVCALC_TRACE_BRENT_COMPLETE(a, 0, 0);
+        MANGO_TRACE_BRENT_COMPLETE(a, 0, 0);
         result.root = a;
         result.f_root = fa;
         return result;
@@ -64,14 +64,14 @@ static inline BrentResult brent_find_root(BrentFunction f,
 
     // If one endpoint is already a root
     if (fabs(fa) < tolerance) {
-        IVCALC_TRACE_BRENT_COMPLETE(a, 1, 1);
+        MANGO_TRACE_BRENT_COMPLETE(a, 1, 1);
         result.root = a;
         result.f_root = fa;
         result.converged = true;
         return result;
     }
     if (fabs(fb) < tolerance) {
-        IVCALC_TRACE_BRENT_COMPLETE(b, 1, 1);
+        MANGO_TRACE_BRENT_COMPLETE(b, 1, 1);
         result.root = b;
         result.f_root = fb;
         result.converged = true;
@@ -92,7 +92,7 @@ static inline BrentResult brent_find_root(BrentFunction f,
         result.iterations = iter + 1;
 
         // Trace iteration
-        IVCALC_TRACE_BRENT_ITER(iter, b, fb, fabs(b - a));
+        MANGO_TRACE_BRENT_ITER(iter, b, fb, fabs(b - a));
 
         double s; // Candidate for next point
 
@@ -147,7 +147,7 @@ static inline BrentResult brent_find_root(BrentFunction f,
 
         // Check for convergence
         if (fabs(fb) < tolerance || fabs(b - a) < tolerance) {
-            IVCALC_TRACE_BRENT_COMPLETE(b, result.iterations, 1);
+            MANGO_TRACE_BRENT_COMPLETE(b, result.iterations, 1);
             result.root = b;
             result.f_root = fb;
             result.converged = true;
@@ -156,7 +156,7 @@ static inline BrentResult brent_find_root(BrentFunction f,
     }
 
     // Max iterations reached
-    IVCALC_TRACE_BRENT_COMPLETE(b, max_iter, 0);
+    MANGO_TRACE_BRENT_COMPLETE(b, max_iter, 0);
     result.root = b;
     result.f_root = fb;
     result.converged = false;

--- a/src/cubic_spline.c
+++ b/src/cubic_spline.c
@@ -30,7 +30,7 @@ int pde_spline_init(CubicSpline *spline, const double *x, const double *y,
                     size_t n_points, double *workspace, double *temp_workspace) {
     if (n_points < 2 || spline == nullptr || workspace == nullptr || temp_workspace == nullptr) {
         // Trace error condition
-        IVCALC_TRACE_SPLINE_ERROR(n_points, 2);
+        MANGO_TRACE_SPLINE_ERROR(n_points, 2);
         return -1;
     }
 
@@ -118,7 +118,7 @@ int pde_spline_init(CubicSpline *spline, const double *x, const double *y,
 CubicSpline* pde_spline_create(const double *x, const double *y, size_t n_points) {
     if (n_points < 2) {
         // Trace error condition
-        IVCALC_TRACE_SPLINE_ERROR(n_points, 2);
+        MANGO_TRACE_SPLINE_ERROR(n_points, 2);
         return nullptr;
     }
 

--- a/src/implied_volatility.c
+++ b/src/implied_volatility.c
@@ -52,27 +52,27 @@ IVResult calculate_iv(const IVParams *params,
     IVResult result = {0.0, 0.0, 0, false, NULL};
 
     // Trace calculation start
-    IVCALC_TRACE_IV_START(params->spot_price, params->strike,
+    MANGO_TRACE_IV_START(params->spot_price, params->strike,
                           params->time_to_maturity, params->market_price);
 
     // Validate inputs
     if (params->spot_price <= 0.0) {
-        IVCALC_TRACE_IV_VALIDATION_ERROR(1, params->spot_price, 0.0);
+        MANGO_TRACE_IV_VALIDATION_ERROR(1, params->spot_price, 0.0);
         result.error = "Spot price must be positive";
         return result;
     }
     if (params->strike <= 0.0) {
-        IVCALC_TRACE_IV_VALIDATION_ERROR(2, params->strike, 0.0);
+        MANGO_TRACE_IV_VALIDATION_ERROR(2, params->strike, 0.0);
         result.error = "Strike price must be positive";
         return result;
     }
     if (params->time_to_maturity <= 0.0) {
-        IVCALC_TRACE_IV_VALIDATION_ERROR(3, params->time_to_maturity, 0.0);
+        MANGO_TRACE_IV_VALIDATION_ERROR(3, params->time_to_maturity, 0.0);
         result.error = "Time to maturity must be positive";
         return result;
     }
     if (params->market_price <= 0.0) {
-        IVCALC_TRACE_IV_VALIDATION_ERROR(4, params->market_price, 0.0);
+        MANGO_TRACE_IV_VALIDATION_ERROR(4, params->market_price, 0.0);
         result.error = "Market price must be positive";
         return result;
     }
@@ -82,21 +82,21 @@ IVResult calculate_iv(const IVParams *params,
     if (params->is_call) {
         intrinsic_value = fmax(params->spot_price - params->strike, 0.0);
         if (params->market_price > params->spot_price) {
-            IVCALC_TRACE_IV_VALIDATION_ERROR(5, params->market_price, params->spot_price);
+            MANGO_TRACE_IV_VALIDATION_ERROR(5, params->market_price, params->spot_price);
             result.error = "Call price exceeds spot price (arbitrage)";
             return result;
         }
     } else {
         intrinsic_value = fmax(params->strike - params->spot_price, 0.0);
         if (params->market_price > params->strike) {
-            IVCALC_TRACE_IV_VALIDATION_ERROR(5, params->market_price, params->strike);
+            MANGO_TRACE_IV_VALIDATION_ERROR(5, params->market_price, params->strike);
             result.error = "Put price exceeds strike (arbitrage)";
             return result;
         }
     }
 
     if (params->market_price < intrinsic_value - tolerance) {
-        IVCALC_TRACE_IV_VALIDATION_ERROR(5, params->market_price, intrinsic_value);
+        MANGO_TRACE_IV_VALIDATION_ERROR(5, params->market_price, intrinsic_value);
         result.error = "Market price below intrinsic value (arbitrage)";
         return result;
     }
@@ -134,11 +134,11 @@ IVResult calculate_iv(const IVParams *params,
         result.converged = true;
         result.vega = 0.0;  // Could compute via finite differences if needed
 
-        IVCALC_TRACE_IV_COMPLETE(result.implied_vol, result.iterations, 1);
+        MANGO_TRACE_IV_COMPLETE(result.implied_vol, result.iterations, 1);
     } else {
         result.error = "Failed to converge";
         result.iterations = brent_result.iterations;
-        IVCALC_TRACE_CONVERGENCE_FAILED(MODULE_IMPLIED_VOL, brent_result.iterations, max_iter, 0.0);
+        MANGO_TRACE_CONVERGENCE_FAILED(MODULE_IMPLIED_VOL, brent_result.iterations, max_iter, 0.0);
     }
 
     return result;

--- a/src/interp_cubic.h
+++ b/src/interp_cubic.h
@@ -1,5 +1,5 @@
-#ifndef IVCALC_INTERP_CUBIC_H
-#define IVCALC_INTERP_CUBIC_H
+#ifndef MANGO_INTERP_CUBIC_H
+#define MANGO_INTERP_CUBIC_H
 
 #include "interp_strategy.h"
 #include <stddef.h>
@@ -249,4 +249,4 @@ double cubic_interpolate_5d_workspace(const OptionPriceTable *table,
                                        double dividend,
                                        CubicInterpWorkspace workspace);
 
-#endif // IVCALC_INTERP_CUBIC_H
+#endif // MANGO_INTERP_CUBIC_H

--- a/src/interp_strategy.h
+++ b/src/interp_strategy.h
@@ -1,5 +1,5 @@
-#ifndef IVCALC_INTERP_STRATEGY_H
-#define IVCALC_INTERP_STRATEGY_H
+#ifndef MANGO_INTERP_STRATEGY_H
+#define MANGO_INTERP_STRATEGY_H
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -125,4 +125,4 @@ struct InterpolationStrategy {
     int (*precompute)(const void *grid_data, InterpContext context);
 };
 
-#endif // IVCALC_INTERP_STRATEGY_H
+#endif // MANGO_INTERP_STRATEGY_H

--- a/src/iv_surface.h
+++ b/src/iv_surface.h
@@ -1,5 +1,5 @@
-#ifndef IVCALC_IV_SURFACE_H
-#define IVCALC_IV_SURFACE_H
+#ifndef MANGO_IV_SURFACE_H
+#define MANGO_IV_SURFACE_H
 
 #include <stddef.h>
 #include <time.h>
@@ -199,4 +199,4 @@ int iv_surface_save(const IVSurface *surface, const char *filename);
  */
 IVSurface* iv_surface_load(const char *filename);
 
-#endif // IVCALC_IV_SURFACE_H
+#endif // MANGO_IV_SURFACE_H

--- a/src/ivcalc_trace.h
+++ b/src/ivcalc_trace.h
@@ -1,6 +1,6 @@
 /**
  * @file ivcalc_trace.h
- * @brief USDT (User Statically-Defined Tracing) probes for iv_calc library
+ * @brief USDT (User Statically-Defined Tracing) probes for mango library
  *
  * This header provides zero-overhead tracing points that can be dynamically
  * enabled at runtime using tools like bpftrace, systemtap, or perf.
@@ -14,10 +14,10 @@
  *
  * Example usage with bpftrace:
  *   # Trace all algorithm executions
- *   sudo bpftrace -e 'usdt:./lib*.so:ivcalc:algo_* { ... }'
+ *   sudo bpftrace -e 'usdt:./lib*.so:mango:algo_* { ... }'
  *
  *   # Monitor convergence across all modules
- *   sudo bpftrace -e 'usdt:./lib*.so:ivcalc:convergence_failed { ... }'
+ *   sudo bpftrace -e 'usdt:./lib*.so:mango:convergence_failed { ... }'
  */
 
 #ifndef IVCALC_TRACE_H
@@ -45,9 +45,9 @@
 #endif
 
 /**
- * Provider name for all iv_calc library probes
+ * Provider name for all mango library probes
  */
-#define IVCALC_PROVIDER ivcalc
+#define MANGO_PROVIDER mango
 
 /**
  * Module identifiers for multi-module tracing
@@ -73,8 +73,8 @@
  * @param param2: Module-specific parameter (e.g., dt, tolerance)
  * @param param3: Module-specific parameter
  */
-#define IVCALC_TRACE_ALGO_START(module_id, param1, param2, param3) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, algo_start, module_id, param1, param2, param3)
+#define MANGO_TRACE_ALGO_START(module_id, param1, param2, param3) \
+    DTRACE_PROBE4(MANGO_PROVIDER, algo_start, module_id, param1, param2, param3)
 
 /**
  * Fired periodically during algorithm execution to report progress
@@ -83,8 +83,8 @@
  * @param total: Total work (e.g., total steps, max iterations)
  * @param metric: Progress metric (e.g., current time, current error)
  */
-#define IVCALC_TRACE_ALGO_PROGRESS(module_id, current, total, metric) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, algo_progress, module_id, current, total, metric)
+#define MANGO_TRACE_ALGO_PROGRESS(module_id, current, total, metric) \
+    DTRACE_PROBE4(MANGO_PROVIDER, algo_progress, module_id, current, total, metric)
 
 /**
  * Fired when an algorithm completes successfully
@@ -92,8 +92,8 @@
  * @param iterations: Number of iterations/steps completed
  * @param final_metric: Final metric value (e.g., final time, final error)
  */
-#define IVCALC_TRACE_ALGO_COMPLETE(module_id, iterations, final_metric) \
-    DTRACE_PROBE3(IVCALC_PROVIDER, algo_complete, module_id, iterations, final_metric)
+#define MANGO_TRACE_ALGO_COMPLETE(module_id, iterations, final_metric) \
+    DTRACE_PROBE3(MANGO_PROVIDER, algo_complete, module_id, iterations, final_metric)
 
 /**
  * ============================================================================
@@ -110,8 +110,8 @@
  * @param error: Current error metric
  * @param tolerance: Convergence threshold
  */
-#define IVCALC_TRACE_CONVERGENCE_ITER(module_id, step, iter, error, tolerance) \
-    DTRACE_PROBE5(IVCALC_PROVIDER, convergence_iter, module_id, step, iter, error, tolerance)
+#define MANGO_TRACE_CONVERGENCE_ITER(module_id, step, iter, error, tolerance) \
+    DTRACE_PROBE5(MANGO_PROVIDER, convergence_iter, module_id, step, iter, error, tolerance)
 
 /**
  * Fired when convergence is achieved
@@ -120,8 +120,8 @@
  * @param final_iter: Number of iterations required
  * @param final_error: Final error achieved
  */
-#define IVCALC_TRACE_CONVERGENCE_SUCCESS(module_id, step, final_iter, final_error) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, convergence_success, module_id, step, final_iter, final_error)
+#define MANGO_TRACE_CONVERGENCE_SUCCESS(module_id, step, final_iter, final_error) \
+    DTRACE_PROBE4(MANGO_PROVIDER, convergence_success, module_id, step, final_iter, final_error)
 
 /**
  * Fired when convergence fails
@@ -130,8 +130,8 @@
  * @param max_iter: Maximum iterations attempted
  * @param final_error: Final error at failure
  */
-#define IVCALC_TRACE_CONVERGENCE_FAILED(module_id, step, max_iter, final_error) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, convergence_failed, module_id, step, max_iter, final_error)
+#define MANGO_TRACE_CONVERGENCE_FAILED(module_id, step, max_iter, final_error) \
+    DTRACE_PROBE4(MANGO_PROVIDER, convergence_failed, module_id, step, max_iter, final_error)
 
 /**
  * ============================================================================
@@ -147,8 +147,8 @@
  * @param param1: Relevant parameter value
  * @param param2: Relevant parameter value or threshold
  */
-#define IVCALC_TRACE_VALIDATION_ERROR(module_id, error_code, param1, param2) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, validation_error, module_id, error_code, param1, param2)
+#define MANGO_TRACE_VALIDATION_ERROR(module_id, error_code, param1, param2) \
+    DTRACE_PROBE4(MANGO_PROVIDER, validation_error, module_id, error_code, param1, param2)
 
 /**
  * Fired when a runtime error occurs
@@ -156,8 +156,8 @@
  * @param error_code: Error code
  * @param context: Context value (e.g., step number, iteration)
  */
-#define IVCALC_TRACE_RUNTIME_ERROR(module_id, error_code, context) \
-    DTRACE_PROBE3(IVCALC_PROVIDER, runtime_error, module_id, error_code, context)
+#define MANGO_TRACE_RUNTIME_ERROR(module_id, error_code, context) \
+    DTRACE_PROBE3(MANGO_PROVIDER, runtime_error, module_id, error_code, context)
 
 /**
  * ============================================================================
@@ -172,8 +172,8 @@
  * @param dt: Time step size
  * @param n_steps: Total number of steps
  */
-#define IVCALC_TRACE_PDE_START(t_start, t_end, dt, n_steps) \
-    IVCALC_TRACE_ALGO_START(MODULE_PDE_SOLVER, n_steps, dt, (t_end - t_start))
+#define MANGO_TRACE_PDE_START(t_start, t_end, dt, n_steps) \
+    MANGO_TRACE_ALGO_START(MODULE_PDE_SOLVER, n_steps, dt, (t_end - t_start))
 
 /**
  * Fired during PDE solve progress
@@ -181,34 +181,34 @@
  * @param n_steps: Total steps
  * @param t_current: Current time
  */
-#define IVCALC_TRACE_PDE_PROGRESS(step, n_steps, t_current) \
-    IVCALC_TRACE_ALGO_PROGRESS(MODULE_PDE_SOLVER, step, n_steps, t_current)
+#define MANGO_TRACE_PDE_PROGRESS(step, n_steps, t_current) \
+    MANGO_TRACE_ALGO_PROGRESS(MODULE_PDE_SOLVER, step, n_steps, t_current)
 
 /**
  * Fired when PDE solve completes
  * @param total_steps: Total steps executed
  * @param final_time: Final time reached
  */
-#define IVCALC_TRACE_PDE_COMPLETE(total_steps, final_time) \
-    IVCALC_TRACE_ALGO_COMPLETE(MODULE_PDE_SOLVER, total_steps, final_time)
+#define MANGO_TRACE_PDE_COMPLETE(total_steps, final_time) \
+    MANGO_TRACE_ALGO_COMPLETE(MODULE_PDE_SOLVER, total_steps, final_time)
 
 /**
  * PDE implicit solver iteration
  */
-#define IVCALC_TRACE_PDE_IMPLICIT_ITER(step, iter, error, tolerance) \
-    IVCALC_TRACE_CONVERGENCE_ITER(MODULE_PDE_SOLVER, step, iter, error, tolerance)
+#define MANGO_TRACE_PDE_IMPLICIT_ITER(step, iter, error, tolerance) \
+    MANGO_TRACE_CONVERGENCE_ITER(MODULE_PDE_SOLVER, step, iter, error, tolerance)
 
 /**
  * PDE implicit solver converged
  */
-#define IVCALC_TRACE_PDE_IMPLICIT_CONVERGED(step, final_iter, final_error) \
-    IVCALC_TRACE_CONVERGENCE_SUCCESS(MODULE_PDE_SOLVER, step, final_iter, final_error)
+#define MANGO_TRACE_PDE_IMPLICIT_CONVERGED(step, final_iter, final_error) \
+    MANGO_TRACE_CONVERGENCE_SUCCESS(MODULE_PDE_SOLVER, step, final_iter, final_error)
 
 /**
  * PDE implicit solver failed to converge
  */
-#define IVCALC_TRACE_PDE_IMPLICIT_FAILED(step, max_iter, final_error) \
-    IVCALC_TRACE_CONVERGENCE_FAILED(MODULE_PDE_SOLVER, step, max_iter, final_error)
+#define MANGO_TRACE_PDE_IMPLICIT_FAILED(step, max_iter, final_error) \
+    MANGO_TRACE_CONVERGENCE_FAILED(MODULE_PDE_SOLVER, step, max_iter, final_error)
 
 /**
  * ============================================================================
@@ -223,8 +223,8 @@
  * @param time_to_maturity: Time to expiration
  * @param market_price: Market price
  */
-#define IVCALC_TRACE_IV_START(spot, strike, time_to_maturity, market_price) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, iv_start, spot, strike, time_to_maturity, market_price)
+#define MANGO_TRACE_IV_START(spot, strike, time_to_maturity, market_price) \
+    DTRACE_PROBE4(MANGO_PROVIDER, iv_start, spot, strike, time_to_maturity, market_price)
 
 /**
  * Fired when IV calculation completes
@@ -232,8 +232,8 @@
  * @param iterations: Number of iterations
  * @param converged: 1 if converged, 0 if failed
  */
-#define IVCALC_TRACE_IV_COMPLETE(implied_vol, iterations, converged) \
-    DTRACE_PROBE3(IVCALC_PROVIDER, iv_complete, implied_vol, iterations, converged)
+#define MANGO_TRACE_IV_COMPLETE(implied_vol, iterations, converged) \
+    DTRACE_PROBE3(MANGO_PROVIDER, iv_complete, implied_vol, iterations, converged)
 
 /**
  * Fired when IV validation fails (arbitrage bounds, etc.)
@@ -241,8 +241,8 @@
  * @param param1: Relevant parameter
  * @param param2: Threshold or bound
  */
-#define IVCALC_TRACE_IV_VALIDATION_ERROR(error_code, param1, param2) \
-    IVCALC_TRACE_VALIDATION_ERROR(MODULE_IMPLIED_VOL, error_code, param1, param2)
+#define MANGO_TRACE_IV_VALIDATION_ERROR(error_code, param1, param2) \
+    MANGO_TRACE_VALIDATION_ERROR(MODULE_IMPLIED_VOL, error_code, param1, param2)
 
 /**
  * ============================================================================
@@ -257,8 +257,8 @@
  * @param tolerance: Convergence tolerance
  * @param max_iter: Maximum iterations
  */
-#define IVCALC_TRACE_BRENT_START(a, b, tolerance, max_iter) \
-    IVCALC_TRACE_ALGO_START(MODULE_BRENT_ROOT, max_iter, tolerance, (b - a))
+#define MANGO_TRACE_BRENT_START(a, b, tolerance, max_iter) \
+    MANGO_TRACE_ALGO_START(MODULE_BRENT_ROOT, max_iter, tolerance, (b - a))
 
 /**
  * Fired on each Brent iteration
@@ -267,8 +267,8 @@
  * @param fx: Function value at x
  * @param interval_width: Current bracket width
  */
-#define IVCALC_TRACE_BRENT_ITER(iter, x, fx, interval_width) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, brent_iter, iter, x, fx, interval_width)
+#define MANGO_TRACE_BRENT_ITER(iter, x, fx, interval_width) \
+    DTRACE_PROBE4(MANGO_PROVIDER, brent_iter, iter, x, fx, interval_width)
 
 /**
  * Fired when root finding completes
@@ -276,8 +276,8 @@
  * @param iterations: Number of iterations
  * @param converged: 1 if converged, 0 if failed
  */
-#define IVCALC_TRACE_BRENT_COMPLETE(root, iterations, converged) \
-    IVCALC_TRACE_ALGO_COMPLETE(MODULE_BRENT_ROOT, iterations, root)
+#define MANGO_TRACE_BRENT_COMPLETE(root, iterations, converged) \
+    MANGO_TRACE_ALGO_COMPLETE(MODULE_BRENT_ROOT, iterations, root)
 
 /**
  * ============================================================================
@@ -292,16 +292,16 @@
  * @param volatility: Volatility
  * @param time_to_maturity: Time to maturity
  */
-#define IVCALC_TRACE_OPTION_START(option_type, strike, volatility, time_to_maturity) \
-    DTRACE_PROBE4(IVCALC_PROVIDER, option_start, option_type, strike, volatility, time_to_maturity)
+#define MANGO_TRACE_OPTION_START(option_type, strike, volatility, time_to_maturity) \
+    DTRACE_PROBE4(MANGO_PROVIDER, option_start, option_type, strike, volatility, time_to_maturity)
 
 /**
  * Fired when option pricing completes
  * @param status: 0=success, -1=failure
  * @param iterations: Number of PDE steps
  */
-#define IVCALC_TRACE_OPTION_COMPLETE(status, iterations) \
-    DTRACE_PROBE2(IVCALC_PROVIDER, option_complete, status, iterations)
+#define MANGO_TRACE_OPTION_COMPLETE(status, iterations) \
+    DTRACE_PROBE2(MANGO_PROVIDER, option_complete, status, iterations)
 
 /**
  * ============================================================================
@@ -314,7 +314,7 @@
  * @param n_points: Points provided
  * @param min_required: Minimum required
  */
-#define IVCALC_TRACE_SPLINE_ERROR(n_points, min_required) \
-    IVCALC_TRACE_VALIDATION_ERROR(MODULE_CUBIC_SPLINE, 1, n_points, min_required)
+#define MANGO_TRACE_SPLINE_ERROR(n_points, min_required) \
+    MANGO_TRACE_VALIDATION_ERROR(MODULE_CUBIC_SPLINE, 1, n_points, min_required)
 
 #endif // IVCALC_TRACE_H

--- a/src/pde_solver.c
+++ b/src/pde_solver.c
@@ -311,15 +311,15 @@ static int solve_implicit_step(PDESolver *solver, double t, double coeff_dt,
         rel_error = (norm > 1e-12) ? error / (norm + 1e-12) : error;
 
         // Trace iteration progress
-        IVCALC_TRACE_PDE_IMPLICIT_ITER(step, iter, rel_error, tol);
+        MANGO_TRACE_PDE_IMPLICIT_ITER(step, iter, rel_error, tol);
 
         if (rel_error < tol || error < tol) {
-            IVCALC_TRACE_PDE_IMPLICIT_CONVERGED(step, iter, rel_error);
+            MANGO_TRACE_PDE_IMPLICIT_CONVERGED(step, iter, rel_error);
             return 0;
         }
     }
 
-    IVCALC_TRACE_PDE_IMPLICIT_FAILED(step, max_iter, rel_error);
+    MANGO_TRACE_PDE_IMPLICIT_FAILED(step, max_iter, rel_error);
     return -1;
 }
 
@@ -387,12 +387,12 @@ PDESolver* pde_solver_create(SpatialGrid *grid,
 
     // Validate Robin boundary condition coefficients
     if (bc_config->left_type == BC_ROBIN && fabs(bc_config->left_robin_a) < 1e-15) {
-        IVCALC_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 1, bc_config->left_robin_a, 1e-15);
+        MANGO_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 1, bc_config->left_robin_a, 1e-15);
         free(solver);
         return nullptr;
     }
     if (bc_config->right_type == BC_ROBIN && fabs(bc_config->right_robin_a) < 1e-15) {
-        IVCALC_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 2, bc_config->right_robin_a, 1e-15);
+        MANGO_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 2, bc_config->right_robin_a, 1e-15);
         free(solver);
         return nullptr;
     }
@@ -418,7 +418,7 @@ PDESolver* pde_solver_create(SpatialGrid *grid,
         solver->workspace = malloc(workspace_size * sizeof(double));
         if (solver->workspace == nullptr) {
             // Both allocations failed
-            IVCALC_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 0, workspace_size, 0.0);
+            MANGO_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 0, workspace_size, 0.0);
             free(solver);
             return nullptr;
         }
@@ -539,7 +539,7 @@ int pde_solver_solve(PDESolver *solver) {
     size_t next_event_idx = 0; // Track next event to check
 
     // Trace solver start
-    IVCALC_TRACE_PDE_START(solver->time.t_start, solver->time.t_end,
+    MANGO_TRACE_PDE_START(solver->time.t_start, solver->time.t_end,
                            solver->time.dt, solver->time.n_steps);
 
     for (size_t step = 0; step < solver->time.n_steps; step++) {
@@ -594,12 +594,12 @@ int pde_solver_solve(PDESolver *solver) {
 
         // Trace progress periodically (every 10%)
         if (step % (solver->time.n_steps / 10 + 1) == 0) {
-            IVCALC_TRACE_PDE_PROGRESS(step, solver->time.n_steps, t);
+            MANGO_TRACE_PDE_PROGRESS(step, solver->time.n_steps, t);
         }
     }
 
     // Trace successful completion
-    IVCALC_TRACE_PDE_COMPLETE(solver->time.n_steps, t);
+    MANGO_TRACE_PDE_COMPLETE(solver->time.n_steps, t);
     return 0;
 }
 

--- a/src/price_table.c
+++ b/src/price_table.c
@@ -118,13 +118,13 @@ static OptionData grid_point_to_option(const OptionPriceTable *table,
 
 /**
  * Get batch size for parallel computation from environment variable.
- * Defaults to 100 if IVCALC_PRECOMPUTE_BATCH_SIZE is not set or invalid.
+ * Defaults to 100 if MANGO_PRECOMPUTE_BATCH_SIZE is not set or invalid.
  * Valid range: 1 to 100000.
  */
 static size_t get_batch_size(void) {
     size_t batch_size = 100;  // Default
 
-    char *env_batch = getenv("IVCALC_PRECOMPUTE_BATCH_SIZE");
+    char *env_batch = getenv("MANGO_PRECOMPUTE_BATCH_SIZE");
     if (env_batch) {
         long val = atol(env_batch);
         if (val >= 1 && val <= 100000) {
@@ -448,7 +448,7 @@ int price_table_precompute(OptionPriceTable *table,
         return -1;
     }
 
-    IVCALC_TRACE_ALGO_START(MODULE_PRICE_TABLE, n_total, batch_size, 0);
+    MANGO_TRACE_ALGO_START(MODULE_PRICE_TABLE, n_total, batch_size, 0);
 
     const double K_ref = 100.0;  // Reference strike for moneyness scaling
     size_t completed = 0;
@@ -504,7 +504,7 @@ int price_table_precompute(OptionPriceTable *table,
             if (status != 0) {
                 free(batch_options);
                 free(batch_results);
-                IVCALC_TRACE_RUNTIME_ERROR(MODULE_PRICE_TABLE, status, completed);
+                MANGO_TRACE_RUNTIME_ERROR(MODULE_PRICE_TABLE, status, completed);
                 return -1;
             }
 
@@ -553,14 +553,14 @@ int price_table_precompute(OptionPriceTable *table,
 
             // Progress tracking (every 10 batches)
             if ((completed / batch_size) % 10 == 0) {
-                IVCALC_TRACE_ALGO_PROGRESS(MODULE_PRICE_TABLE,
+                MANGO_TRACE_ALGO_PROGRESS(MODULE_PRICE_TABLE,
                                            completed, n_total,
                                            (double)completed / (double)n_total);
             }
         }
     }
 
-    IVCALC_TRACE_ALGO_COMPLETE(MODULE_PRICE_TABLE, n_total, 1.0);
+    MANGO_TRACE_ALGO_COMPLETE(MODULE_PRICE_TABLE, n_total, 1.0);
 
     free(batch_options);
     free(batch_results);
@@ -572,7 +572,7 @@ int price_table_precompute(OptionPriceTable *table,
     if (table->strategy && table->strategy->precompute && table->interp_context) {
         int precompute_status = table->strategy->precompute(table, table->interp_context);
         if (precompute_status != 0) {
-            IVCALC_TRACE_RUNTIME_ERROR(MODULE_PRICE_TABLE, precompute_status, 0);
+            MANGO_TRACE_RUNTIME_ERROR(MODULE_PRICE_TABLE, precompute_status, 0);
             return -1;
         }
     }

--- a/src/price_table.h
+++ b/src/price_table.h
@@ -1,5 +1,5 @@
-#ifndef IVCALC_PRICE_TABLE_H
-#define IVCALC_PRICE_TABLE_H
+#ifndef MANGO_PRICE_TABLE_H
+#define MANGO_PRICE_TABLE_H
 
 #include <stddef.h>
 #include <time.h>
@@ -279,7 +279,7 @@ void price_table_destroy(OptionPriceTable *table);
  * Populates the price table by computing option prices at each grid point
  * using the FDM solver via american_option_price_batch(). Uses batch
  * processing with configurable batch size (environment variable
- * IVCALC_PRECOMPUTE_BATCH_SIZE, default 100).
+ * MANGO_PRECOMPUTE_BATCH_SIZE, default 100).
  *
  * Performance:
  * - 300K grid points: ~15-20 minutes on 16-core machine
@@ -297,7 +297,7 @@ void price_table_destroy(OptionPriceTable *table);
  * @return 0 on success, -1 on error (NULL inputs, allocation failure, batch failure)
  *
  * Environment variables:
- * - IVCALC_PRECOMPUTE_BATCH_SIZE: Batch size (1-100000, default 100)
+ * - MANGO_PRECOMPUTE_BATCH_SIZE: Batch size (1-100000, default 100)
  *
  * Example:
  * @code
@@ -472,4 +472,4 @@ OptionPriceTable* price_table_load(const char *filename);
 }
 #endif
 
-#endif // IVCALC_PRICE_TABLE_H
+#endif // MANGO_PRICE_TABLE_H

--- a/tests/trace_validation_test.sh
+++ b/tests/trace_validation_test.sh
@@ -99,7 +99,7 @@ if [[ $SKIP_BPFTRACE -eq 0 ]]; then
         SKIP_BPFTRACE=1
     else
         # Check expected probes exist
-        PROBE_COUNT=$(bpftrace -l "usdt:$HEAT_EQ_BIN:ivcalc:*" 2>/dev/null | wc -l)
+        PROBE_COUNT=$(bpftrace -l "usdt:$HEAT_EQ_BIN:mango:*" 2>/dev/null | wc -l)
 
         if [[ $PROBE_COUNT -gt 0 ]]; then
             log_success "bpftrace can list probes (found $PROBE_COUNT probes)"
@@ -117,7 +117,7 @@ if [[ $SKIP_BPFTRACE -eq 0 ]]; then
         )
 
         for probe in "${EXPECTED_PROBES[@]}"; do
-            if bpftrace -l "usdt:$HEAT_EQ_BIN:ivcalc:$probe" 2>/dev/null | grep -q "$probe"; then
+            if bpftrace -l "usdt:$HEAT_EQ_BIN:mango:$probe" 2>/dev/null | grep -q "$probe"; then
                 log_success "Found probe: $probe"
             else
                 log_error "Missing probe: $probe"
@@ -137,19 +137,19 @@ if [[ $SKIP_BPFTRACE -eq 0 ]]; then
     cat > "$TEST_SCRIPT" << 'EOF'
 BEGIN { @algo_start = 0; @algo_complete = 0; @convergence = 0; }
 
-usdt::ivcalc:algo_start /@algo_start < 5/ {
+usdt::mango:algo_start /@algo_start < 5/ {
     @algo_start++;
 }
 
-usdt::ivcalc:algo_complete /@algo_complete < 5/ {
+usdt::mango:algo_complete /@algo_complete < 5/ {
     @algo_complete++;
 }
 
-usdt::ivcalc:convergence_iter /@convergence < 10/ {
+usdt::mango:convergence_iter /@convergence < 10/ {
     @convergence++;
 }
 
-usdt::ivcalc:convergence_success {
+usdt::mango:convergence_success {
     @success = 1;
 }
 
@@ -191,21 +191,21 @@ fi
 # Test 4: Validate helper tool works
 log_info "Test 4: Validating helper tool..."
 
-if [[ ! -x "$PROJECT_ROOT/scripts/ivcalc-trace" ]]; then
-    log_error "Helper tool not executable: $PROJECT_ROOT/scripts/ivcalc-trace"
+if [[ ! -x "$PROJECT_ROOT/scripts/mango-trace" ]]; then
+    log_error "Helper tool not executable: $PROJECT_ROOT/scripts/mango-trace"
 else
     log_success "Helper tool is executable"
 
     if [[ $SKIP_BPFTRACE -eq 0 ]]; then
         # Test check command
-        if "$PROJECT_ROOT/scripts/ivcalc-trace" check "$HEAT_EQ_BIN" 2>&1 | grep -q "USDT support: OK"; then
+        if "$PROJECT_ROOT/scripts/mango-trace" check "$HEAT_EQ_BIN" 2>&1 | grep -q "USDT support: OK"; then
             log_success "Helper tool 'check' command works"
         else
             log_error "Helper tool 'check' command failed"
         fi
 
         # Test list command
-        if "$PROJECT_ROOT/scripts/ivcalc-trace" list "$HEAT_EQ_BIN" 2>&1 | grep -q "ivcalc"; then
+        if "$PROJECT_ROOT/scripts/mango-trace" list "$HEAT_EQ_BIN" 2>&1 | grep -q "mango"; then
             log_success "Helper tool 'list' command works"
         else
             log_error "Helper tool 'list' command failed"


### PR DESCRIPTION
The tracing system previously used "ivcalc" as its provider name and macro prefix, which was too specific to implied volatility calculations. Since mango-iv includes a general-purpose PDE solver library that can be used for many applications beyond IV calculations, a more generic name is appropriate.

Changes:
- Rename USDT provider from "ivcalc" to "mango"
- Update all trace macros from IVCALC_TRACE_* to MANGO_TRACE_*
- Rename helper script from ivcalc-trace to mango-trace
- Update all bpftrace scripts to use usdt::mango: probes
- Update header guards from IVCALC_* to MANGO_*
- Rename environment variable IVCALC_PRECOMPUTE_BATCH_SIZE to MANGO_PRECOMPUTE_BATCH_SIZE
- Update all documentation and examples

The source file name ivcalc_trace.h remains unchanged to minimize breaking changes, but all public-facing names now use "mango".