### PR TITLE
Fix memory leak in pde_solver_create on validation failures

### DIFF
--- a/src/pde_solver.c
+++ b/src/pde_solver.c
@@ -409,11 +409,13 @@ PDESolver* pde_solver_create(SpatialGrid *grid,
     // Validate Robin boundary condition coefficients
     if (bc_config->left_type == BC_ROBIN && fabs(bc_config->left_robin_a) < 1e-15) {
         MANGO_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 1, bc_config->left_robin_a, 1e-15);
+        free(solver->grid.x);  // Free the transferred grid
         free(solver);
         return nullptr;
     }
     if (bc_config->right_type == BC_ROBIN && fabs(bc_config->right_robin_a) < 1e-15) {
         MANGO_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 2, bc_config->right_robin_a, 1e-15);
+        free(solver->grid.x);  // Free the transferred grid
         free(solver);
         return nullptr;
     }
@@ -441,6 +443,7 @@ PDESolver* pde_solver_create(SpatialGrid *grid,
         if (solver->workspace == nullptr) {
             // Both allocations failed
             MANGO_TRACE_VALIDATION_ERROR(MODULE_PDE_SOLVER, 0, workspace_size, 0.0);
+            free(solver->grid.x);  // Free the transferred grid
             free(solver);
             return nullptr;
         }


### PR DESCRIPTION
## Summary
Fixes memory leak when `pde_solver_create` fails after transferring grid ownership but before completing initialization.

## Problem Fixed
The function transfers grid ownership early (lines 401-402) but if validation or allocation fails afterwards, the transferred grid memory is not freed, causing a leak.

## Changes
- Added `free(solver->grid.x)` in all error return paths after ownership transfer:
  - Robin BC left coefficient validation failure (line 412)
  - Robin BC right coefficient validation failure (line 418)
  - Workspace allocation failure (line 446)

## Testing
- Memory sanitizers (AddressSanitizer, Valgrind) can verify no leaks
- Test cases that trigger validation failures will exercise these paths
- All existing tests continue to pass

## Related Issues
Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)