### PR TITLE
Document PDESolver vs PDEWorkspace array separation

### DIFF
--- a/src/pde/core/pde_solver.hpp
+++ b/src/pde/core/pde_solver.hpp
@@ -256,14 +256,26 @@ private:
     std::vector<double> solution_storage_;  // Backing storage when no external buffer
     std::span<double> u_current_;           // u^{n+1} or u^{n+γ}
     std::span<double> u_old_;               // u^n
-    std::vector<double> rhs_;               // n: RHS vector for stages
 
-    // Newton workspace arrays (merged from NewtonWorkspace)
-    std::vector<double> jacobian_lower_;      // n-1: Lower diagonal
-    std::vector<double> jacobian_diag_;       // n: Main diagonal
-    std::vector<double> jacobian_upper_;      // n-1: Upper diagonal
-    std::vector<double> residual_;            // n: Residual vector
-    std::vector<double> delta_u_;             // n: Newton step
+    // ═══════════════════════════════════════════════════════════════════════
+    // PDESolver INTERNAL working arrays (NOT duplicates of workspace arrays!)
+    // ═══════════════════════════════════════════════════════════════════════
+    // These std::vector arrays are PDESolver's PRIMARY working memory for:
+    //   - TR-BDF2 stage computations (rhs_)
+    //   - Newton iteration (jacobian_*, residual_, delta_u_, newton_u_old_)
+    //   - Tridiagonal solver (tridiag_workspace_)
+    //
+    // PDEWorkspace arrays serve a DIFFERENT purpose (batch/external sharing).
+    // DO NOT remove these arrays thinking they are "duplicates"!
+    // ═══════════════════════════════════════════════════════════════════════
+    std::vector<double> rhs_;                 // n: RHS vector for TR-BDF2 stages
+
+    // Newton iteration working arrays
+    std::vector<double> jacobian_lower_;      // n-1: Jacobian lower diagonal
+    std::vector<double> jacobian_diag_;       // n: Jacobian main diagonal
+    std::vector<double> jacobian_upper_;      // n-1: Jacobian upper diagonal
+    std::vector<double> residual_;            // n: Newton residual F(u)
+    std::vector<double> delta_u_;             // n: Newton correction δu
     std::vector<double> newton_u_old_;        // n: Previous Newton iterate
     std::vector<double> tridiag_workspace_;   // 2n: Thomas algorithm workspace
 

--- a/src/pde/core/pde_workspace.hpp
+++ b/src/pde/core/pde_workspace.hpp
@@ -125,21 +125,40 @@ private:
     size_t padded_n_;
     std::pmr::memory_resource* resource_;
 
-    std::pmr::vector<double> grid_;
-    std::pmr::vector<double> u_current_;
-    std::pmr::vector<double> u_next_;
-    std::pmr::vector<double> u_stage_;
-    std::pmr::vector<double> rhs_;
-    std::pmr::vector<double> lu_;
-    std::pmr::vector<double> psi_;
-    std::pmr::vector<double> dx_;
-    std::pmr::vector<double> jacobian_diag_;
-    std::pmr::vector<double> jacobian_upper_;
-    std::pmr::vector<double> jacobian_lower_;
-    std::pmr::vector<double> residual_;
-    std::pmr::vector<double> delta_u_;
-    std::pmr::vector<double> newton_u_old_;
-    std::pmr::vector<double> tridiag_workspace_;
+    // ═══════════════════════════════════════════════════════════════════════
+    // IMPORTANT: PDEWorkspace arrays are CURRENTLY UNUSED (reserved for future)
+    // ═══════════════════════════════════════════════════════════════════════
+    // PDESolver has its OWN separate std::vector arrays for internal computation
+    // and does NOT use these PMR arrays.
+    //
+    // These arrays are ALLOCATED but UNUSED in current code. They are reserved for:
+    //   1. Future batch operations (multiple solvers sharing memory arena)
+    //   2. Future external workspace management
+    //   3. Future zero-copy sharing between solver instances
+    //
+    // STATUS: As of PR #202, these arrays exist but are never accessed by PDESolver.
+    //         They consume memory (~13n doubles) without providing current value.
+    //
+    // DO NOT attempt to "deduplicate" by removing PDESolver's arrays!
+    // PDESolver MUST keep its own std::vector members for internal computation.
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // MUST be declared in same order as constructor initialization!
+    std::pmr::vector<double> grid_;              // Spatial grid points
+    std::pmr::vector<double> u_current_;         // Current solution u^{n+1}
+    std::pmr::vector<double> u_next_;            // Next solution (for multi-stage)
+    std::pmr::vector<double> u_stage_;           // Stage solution u^{n+γ}
+    std::pmr::vector<double> rhs_;               // Right-hand side vector
+    std::pmr::vector<double> lu_;                // Spatial operator output L(u)
+    std::pmr::vector<double> psi_;               // Obstacle constraint ψ(x,t)
+    std::pmr::vector<double> dx_;                // Precomputed grid spacing (n-1)
+    std::pmr::vector<double> jacobian_diag_;     // Jacobian main diagonal (n)
+    std::pmr::vector<double> jacobian_upper_;    // Jacobian upper diagonal (n-1)
+    std::pmr::vector<double> jacobian_lower_;    // Jacobian lower diagonal (n-1)
+    std::pmr::vector<double> residual_;          // Newton residual F(u)
+    std::pmr::vector<double> delta_u_;           // Newton correction δu
+    std::pmr::vector<double> newton_u_old_;      // Previous Newton iterate
+    std::pmr::vector<double> tridiag_workspace_; // Thomas solver workspace (2n)
 };
 
 }  // namespace mango


### PR DESCRIPTION
## Summary
Adds critical documentation to prevent future bugs from attempting to "deduplicate" PDESolver and PDEWorkspace arrays, which serve completely different purposes.

## Background
Investigation revealed that PDESolver and PDEWorkspace maintain **separate, non-duplicate** array sets:

### PDESolver Arrays (`std::vector`)
- **Purpose**: Primary working memory for ALL solver computation
- **Used for**: TR-BDF2 staging, Newton iteration, tridiagonal solves
- **Status**: Essential - removing these breaks the solver

### PDEWorkspace Arrays (`std::pmr::vector`)
- **Purpose**: Reserved for future batch operations and workspace sharing
- **Current status**: UNUSED by PDESolver (added in PR #202 but never accessed)
- **Memory cost**: ~13n doubles per solver instance
- **Added**: PR #202, based on incorrect assumption PDESolver would use them

## Changes
### PDEWorkspace Documentation
- Added prominent warning that arrays are currently unused
- Explained they're reserved for future batch/external workspace features
- Noted memory cost (~13n doubles) without current value
- Warned against removing PDESolver's arrays

### PDESolver Documentation
- Clarified these are PRIMARY working arrays (not duplicates)
- Listed exact usage: TR-BDF2 stages, Newton iteration, Thomas solver
- Added strong warning against removal attempts

## Why This Matters
Without this documentation, it appears PDESolver has "duplicate" arrays that should be removed. This led to a debugging session where:
1. Attempted refactoring to remove PDESolver arrays
2. All tests failed (Newton solver had no working memory)
3. Systematic debugging revealed the arrays serve different purposes
4. Reverted changes and added this documentation

## Testing
- All 38 tests passing
- No functional changes, documentation only
- Prevents future bugs from incorrect refactoring

## Related
- PR #202: Added PDEWorkspace arrays (safe but unused)
- This PR documents the current state to prevent confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)