### PR TITLE
Fix missing price_table_build_interpolation() calls (partial fix for #61)

### DIFF
--- a/src/validation.c
+++ b/src/validation.c
@@ -497,6 +497,9 @@ int price_table_precompute_adaptive(
             return -1;
         }
 
+        // Build interpolation structures (required before interpolation queries)
+        price_table_build_interpolation(table);
+
         // 2b. Validate interpolation error
         printf("  Validating accuracy...\n");
         ValidationResult result = validate_interpolation_error(

--- a/tests/adaptive_accuracy_test.cc
+++ b/tests/adaptive_accuracy_test.cc
@@ -117,6 +117,7 @@ TEST_F(AdaptiveAccuracyTest, GridExpansionPreservesValues) {
     // Precompute initial prices
     int status = price_table_precompute(table, &default_grid);
     EXPECT_EQ(status, 0);
+    price_table_build_interpolation(table);
 
     // Save initial prices at key points
     double price_before_1 = price_table_interpolate_4d(table, 0.9, 0.25, 0.20, 0.05);
@@ -138,6 +139,7 @@ TEST_F(AdaptiveAccuracyTest, GridExpansionPreservesValues) {
     // Recompute (only fills NaN entries)
     status = price_table_precompute(table, &default_grid);
     EXPECT_EQ(status, 0);
+    price_table_build_interpolation(table);
 
     // Check that original prices are preserved (within numerical tolerance)
     double price_after_1 = price_table_interpolate_4d(table, 0.9, 0.25, 0.20, 0.05);
@@ -176,6 +178,7 @@ TEST_F(AdaptiveAccuracyTest, ValidationStatistics) {
     // Precompute
     int status = price_table_precompute(table, &default_grid);
     EXPECT_EQ(status, 0);
+    price_table_build_interpolation(table);
 
     // Validate with 200 samples
     ValidationResult result = validate_interpolation_error(
@@ -233,6 +236,7 @@ TEST_F(AdaptiveAccuracyTest, RefinementPointSelection) {
 
     // Precompute
     price_table_precompute(table, &default_grid);
+    price_table_build_interpolation(table);
 
     // Validate to get high-error points
     ValidationResult result = validate_interpolation_error(


### PR DESCRIPTION
## Summary

Fixes the root cause of interpolation returning NaN in adaptive accuracy tests by adding missing `price_table_build_interpolation()` calls after `price_table_precompute()`.

## Root Cause Analysis

**Phase 1: Investigation**
- `validate_interpolation_error()` was returning `n_samples = 0` instead of 200
- Traced to `price_table_interpolate_4d()` returning NaN for all samples
- Found that `price_table_build_interpolation()` was never called after `price_table_precompute()`

**Phase 2: Pattern Analysis**
- API design footgun: `build_interpolation()` must be manually called after `precompute()` or `load()`
- Multiple locations (tests, examples, benchmarks) forget this step
- No compile-time or runtime enforcement
- Silent failure: interpolation just returns NaN

**Phase 3: Hypothesis Testing**
- Added `build_interpolation()` to ValidationStatistics test
- Result: 0 samples → 128 valid samples (64% success rate)
- Confirmed fix works, but revealed additional bugs

## Changes

Fixed 5 locations where `price_table_precompute()` was missing subsequent `build_interpolation()`:

1. **src/validation.c:500** - `price_table_precompute_adaptive()` loop
2. **tests/adaptive_accuracy_test.cc:120** - GridExpansionPreservesValues (first precompute)
3. **tests/adaptive_accuracy_test.cc:142** - GridExpansionPreservesValues (after grid expansion)
4. **tests/adaptive_accuracy_test.cc:181** - ValidationStatistics
5. **tests/adaptive_accuracy_test.cc:239** - RefinementPointSelection

## Testing

**ValidationStatistics (when run alone)**:
- Before: 0 valid samples (all NaN)
- After: 128 valid samples out of 200 (64% success)
- Test duration: ~104 seconds

**RefinementPointSelection**: ✅ PASSES

## Known Remaining Issues

This fix addresses the immediate interpolation NaN bug, but reveals additional issues:

1. **Test Isolation**: Tests pass individually but interfere when run together (shared state corruption)
2. **ValidationStatistics**: Expects 200 samples, gets 128 (72 still invalid - possibly out-of-bounds queries or precompute failures)
3. **GridExpansionPreservesValues**: First interpolation fails (NaN) but second succeeds with same code
4. **AccuracyImprovement**: Algorithmic bug - accuracy DEGRADES with refinement (583bp → 1712bp → 1654bp)
5. **AdaptiveConvergence**: Times out after 300 seconds

These require separate investigation and are tracked in issue #61.

## Future Improvements

To prevent this API footgun:
- Have `price_table_precompute()` automatically call `build_interpolation()`
- Have `price_table_load()` automatically call `build_interpolation()`
- Add runtime checks in `interpolate_4d()` to detect missing interpolation and return error code
- Improve API documentation

## Related Issues

Partially addresses #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)