### PR TITLE
Fix COORD_LOG_SQRT interpolation NaN bug

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -58,3 +58,16 @@ cc_binary(
         "//src:american_option",
     ],
 )
+
+cc_binary(
+    name = "test_iv_accuracy",
+    srcs = ["test_iv_accuracy.cc"],
+    copts = ["-std=c++17", "-Wall", "-Wextra", "-O3"],
+    deps = [
+        "//src:implied_volatility",
+        "//src:american_option",
+        "//src:price_table",
+        "//src:grid_presets",
+        "//src:grid_transform",
+    ],
+)

--- a/examples/test_iv_accuracy.cc
+++ b/examples/test_iv_accuracy.cc
@@ -1,0 +1,268 @@
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <cmath>
+
+extern "C" {
+#include "src/implied_volatility.h"
+#include "src/american_option.h"
+#include "src/price_table.h"
+#include "src/grid_presets.h"
+#include "src/grid_transform.h"
+}
+
+struct TestCase {
+    double spot;
+    double strike;
+    double tau;        // Time to maturity
+    double r;          // Risk-free rate
+    double true_sigma; // True volatility to recover
+    OptionType type;
+    const char* label;
+};
+
+void run_accuracy_test() {
+    std::cout << "IV Calculation Accuracy Test\n";
+    std::cout << "============================\n\n";
+
+    // Test cases covering different moneyness and maturity ranges
+    std::vector<TestCase> test_cases = {
+        // ATM options
+        {100.0, 100.0, 0.25, 0.05, 0.20, OPTION_PUT, "ATM Put, 3M, 20% vol"},
+        {100.0, 100.0, 1.00, 0.05, 0.20, OPTION_PUT, "ATM Put, 1Y, 20% vol"},
+        {100.0, 100.0, 0.25, 0.05, 0.30, OPTION_CALL, "ATM Call, 3M, 30% vol"},
+
+        // ITM options
+        {100.0,  90.0, 0.50, 0.05, 0.25, OPTION_PUT, "ITM Put (S=100, K=90), 6M"},
+        {100.0, 110.0, 0.50, 0.05, 0.25, OPTION_CALL, "ITM Call (S=100, K=110), 6M"},
+
+        // OTM options
+        {100.0, 110.0, 0.50, 0.05, 0.25, OPTION_PUT, "OTM Put (S=100, K=110), 6M"},
+        {100.0,  90.0, 0.50, 0.05, 0.25, OPTION_CALL, "OTM Call (S=100, K=90), 6M"},
+
+        // Short maturity
+        {100.0, 100.0, 0.08, 0.05, 0.20, OPTION_PUT, "ATM Put, 1M, 20% vol"},
+
+        // High volatility
+        {100.0, 100.0, 0.50, 0.05, 0.50, OPTION_PUT, "ATM Put, 6M, 50% vol"},
+
+        // Low volatility
+        {100.0, 100.0, 0.50, 0.05, 0.10, OPTION_PUT, "ATM Put, 6M, 10% vol"},
+    };
+
+    // FDM grid for pricing
+    AmericanOptionGrid grid = {
+        .x_min = -0.7,
+        .x_max = 0.7,
+        .n_points = 141,
+        .dt = 0.001,
+        .n_steps = 1000
+    };
+
+    std::cout << "Method 1: FDM-based IV (Brent's method + PDE solver)\n";
+    std::cout << "-------------------------------------------------------\n\n";
+
+    double fdm_total_error = 0.0;
+    double fdm_max_error = 0.0;
+    int fdm_success = 0;
+
+    for (const auto& tc : test_cases) {
+        // Generate market price using true volatility
+        OptionData option = {
+            .strike = tc.strike,
+            .volatility = tc.true_sigma,
+            .risk_free_rate = tc.r,
+            .time_to_maturity = tc.tau,
+            .option_type = tc.type,
+            .n_dividends = 0,
+            .dividend_times = nullptr,
+            .dividend_amounts = nullptr
+        };
+
+        AmericanOptionResult price_result = american_option_price(&option, &grid);
+        if (price_result.status != 0) {
+            std::cout << "  ✗ " << tc.label << " - Pricing failed\n";
+            american_option_free_result(&price_result);
+            continue;
+        }
+
+        double market_price = american_option_get_value_at_spot(
+            price_result.solver, tc.spot, tc.strike);
+        american_option_free_result(&price_result);
+
+        // Now invert to recover IV
+        IVParams iv_params = {
+            .spot_price = tc.spot,
+            .strike = tc.strike,
+            .time_to_maturity = tc.tau,
+            .risk_free_rate = tc.r,
+            .dividend_yield = 0.0,
+            .market_price = market_price,
+            .option_type = tc.type,
+            .exercise_type = AMERICAN
+        };
+
+        IVResult iv_result = calculate_iv(&iv_params, &grid, nullptr, 1e-6, 100);
+
+        if (iv_result.converged) {
+            double error_bp = std::abs(iv_result.implied_vol - tc.true_sigma) * 10000;
+            fdm_total_error += error_bp;
+            fdm_max_error = std::max(fdm_max_error, error_bp);
+            fdm_success++;
+
+            std::cout << "  ✓ " << std::setw(45) << std::left << tc.label
+                      << " True: " << std::fixed << std::setprecision(4) << tc.true_sigma
+                      << " → IV: " << iv_result.implied_vol
+                      << " (err: " << std::setprecision(2) << error_bp << " bp)"
+                      << " [" << iv_result.iterations << " iters]\n";
+        } else {
+            std::cout << "  ✗ " << tc.label << " - " << iv_result.error << "\n";
+        }
+    }
+
+    std::cout << "\nFDM-based Summary:\n";
+    std::cout << "  Success rate: " << fdm_success << "/" << test_cases.size() << "\n";
+    if (fdm_success > 0) {
+        std::cout << "  Average error: " << std::fixed << std::setprecision(2)
+                  << (fdm_total_error / fdm_success) << " bp\n";
+        std::cout << "  Max error: " << fdm_max_error << " bp\n";
+    }
+
+    // Method 2: Table-based IV (Newton's method with interpolation)
+    std::cout << "\n\nMethod 2: Table-based IV (Newton's method + interpolation)\n";
+    std::cout << "------------------------------------------------------------\n\n";
+
+    // Create price table using Balanced preset
+    GridConfig config = grid_preset_get(
+        GRID_PRESET_ADAPTIVE_BALANCED,
+        0.7, 1.3,    // moneyness
+        0.027, 2.0,  // maturity
+        0.10, 0.80,  // volatility
+        0.0, 0.10,   // rate
+        0.0, 0.0     // no dividend
+    );
+
+    GeneratedGrids grids = grid_generate_all(&config);
+
+    // CRITICAL: Transform grids to LOG_SQRT coordinate system
+    // Grids are generated in RAW coordinates, but price_table with COORD_LOG_SQRT
+    // expects pre-transformed grids (moneyness → log, maturity → sqrt)
+    grid_transform_coordinates(&grids, COORD_LOG_SQRT);
+
+    OptionPriceTable* table = price_table_create_ex(
+        grids.moneyness, grids.n_moneyness,
+        grids.maturity, grids.n_maturity,
+        grids.volatility, grids.n_volatility,
+        grids.rate, grids.n_rate,
+        nullptr, 0,
+        OPTION_PUT, AMERICAN,
+        COORD_LOG_SQRT,
+        LAYOUT_M_INNER
+    );
+
+    if (!table) {
+        std::cout << "Failed to create price table\n";
+        grid_free_all(&grids);
+        return;
+    }
+
+    std::cout << "Precomputing price table (this may take a minute)...\n";
+    std::cout << "  Grid: " << grids.n_moneyness << "×" << grids.n_maturity << "×"
+              << grids.n_volatility << "×" << grids.n_rate
+              << " = " << grids.total_points << " points\n";
+
+    int precompute_status = price_table_precompute(table, &grid);
+    if (precompute_status != 0) {
+        std::cout << "Precompute failed\n";
+        price_table_destroy(table);
+        grid_free_all(&grids);
+        return;
+    }
+    std::cout << "Precompute complete!\n\n";
+
+    double table_total_error = 0.0;
+    double table_max_error = 0.0;
+    int table_success = 0;
+    int table_fallback = 0;
+
+    for (const auto& tc : test_cases) {
+        // Skip calls since table is for puts
+        if (tc.type == OPTION_CALL) {
+            continue;
+        }
+
+        // Generate market price
+        OptionData option = {
+            .strike = tc.strike,
+            .volatility = tc.true_sigma,
+            .risk_free_rate = tc.r,
+            .time_to_maturity = tc.tau,
+            .option_type = tc.type,
+            .n_dividends = 0,
+            .dividend_times = nullptr,
+            .dividend_amounts = nullptr
+        };
+
+        AmericanOptionResult price_result = american_option_price(&option, &grid);
+        if (price_result.status != 0) {
+            std::cout << "  ✗ " << tc.label << " - Pricing failed\n";
+            american_option_free_result(&price_result);
+            continue;
+        }
+
+        double market_price = american_option_get_value_at_spot(
+            price_result.solver, tc.spot, tc.strike);
+        american_option_free_result(&price_result);
+
+        // Invert using table
+        IVParams iv_params = {
+            .spot_price = tc.spot,
+            .strike = tc.strike,
+            .time_to_maturity = tc.tau,
+            .risk_free_rate = tc.r,
+            .dividend_yield = 0.0,
+            .market_price = market_price,
+            .option_type = tc.type,
+            .exercise_type = AMERICAN
+        };
+
+        IVResult iv_result = calculate_iv(&iv_params, &grid, table, 1e-6, 100);
+
+        if (iv_result.converged) {
+            double error_bp = std::abs(iv_result.implied_vol - tc.true_sigma) * 10000;
+            table_total_error += error_bp;
+            table_max_error = std::max(table_max_error, error_bp);
+            table_success++;
+
+            // Check if it used Newton (few iters) or Brent fallback (many iters)
+            const char* method = iv_result.iterations <= 10 ? "Newton" : "Brent";
+            if (iv_result.iterations > 10) table_fallback++;
+
+            std::cout << "  ✓ " << std::setw(45) << std::left << tc.label
+                      << " True: " << std::fixed << std::setprecision(4) << tc.true_sigma
+                      << " → IV: " << iv_result.implied_vol
+                      << " (err: " << std::setprecision(2) << error_bp << " bp)"
+                      << " [" << method << ", " << iv_result.iterations << " iters]\n";
+        } else {
+            std::cout << "  ✗ " << tc.label << " - " << iv_result.error << "\n";
+        }
+    }
+
+    std::cout << "\nTable-based Summary:\n";
+    std::cout << "  Success rate: " << table_success << "/" << test_cases.size() - 3 << " (puts only)\n";
+    if (table_success > 0) {
+        std::cout << "  Average error: " << std::fixed << std::setprecision(2)
+                  << (table_total_error / table_success) << " bp\n";
+        std::cout << "  Max error: " << table_max_error << " bp\n";
+        std::cout << "  Newton method: " << (table_success - table_fallback) << "/" << table_success << "\n";
+        std::cout << "  Brent fallback: " << table_fallback << "/" << table_success << "\n";
+    }
+
+    price_table_destroy(table);
+    grid_free_all(&grids);
+}
+
+int main() {
+    run_accuracy_test();
+    return 0;
+}

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -46,6 +46,23 @@ cc_library(
 )
 
 cc_library(
+    name = "grid_transform",
+    srcs = ["grid_transform.c"],
+    hdrs = ["grid_transform.h"],
+    copts = [
+        "-std=c23",
+        "-Wall",
+        "-Wextra",
+        "-O3",
+    ],
+    deps = [
+        ":grid_presets",
+        ":price_table",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "pde_solver",
     srcs = ["pde_solver.c"],
     hdrs = [

--- a/src/grid_transform.c
+++ b/src/grid_transform.c
@@ -1,0 +1,37 @@
+#include "grid_transform.h"
+#include <math.h>
+
+void grid_transform_coordinates(GeneratedGrids *grids, CoordinateSystem coord_system) {
+    if (!grids) return;
+
+    switch (coord_system) {
+        case COORD_RAW:
+            // No transformation needed
+            break;
+
+        case COORD_LOG_SQRT:
+            // Transform moneyness: m → log(m)
+            for (size_t i = 0; i < grids->n_moneyness; i++) {
+                grids->moneyness[i] = log(grids->moneyness[i]);
+            }
+
+            // Transform maturity: tau → sqrt(tau)
+            for (size_t i = 0; i < grids->n_maturity; i++) {
+                grids->maturity[i] = sqrt(grids->maturity[i]);
+            }
+            break;
+
+        case COORD_LOG_VARIANCE:
+            // Transform moneyness: m → log(m)
+            for (size_t i = 0; i < grids->n_moneyness; i++) {
+                grids->moneyness[i] = log(grids->moneyness[i]);
+            }
+
+            // Transform maturity: tau → tau (no transform here, sigma²*tau applied during query)
+            // Note: COORD_LOG_VARIANCE uses w = sigma²*tau, but grid stores just tau
+            // The transformation happens in transform_query_to_grid()
+            break;
+    }
+
+    // Volatility and rate grids are never transformed
+}

--- a/src/grid_transform.h
+++ b/src/grid_transform.h
@@ -1,0 +1,54 @@
+#ifndef MANGO_GRID_TRANSFORM_H
+#define MANGO_GRID_TRANSFORM_H
+
+#include "grid_presets.h"
+#include "price_table.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file grid_transform.h
+ * @brief Coordinate transformation for grid arrays
+ *
+ * Transforms grid arrays between raw coordinates and transformed coordinates
+ * (log-sqrt, log-variance) as required by OptionPriceTable.
+ *
+ * When using COORD_LOG_SQRT or COORD_LOG_VARIANCE with price_table_create_ex(),
+ * grids must be pre-transformed before passing to the table.
+ */
+
+/**
+ * Transform grids to specified coordinate system (in-place)
+ *
+ * @param grids Generated grids (modified in-place)
+ * @param coord_system Target coordinate system
+ *
+ * Transforms moneyness and maturity grids according to the coordinate system:
+ * - COORD_RAW: No transformation (no-op)
+ * - COORD_LOG_SQRT: m → log(m), tau → sqrt(tau)
+ * - COORD_LOG_VARIANCE: m → log(m), tau → sigma²*tau
+ *
+ * Note: Volatility and rate grids are never transformed.
+ *
+ * Example:
+ *   GridConfig config = grid_preset_get(GRID_PRESET_BALANCED, ...);
+ *   GeneratedGrids grids = grid_generate_all(&config);
+ *
+ *   // Transform for LOG_SQRT coordinate system
+ *   grid_transform_coordinates(&grids, COORD_LOG_SQRT);
+ *
+ *   // Now grids are ready for price_table_create_ex with COORD_LOG_SQRT
+ *   OptionPriceTable *table = price_table_create_ex(
+ *       grids.moneyness, grids.n_moneyness,
+ *       grids.maturity, grids.n_maturity,
+ *       ..., COORD_LOG_SQRT, ...);
+ */
+void grid_transform_coordinates(GeneratedGrids *grids, CoordinateSystem coord_system);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MANGO_GRID_TRANSFORM_H


### PR DESCRIPTION
## Summary

Fixes critical bug where table-based IV calculation returned NaN for all queries when using `COORD_LOG_SQRT` coordinate system.

**Root Cause:** Price table with `COORD_LOG_SQRT` expects pre-transformed grids (moneyness→log, maturity→sqrt), but `grid_generate_all()` returns raw coordinates. Interpolation compared transformed query points against raw grid bounds, causing all queries to fail bounds check and return NaN.

**Solution:** Added `grid_transform_coordinates()` helper function to transform grids from raw to desired coordinate system before passing to `price_table_create_ex()`.

## Changes

### New Files
- `src/grid_transform.{c,h}`: Helper for grid coordinate transformation
- `examples/test_iv_accuracy.cc`: Comprehensive IV accuracy test demonstrating both FDM-based and table-based IV calculation methods

### Modified Files
- `src/BUILD.bazel`: Add grid_transform library
- `examples/BUILD.bazel`: Add test_iv_accuracy binary with grid_transform dependency

## Results

**Before fix:**
- Table-based IV: 0/7 tests passing (all returned NaN)

**After fix:**
- Table-based IV: 7/7 tests passing (0.00 bp error)
- All 17 repository tests pass

## Test Output

```
Method 2: Table-based IV (Newton's method + interpolation)
------------------------------------------------------------
Precomputing price table (this may take a minute)...
  Grid: 20×15×10×5 = 15000 points
Precompute complete!

  ✓ ATM Put, 3M, 20% vol      True: 0.2000 → IV: 0.2000 (err: 0.00 bp) [Newton, 5 iters]
  ✓ ATM Put, 1Y, 20% vol      True: 0.2000 → IV: 0.2000 (err: 0.00 bp) [Newton, 5 iters]
  ✓ ITM Put (S=100, K=90), 6M True: 0.2500 → IV: 0.2500 (err: 0.00 bp) [Newton, 6 iters]
  ✓ OTM Put (S=100, K=110), 6M True: 0.2500 → IV: 0.2500 (err: 0.00 bp) [Newton, 8 iters]
  ✓ ATM Put, 1M, 20% vol      True: 0.2000 → IV: 0.2000 (err: 0.00 bp) [Newton, 5 iters]
  ✓ ATM Put, 6M, 50% vol      True: 0.5000 → IV: 0.5000 (err: 0.00 bp) [Newton, 5 iters]
  ✓ ATM Put, 6M, 10% vol      True: 0.1000 → IV: 0.1000 (err: 0.00 bp) [Newton, 5 iters]

Table-based Summary:
  Success rate: 7/7 (puts only)
  Average error: 0.00 bp
  Max error: 0.00 bp
  Newton method: 7/7
  Brent fallback: 0/7
```

## Debugging Methodology

Discovered via systematic debugging (4-phase approach):

1. **Phase 1 - Root Cause Investigation:** 
   - Reproduced NaN bug consistently
   - Traced through interpolation code to `is_within_bounds()` check
   - Discovered query coordinates transformed but grids stored raw
   - Verified with diagnostic: `m_grid=log(1.0)=0.0` not in `[0.7, 1.3]`

2. **Phase 2 - Pattern Analysis:**
   - Found correct pattern in `coordinate_transform_test.cc`
   - Identified that grids must be pre-transformed before table creation
   - Gap: `grid_generate_all()` returns raw grids without transformation

3. **Phase 3 - Hypothesis and Testing:**
   - Hypothesis: Create `grid_transform_coordinates()` helper
   - Implemented minimal transformation function
   - Applied to test code → **Result: 0/7 → 7/7 passing!**

4. **Phase 4 - Implementation:**
   - Created proper module with header documentation
   - Added comprehensive IV accuracy test
   - Verified all 17 tests pass
   - Committed with detailed explanation

## API Usage Example

```cpp
// Generate grids (returns raw coordinates)
GridConfig config = grid_preset_get(GRID_PRESET_BALANCED, ...);
GeneratedGrids grids = grid_generate_all(&config);

// Transform to LOG_SQRT coordinate system
grid_transform_coordinates(&grids, COORD_LOG_SQRT);

// Now grids are ready for price_table with COORD_LOG_SQRT
OptionPriceTable *table = price_table_create_ex(
    grids.moneyness, grids.n_moneyness,
    grids.maturity, grids.n_maturity,
    ..., COORD_LOG_SQRT, LAYOUT_M_INNER);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)