### PR TITLE
Fix IV solver benchmark failure with manual grid mode

### DIFF
--- a/src/option/american_option.hpp
+++ b/src/option/american_option.hpp
@@ -162,10 +162,14 @@ public:
      * @param params Option pricing parameters
      * @param workspace PDEWorkspace with pre-allocated buffers
      * @param snapshot_times Optional times to record solution snapshots
+     * @param custom_grid Optional custom grid specification (bypasses auto-estimation)
+     * @param custom_n_time Optional custom time steps (used with custom_grid)
      */
     AmericanOptionSolver(const PricingParams& params,
                         PDEWorkspace workspace,
-                        std::optional<std::span<const double>> snapshot_times = std::nullopt);
+                        std::optional<std::span<const double>> snapshot_times = std::nullopt,
+                        std::optional<GridSpec<double>> custom_grid = std::nullopt,
+                        std::optional<size_t> custom_n_time = std::nullopt);
 
     /**
      * Solve for option value.
@@ -187,6 +191,10 @@ private:
 
     // Snapshot times for Grid creation
     std::vector<double> snapshot_times_;
+
+    // Optional custom grid configuration (bypasses auto-estimation)
+    std::optional<GridSpec<double>> custom_grid_;
+    std::optional<size_t> custom_n_time_;
 };
 
 }  // namespace mango

--- a/src/option/iv_solver_fdm.cpp
+++ b/src/option/iv_solver_fdm.cpp
@@ -144,7 +144,19 @@ double IVSolverFDM::objective_function(const IVQuery& query, double volatility) 
 
     // Create solver and solve
     try {
-        AmericanOptionSolver solver(option_params, pde_workspace_result.value());
+        // Pass custom grid if manual mode is enabled
+        std::optional<GridSpec<double>> custom_grid_opt = std::nullopt;
+        std::optional<size_t> custom_n_time_opt = std::nullopt;
+
+        if (config_.use_manual_grid) {
+            custom_grid_opt = grid_spec;
+            custom_n_time_opt = config_.grid_n_time;
+        }
+
+        AmericanOptionSolver solver(option_params, pde_workspace_result.value(),
+                                    std::nullopt,  // snapshot_times
+                                    custom_grid_opt,
+                                    custom_n_time_opt);
         // Surface always collected for value_at()
         auto price_result = solver.solve();
 


### PR DESCRIPTION
## Summary

Fixes critical bug in IV solver where manual grid mode (used for benchmarking) failed due to workspace size mismatch. The root cause was that `AmericanOptionSolver` always auto-estimated grid size from volatility, ignoring the caller's intended grid configuration.

## Root Cause

1. `IVSolverFDM` creates workspace sized for manual grid (e.g., 201 points for stress testing)
2. `AmericanOptionSolver::solve()` calls `estimate_grid_for_option(params_)` which produces 101 points for typical volatilities
3. Workspace size mismatch (201 ≠ 101) → error → NaN → Brent throws exception
4. Benchmark fails with "Function returned non-finite value (NaN or Inf)"

## Changes

- **american_option.hpp**: Add optional `custom_grid` and `custom_n_time` parameters to constructor
- **american_option.cpp**: Use custom grid if provided, otherwise auto-estimate (backward compatible)
- **iv_solver_fdm.cpp**: Pass manual grid spec to AmericanOptionSolver when `use_manual_grid=true`

## Testing

**Before fix:**
- ✅ BM_README_IV_FDM/101/1000: PASS
- ❌ BM_README_IV_FDM/201/2000: FAIL (NaN/Inf error)

**After fix:**
- ✅ BM_README_IV_FDM/101/1000: PASS (15.53 ms)
- ✅ BM_README_IV_FDM/201/2000: PASS (60.72 ms)
- ✅ All batch solver tests: PASS
- ✅ All IV solver tests: PASS
- ✅ Full benchmark suite: PASS

## Backward Compatibility

No breaking changes. Auto-estimation still used when custom grid not provided. Existing code continues to work as before.

## Related Issues

Fixes benchmark failure discovered during batch solver development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)