### PR TITLE
Create Makefile build system from Bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Bazel build artifacts
 bazel-*
 
+# Makefile build artifacts
+build/
+
 # IDE and editor files
 .vscode/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,190 @@
+# Makefile for mango-iv PDE Solver
+# Alternative to Bazel for environments without Bazel support
+
+# Compiler settings
+CXX := g++
+CXXFLAGS := -std=c++20 -Wall -Wextra -O3 -march=native
+CXXFLAGS_SIMD := -fopenmp-simd -ftree-vectorize
+CXXFLAGS_OMP := -fopenmp
+LDFLAGS :=
+LDFLAGS_OMP := -fopenmp
+
+# Optional USDT tracing support (requires systemtap-sdt-dev package)
+# Uncomment the line below to enable USDT tracing:
+# USDT_FLAG := -DHAVE_SYSTEMTAP_SDT
+# Default: disabled (uses no-op fallback macros)
+USDT_FLAG :=
+
+# Directories
+SRC_DIR := src
+TEST_DIR := tests
+EXAMPLE_DIR := examples
+BUILD_DIR := build
+OBJ_DIR := $(BUILD_DIR)/obj
+BIN_DIR := $(BUILD_DIR)/bin
+LIB_DIR := $(BUILD_DIR)/lib
+GTEST_DIR := $(BUILD_DIR)/googletest
+
+# Include paths
+INCLUDES := -I. -I$(SRC_DIR) -I$(SRC_DIR)/operators -Icommon
+
+# GoogleTest paths (will be populated after gtest is built)
+GTEST_INCLUDES := -I$(GTEST_DIR)/googletest/include -I$(GTEST_DIR)/googlemock/include
+GTEST_LIBS := $(GTEST_DIR)/lib/libgtest.a $(GTEST_DIR)/lib/libgtest_main.a
+GTEST_LDFLAGS := -pthread
+
+# Source files
+LIB_SOURCES := $(SRC_DIR)/american_option.cpp $(SRC_DIR)/iv_solver.cpp
+LIB_OBJECTS := $(patsubst $(SRC_DIR)/%.cpp,$(OBJ_DIR)/%.o,$(LIB_SOURCES))
+
+# Library output
+STATIC_LIB := $(LIB_DIR)/libmango.a
+
+# Example sources
+EXAMPLE_SOURCES := $(wildcard $(EXAMPLE_DIR)/*.cc)
+EXAMPLE_BINS := $(patsubst $(EXAMPLE_DIR)/%.cc,$(BIN_DIR)/%,$(EXAMPLE_SOURCES))
+
+# Test sources (only built if GoogleTest is available)
+# Exclude american_option_test.cc - it's a legacy C test
+TEST_SOURCES := $(filter-out $(TEST_DIR)/american_option_test.cc,$(wildcard $(TEST_DIR)/*.cc))
+TEST_BINS := $(patsubst $(TEST_DIR)/%.cc,$(BIN_DIR)/test_%,$(TEST_SOURCES))
+
+# Phony targets
+.PHONY: all lib examples tests clean distclean help setup-gtest check-gtest run-tests
+
+# Default target
+all: lib examples
+
+# Help target
+help:
+	@echo "Makefile for mango-iv PDE Solver"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all           - Build library and examples (default)"
+	@echo "  lib           - Build static library"
+	@echo "  examples      - Build example programs"
+	@echo "  tests         - Build test suite (requires GoogleTest)"
+	@echo "  run-tests     - Build and run all tests"
+	@echo "  setup-gtest   - Download and build GoogleTest locally"
+	@echo "  clean         - Remove build artifacts"
+	@echo "  distclean     - Remove all build files including GoogleTest"
+	@echo "  help          - Show this help message"
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  CXX           - C++ compiler (default: g++)"
+	@echo "  CXXFLAGS      - Additional compiler flags"
+	@echo "  LDFLAGS       - Additional linker flags"
+	@echo ""
+	@echo "Note: Set USDT_FLAG to empty string in Makefile to disable USDT tracing"
+
+# Create necessary directories
+$(OBJ_DIR) $(BIN_DIR) $(LIB_DIR):
+	@mkdir -p $@
+
+# Build static library
+lib: $(STATIC_LIB)
+
+$(STATIC_LIB): $(LIB_OBJECTS) | $(LIB_DIR)
+	@echo "Creating static library: $@"
+	ar rcs $@ $^
+
+# Compile library objects
+$(OBJ_DIR)/american_option.o: $(SRC_DIR)/american_option.cpp | $(OBJ_DIR)
+	@echo "Compiling: $<"
+	$(CXX) $(CXXFLAGS) $(CXXFLAGS_SIMD) $(CXXFLAGS_OMP) $(USDT_FLAG) $(INCLUDES) -c $< -o $@
+
+$(OBJ_DIR)/iv_solver.o: $(SRC_DIR)/iv_solver.cpp | $(OBJ_DIR)
+	@echo "Compiling: $<"
+	$(CXX) $(CXXFLAGS) $(CXXFLAGS_OMP) $(USDT_FLAG) $(INCLUDES) -c $< -o $@
+
+# Build examples
+examples: $(EXAMPLE_BINS)
+
+$(BIN_DIR)/example_%: $(EXAMPLE_DIR)/example_%.cc $(STATIC_LIB) | $(BIN_DIR)
+	@echo "Building example: $@"
+	$(CXX) $(CXXFLAGS) $(CXXFLAGS_SIMD) $(INCLUDES) $< $(STATIC_LIB) $(LDFLAGS_OMP) -o $@
+
+# GoogleTest setup
+setup-gtest:
+	@if [ -d "$(GTEST_DIR)" ]; then \
+		echo "GoogleTest already downloaded."; \
+	else \
+		echo "Downloading GoogleTest..."; \
+		mkdir -p $(BUILD_DIR); \
+		cd $(BUILD_DIR) && \
+		git clone --depth 1 --branch v1.14.0 https://github.com/google/googletest.git && \
+		mkdir -p googletest/build && cd googletest/build && \
+		cmake -DCMAKE_INSTALL_PREFIX=.. .. && \
+		cmake --build . && \
+		cmake --install .; \
+	fi
+
+# Check if GoogleTest is available
+check-gtest:
+	@if [ ! -f "$(GTEST_DIR)/lib/libgtest.a" ]; then \
+		echo "ERROR: GoogleTest not found. Run 'make setup-gtest' first."; \
+		exit 1; \
+	fi
+
+# Build tests (requires GoogleTest)
+tests: check-gtest $(TEST_BINS)
+
+# Generic test compilation rule
+$(BIN_DIR)/test_%: $(TEST_DIR)/%.cc $(STATIC_LIB) | $(BIN_DIR)
+	@echo "Building test: $@"
+	$(CXX) $(CXXFLAGS) $(CXXFLAGS_SIMD) $(INCLUDES) $(GTEST_INCLUDES) $< $(STATIC_LIB) \
+		$(GTEST_LIBS) $(LDFLAGS_OMP) $(GTEST_LDFLAGS) -o $@
+
+# Run all tests
+run-tests: tests
+	@echo "Running tests..."
+	@failed=0; \
+	for test in $(TEST_BINS); do \
+		if [ -f "$$test" ]; then \
+			echo ""; \
+			echo "Running: $$(basename $$test)"; \
+			echo "====================================="; \
+			if $$test; then \
+				echo "✓ PASSED"; \
+			else \
+				echo "✗ FAILED"; \
+				failed=$$((failed + 1)); \
+			fi; \
+		fi; \
+	done; \
+	echo ""; \
+	echo "====================================="; \
+	if [ $$failed -eq 0 ]; then \
+		echo "All tests passed!"; \
+	else \
+		echo "$$failed test(s) failed."; \
+		exit 1; \
+	fi
+
+# Clean build artifacts (keep GoogleTest)
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -rf $(OBJ_DIR) $(BIN_DIR) $(LIB_DIR)
+
+# Clean everything including GoogleTest
+distclean:
+	@echo "Cleaning all build files..."
+	rm -rf $(BUILD_DIR)
+
+# Dependencies (simplified - in production use proper dependency tracking)
+$(LIB_OBJECTS): $(wildcard $(SRC_DIR)/*.hpp) $(wildcard $(SRC_DIR)/operators/*.hpp) common/ivcalc_trace.h
+$(EXAMPLE_BINS): $(wildcard $(SRC_DIR)/*.hpp) $(wildcard $(SRC_DIR)/operators/*.hpp)
+$(TEST_BINS): $(wildcard $(SRC_DIR)/*.hpp) $(wildcard $(SRC_DIR)/operators/*.hpp)
+
+# Additional info
+.DEFAULT_GOAL := all
+
+# Print configuration
+print-config:
+	@echo "Configuration:"
+	@echo "  CXX:        $(CXX)"
+	@echo "  CXXFLAGS:   $(CXXFLAGS)"
+	@echo "  USDT:       $(USDT_FLAG)"
+	@echo "  SRC_DIR:    $(SRC_DIR)"
+	@echo "  BUILD_DIR:  $(BUILD_DIR)"
+	@echo "  LIB:        $(STATIC_LIB)"

--- a/README.make.md
+++ b/README.make.md
@@ -1,0 +1,235 @@
+# Makefile Build System for mango-iv
+
+This is an alternative build system using standard Make, designed as a workaround for environments where Bazel is not available (e.g., Claude Code web interface).
+
+## Quick Start
+
+### Build the library and examples:
+```bash
+make
+```
+
+### Build specific targets:
+```bash
+make lib        # Build static library only
+make examples   # Build example programs
+```
+
+### Run an example:
+```bash
+./build/bin/example_newton_solver
+```
+
+## Building Tests
+
+Tests require GoogleTest. You have two options:
+
+### Option 1: Automatic Setup (Recommended)
+```bash
+# Download and build GoogleTest locally (one-time setup)
+make setup-gtest
+
+# Build all tests
+make tests
+
+# Build and run all tests
+make run-tests
+```
+
+### Option 2: System GoogleTest
+If you have GoogleTest installed system-wide, you'll need to modify the Makefile to use system paths instead of the local build.
+
+## Available Targets
+
+| Target | Description |
+|--------|-------------|
+| `all` | Build library and examples (default) |
+| `lib` | Build static library (`build/lib/libmango.a`) |
+| `examples` | Build example programs |
+| `tests` | Build test suite (requires GoogleTest) |
+| `run-tests` | Build and run all tests |
+| `setup-gtest` | Download and build GoogleTest locally |
+| `clean` | Remove build artifacts (keeps GoogleTest) |
+| `distclean` | Remove all build files including GoogleTest |
+| `help` | Show help message |
+| `print-config` | Display build configuration |
+
+## Build Output
+
+All build artifacts are placed in the `build/` directory:
+
+```
+build/
+├── obj/              # Object files (.o)
+├── lib/              # Static library (libmango.a)
+├── bin/              # Executables (examples and tests)
+└── googletest/       # GoogleTest installation (if using setup-gtest)
+```
+
+## Compiler Configuration
+
+### Default Settings
+- Compiler: `g++`
+- Standard: C++20
+- Optimization: `-O3 -march=native`
+- SIMD: `-fopenmp-simd -ftree-vectorize`
+- OpenMP: `-fopenmp` (for parallelization)
+
+### Customization
+
+You can override compiler settings using environment variables:
+
+```bash
+# Use clang++ instead of g++
+make CXX=clang++
+
+# Add extra flags
+make CXXFLAGS="-std=c++20 -Wall -O2"
+
+# Disable native optimization (for portability)
+make CXXFLAGS="-std=c++20 -Wall -O3"
+```
+
+### USDT Tracing
+
+USDT tracing is **disabled by default** (uses no-op fallback macros). To enable it:
+
+1. Install systemtap-sdt-dev:
+   ```bash
+   sudo apt-get install systemtap-sdt-dev
+   ```
+
+2. Edit the Makefile and uncomment the USDT flag:
+   ```makefile
+   USDT_FLAG := -DHAVE_SYSTEMTAP_SDT
+   ```
+
+3. Rebuild:
+   ```bash
+   make clean
+   make
+   ```
+
+## Project Structure
+
+The Makefile builds the following components:
+
+### Core Library
+- `src/american_option.cpp` - American option pricing
+- `src/iv_solver.cpp` - Implied volatility solver
+- Header-only components (automatically included)
+
+### Examples
+- `examples/example_newton_solver.cc` - Newton-Raphson solver example
+
+### Tests
+- All `tests/*.cc` files are built as individual test executables
+- Test binaries are prefixed with `test_` (e.g., `test_pde_solver_test`)
+
+## Comparison with Bazel
+
+| Feature | Bazel | Makefile |
+|---------|-------|----------|
+| Dependency management | Automatic (Bzlmod) | Manual |
+| External deps | Integrated | Manual download |
+| Incremental builds | Excellent | Good |
+| Cross-platform | Excellent | Platform-specific |
+| Setup complexity | High | Low |
+| Build speed | Fast (cached) | Moderate |
+
+The Makefile system is intended as a **temporary workaround** for environments without Bazel support. For production use, Bazel is recommended.
+
+## Troubleshooting
+
+### Missing Headers
+If you encounter missing header errors, ensure all header files are present:
+```bash
+ls src/*.hpp
+ls src/operators/*.hpp
+ls common/*.h
+```
+
+### Compilation Errors
+1. Check your compiler version:
+   ```bash
+   g++ --version  # Should support C++20
+   ```
+
+2. Verify C++20 support:
+   ```bash
+   make CXX=g++-11  # Use a specific version if needed
+   ```
+
+### Test Failures
+If tests fail to build:
+```bash
+# Clean and rebuild GoogleTest
+make distclean
+make setup-gtest
+make tests
+```
+
+### Performance Issues
+If the build is too slow:
+```bash
+# Reduce optimization level
+make clean
+make CXXFLAGS="-std=c++20 -O2"
+
+# Disable native optimization
+make clean
+make CXXFLAGS="-std=c++20 -O3"  # Remove -march=native
+```
+
+## Integration with Development Workflow
+
+### Clean Rebuild
+```bash
+make clean && make -j4
+```
+
+### Specific Test
+```bash
+make tests
+./build/bin/test_pde_solver_test
+```
+
+### Debugging Build
+```bash
+make clean
+make CXXFLAGS="-std=c++20 -g -O0"
+gdb ./build/bin/example_newton_solver
+```
+
+## Limitations
+
+1. **No automatic dependency tracking** - If you modify headers, run `make clean` first
+2. **No external dependency management** - Dependencies like GoogleTest must be manually managed
+3. **Limited parallelism** - Use `make -jN` for parallel builds, but dependency ordering is manual
+4. **Platform-specific** - Tested on Linux, may need adjustments for macOS/Windows
+
+## Future Improvements
+
+Potential enhancements to this Makefile system:
+
+- [ ] Automatic header dependency generation (`.d` files)
+- [ ] Support for system-installed GoogleTest
+- [ ] Cross-platform compatibility (macOS, MSYS2)
+- [ ] Benchmark targets
+- [ ] Installation targets (`make install`)
+- [ ] Package generation (`.deb`, `.rpm`)
+
+## Migrating Back to Bazel
+
+When Bazel becomes available, simply use the standard Bazel commands:
+
+```bash
+# Clean Makefile artifacts
+make distclean
+
+# Use Bazel
+bazel build //...
+bazel test //...
+```
+
+The Bazel build files are authoritative and always kept up-to-date.


### PR DESCRIPTION
This commit introduces a standard Makefile-based build system as a workaround for environments where Bazel is not available (e.g., Claude Code web interface).

Features:
- Build static library (libmango.a) from C++ sources
- Compile example programs with single command
- Support for GoogleTest-based test suite
- Automatic GoogleTest download and setup
- C++20 with optimization flags (-O3, -march=native)
- OpenMP support for parallelization
- SIMD vectorization flags (-fopenmp-simd, -ftree-vectorize)
- USDT tracing support (optional, disabled by default)

Key targets:
- make all: Build library and examples (default)
- make lib: Build static library only
- make examples: Build example programs
- make setup-gtest: Download and build GoogleTest locally
- make tests: Build test suite (requires GoogleTest)
- make run-tests: Build and run all tests
- make clean: Remove build artifacts
- make help: Show all available targets

The Makefile excludes the legacy american_option_test.cc which depends on the old C implementation. All modern C++20 tests are supported.

Documentation provided in README.make.md with quick start guide, configuration options, and troubleshooting tips.

This is intended as a temporary workaround - the Bazel build system remains the authoritative build method for production use.