### PR TITLE
Remove trbdf2 config from American presentation

### DIFF
--- a/src/option/american_option.cpp
+++ b/src/option/american_option.cpp
@@ -119,7 +119,6 @@ AmericanOptionSolver::AmericanOptionSolver(
     const AmericanOptionParams& params,
     std::shared_ptr<AmericanSolverWorkspace> workspace)
     : params_(params)
-    , trbdf2_config_{}  // Default-initialized
     , workspace_(std::move(workspace))
 {
     // Validate parameters using unified validation
@@ -226,7 +225,7 @@ std::expected<AmericanOptionResult, SolverError> AmericanOptionSolver::solve() {
 
     if (params_.type == OptionType::PUT) {
         // Create PDESolver with obstacle
-        PDESolver solver(x_grid, time_domain, trbdf2_config_,
+        PDESolver solver(x_grid, time_domain, TRBDF2Config{},
                         left_bc, right_bc, bs_op,
                         [](double t, auto x, auto psi) {
                             AmericanPutObstacle obstacle;
@@ -292,7 +291,7 @@ std::expected<AmericanOptionResult, SolverError> AmericanOptionSolver::solve() {
     } else {  // CALL
         // Create PDESolver with obstacle
         // Note: left_bc and right_bc already defined above with time-dependent discounting
-        PDESolver solver(x_grid, time_domain, trbdf2_config_,
+        PDESolver solver(x_grid, time_domain, TRBDF2Config{},
                         left_bc, right_bc, bs_op,
                         [](double t, auto x, auto psi) {
                             AmericanCallObstacle obstacle;

--- a/src/option/american_option.hpp
+++ b/src/option/american_option.hpp
@@ -166,18 +166,6 @@ public:
     }
 
     /**
-     * Set TR-BDF2 solver configuration (advanced).
-     *
-     * Allows fine-tuning of the time-stepping scheme and Newton solver.
-     * Most users should use the default configuration.
-     *
-     * @param config TR-BDF2 solver configuration (includes Newton parameters)
-     */
-    void set_trbdf2_config(const TRBDF2Config& config) {
-        trbdf2_config_ = config;
-    }
-
-    /**
      * Get the full solution surface (for debugging/analysis).
      *
      * @return Vector of option values across the spatial grid
@@ -187,7 +175,6 @@ public:
 private:
     // Parameters
     AmericanOptionParams params_;
-    TRBDF2Config trbdf2_config_;
 
     // Workspace (contains grid configuration and pre-allocated storage)
     // Uses shared_ptr to keep workspace alive for the solver's lifetime


### PR DESCRIPTION
Simplifies the high-level American option pricing API by removing the ability to configure TR-BDF2 solver parameters. The solver now uses sensible defaults (20 iterations, 1e-6 tolerance) that work well for most applications.

Changes:
- Removed set_trbdf2_config() method from AmericanOptionSolver
- Removed trbdf2_config_ member variable
- Updated solve() to use default TRBDF2Config{}
- Updated CLAUDE.md to reflect simplified API

Users who need advanced TR-BDF2 configuration can use the low-level PDESolver API directly. This change reduces API surface area and prevents accidental misconfiguration.