### PR TITLE
Add newton_u_old and tridiag_workspace to PDEWorkspace

### DIFF
--- a/src/pde/core/pde_workspace.hpp
+++ b/src/pde/core/pde_workspace.hpp
@@ -69,17 +69,23 @@ public:
     std::span<double> jacobian_diag() { return {jacobian_diag_.data(), n_}; }
     std::span<const double> jacobian_diag() const { return {jacobian_diag_.data(), n_}; }
 
-    std::span<double> jacobian_upper() { return {jacobian_upper_.data(), n_}; }
-    std::span<const double> jacobian_upper() const { return {jacobian_upper_.data(), n_}; }
+    std::span<double> jacobian_upper() { return {jacobian_upper_.data(), n_ - 1}; }
+    std::span<const double> jacobian_upper() const { return {jacobian_upper_.data(), n_ - 1}; }
 
-    std::span<double> jacobian_lower() { return {jacobian_lower_.data(), n_}; }
-    std::span<const double> jacobian_lower() const { return {jacobian_lower_.data(), n_}; }
+    std::span<double> jacobian_lower() { return {jacobian_lower_.data(), n_ - 1}; }
+    std::span<const double> jacobian_lower() const { return {jacobian_lower_.data(), n_ - 1}; }
 
     std::span<double> residual() { return {residual_.data(), n_}; }
     std::span<const double> residual() const { return {residual_.data(), n_}; }
 
     std::span<double> delta_u() { return {delta_u_.data(), n_}; }
     std::span<const double> delta_u() const { return {delta_u_.data(), n_}; }
+
+    std::span<double> newton_u_old() { return {newton_u_old_.data(), n_}; }
+    std::span<const double> newton_u_old() const { return {newton_u_old_.data(), n_}; }
+
+    std::span<double> tridiag_workspace() { return {tridiag_workspace_.data(), 2 * n_}; }
+    std::span<const double> tridiag_workspace() const { return {tridiag_workspace_.data(), 2 * n_}; }
 
     size_t logical_size() const { return n_; }
     size_t padded_size() const { return padded_n_; }
@@ -99,10 +105,12 @@ private:
         , psi_(padded_n_, 0.0, mr)
         , dx_(pad_to_simd(n - 1), 0.0, mr)
         , jacobian_diag_(padded_n_, 0.0, mr)
-        , jacobian_upper_(padded_n_, 0.0, mr)
-        , jacobian_lower_(padded_n_, 0.0, mr)
+        , jacobian_upper_(pad_to_simd(n - 1), 0.0, mr)
+        , jacobian_lower_(pad_to_simd(n - 1), 0.0, mr)
         , residual_(padded_n_, 0.0, mr)
         , delta_u_(padded_n_, 0.0, mr)
+        , newton_u_old_(padded_n_, 0.0, mr)
+        , tridiag_workspace_(pad_to_simd(2 * n), 0.0, mr)
     {
         // Copy grid data
         std::copy(grid_data.begin(), grid_data.end(), grid_.begin());
@@ -130,6 +138,8 @@ private:
     std::pmr::vector<double> jacobian_lower_;
     std::pmr::vector<double> residual_;
     std::pmr::vector<double> delta_u_;
+    std::pmr::vector<double> newton_u_old_;
+    std::pmr::vector<double> tridiag_workspace_;
 };
 
 }  // namespace mango

--- a/tests/pde_workspace_test.cc
+++ b/tests/pde_workspace_test.cc
@@ -58,10 +58,16 @@ TEST(PDEWorkspacePMRTest, NewtonArraysAccessible) {
     auto delta_u = ws->delta_u();
 
     EXPECT_EQ(jac_diag.size(), 101);
-    EXPECT_EQ(jac_upper.size(), 101);
-    EXPECT_EQ(jac_lower.size(), 101);
+    EXPECT_EQ(jac_upper.size(), 100);  // Off-diagonal: n-1
+    EXPECT_EQ(jac_lower.size(), 100);  // Off-diagonal: n-1
     EXPECT_EQ(residual.size(), 101);
     EXPECT_EQ(delta_u.size(), 101);
+
+    // Test new Newton arrays
+    auto newton_u_old = ws->newton_u_old();
+    auto tridiag_ws = ws->tridiag_workspace();
+    EXPECT_EQ(newton_u_old.size(), 101);
+    EXPECT_EQ(tridiag_ws.size(), 202);  // 2*n
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Adds two missing Newton solver buffers to PDEWorkspace and fixes existing buffer allocation/accessor bugs. This is a safe, standalone improvement that prepares for future refactoring.

## Changes
### New Buffers
- **newton_u_old**: Previous Newton iterate (size n) with accessors
- **tridiag_workspace**: Thomas algorithm workspace (size 2n) with accessors

### Bug Fixes
- **jacobian_upper/lower allocation**: Fixed to use `pad_to_simd(n-1)` instead of `padded_n_`
  - **Before**: Allocated n elements (wrong, wasted memory)
  - **After**: Allocated n-1 elements (correct for tridiagonal off-diagonals)
  
- **jacobian_upper/lower accessors**: Fixed to return n-1 elements
  - **Before**: Returned n elements (wrong, inconsistent with Thomas solver API)
  - **After**: Returns n-1 elements (correct, matches Thomas solver requirement)
  - The Thomas solver explicitly validates: `lower.size() == n-1` and `upper.size() == n-1`

### Test Updates
- Updated test expectations to match correct sizes
- Added tests for new newton_u_old and tridiag_workspace accessors

## Why These Changes Are Safe
1. **Additive only**: New buffers don't affect existing functionality
2. **Bug fixes**: Corrects pre-existing bugs in allocation sizes
3. **No behavior changes**: PDESolver still uses its own std::vector members
4. **All tests pass**: 38/38 tests passing

## Future Work
The riskier part (removing duplicate std::vector members from PDESolver) will be done in a separate PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)