### PR TITLE
Refactor to TridiagonalMatrixView for type-safe matrix access

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,8 +1,9 @@
 # All library targets have been reorganized into subdirectories:
 #
 # - Core PDE solver components: //src/pde/core:BUILD.bazel
-#   (grid, boundary_conditions, jacobian_view, root_finding, brent,
-#    newton_workspace, spatial_operators, time_domain, trbdf2_config, thomas_solver, pde_solver)
+#   (grid, boundary_conditions, time_domain, trbdf2_config, pde_solver)
+# - Math components: //src/math:BUILD.bazel
+#   (tridiagonal_matrix_view, thomas_solver, root_finding, brent, etc.)
 #
 # - Interpolation utilities: //src/interpolation:BUILD.bazel
 #   (cubic_spline_solver, snapshot_interpolator, bspline_4d, bspline_basis_1d,

--- a/src/math/BUILD.bazel
+++ b/src/math/BUILD.bazel
@@ -15,8 +15,8 @@ cc_library(
 )
 
 cc_library(
-    name = "jacobian_view",
-    hdrs = ["jacobian_view.hpp"],
+    name = "tridiagonal_matrix_view",
+    hdrs = ["tridiagonal_matrix_view.hpp"],
     copts = [
         "-std=c++23",
         "-Wall",
@@ -29,7 +29,7 @@ cc_library(
 cc_library(
     name = "thomas_solver",
     hdrs = ["thomas_solver.hpp"],
-    deps = [":jacobian_view"],
+    deps = [":tridiagonal_matrix_view"],
     copts = ["-std=c++23"],
     visibility = ["//visibility:public"],
 )

--- a/src/math/thomas_solver.hpp
+++ b/src/math/thomas_solver.hpp
@@ -14,7 +14,7 @@
 #include <optional>
 #include <string_view>
 #include <limits>
-#include "src/math/jacobian_view.hpp"
+#include "src/math/tridiagonal_matrix_view.hpp"
 
 namespace mango {
 
@@ -446,16 +446,16 @@ template<std::floating_point T>
 }
 
 // ============================================================================
-// JacobianView Overloads (Convenience API)
+// TridiagonalMatrixView Overloads (Convenience API)
 // ============================================================================
 //
-// These overloads accept JacobianView instead of three separate spans,
+// These overloads accept TridiagonalMatrixView instead of three separate spans,
 // providing better type safety and clearer intent. They simply forward
 // to the span-based implementations.
 
-/// Thomas solver accepting JacobianView (convenience overload)
+/// Thomas solver accepting TridiagonalMatrixView (convenience overload)
 ///
-/// @param jac Jacobian view containing lower, diag, upper bands
+/// @param matrix Tridiagonal matrix view containing lower, diag, upper bands
 /// @param rhs Right-hand side vector
 /// @param solution Output solution vector
 /// @param workspace Temporary storage (2n)
@@ -463,19 +463,19 @@ template<std::floating_point T>
 /// @return Result indicating success/failure
 template<std::floating_point T>
 [[nodiscard]] constexpr ThomasResult<T> solve_thomas(
-    const JacobianView& jac,
+    const TridiagonalMatrixView& matrix,
     std::span<const T> rhs,
     std::span<T> solution,
     std::span<T> workspace,
     const ThomasConfig<T>& config = {}) noexcept
 {
-    return solve_thomas(jac.lower(), jac.diag(), jac.upper(),
+    return solve_thomas(matrix.lower(), matrix.diag(), matrix.upper(),
                        rhs, solution, workspace, config);
 }
 
-/// Projected Thomas solver accepting JacobianView (convenience overload)
+/// Projected Thomas solver accepting TridiagonalMatrixView (convenience overload)
 ///
-/// @param jac Jacobian view containing lower, diag, upper bands
+/// @param matrix Tridiagonal matrix view containing lower, diag, upper bands
 /// @param rhs Right-hand side vector
 /// @param psi Obstacle constraint vector
 /// @param solution Output solution vector
@@ -484,14 +484,14 @@ template<std::floating_point T>
 /// @return Result indicating success/failure
 template<std::floating_point T>
 [[nodiscard]] constexpr ThomasResult<T> solve_thomas_projected(
-    const JacobianView& jac,
+    const TridiagonalMatrixView& matrix,
     std::span<const T> rhs,
     std::span<const T> psi,
     std::span<T> solution,
     std::span<T> workspace,
     const ThomasConfig<T>& config = {}) noexcept
 {
-    return solve_thomas_projected(jac.lower(), jac.diag(), jac.upper(),
+    return solve_thomas_projected(matrix.lower(), matrix.diag(), matrix.upper(),
                                   rhs, psi, solution, workspace, config);
 }
 

--- a/src/math/tridiagonal_matrix_view.hpp
+++ b/src/math/tridiagonal_matrix_view.hpp
@@ -5,20 +5,25 @@
 
 namespace mango {
 
-/// View into tridiagonal Jacobian storage
+/// View into tridiagonal matrix storage
 ///
 /// Provides safe access to lower, diagonal, and upper bands of a
 /// tridiagonal matrix stored in three separate arrays.
 ///
 /// Memory layout:
-/// - lower[i] represents J[i+1,i] (i = 0..n-2)
-/// - diag[i] represents J[i,i] (i = 0..n-1)
-/// - upper[i] represents J[i,i+1] (i = 0..n-1)
-class JacobianView {
+/// - lower[i] represents A[i+1,i] (i = 0..n-2)
+/// - diag[i] represents A[i,i] (i = 0..n-1)
+/// - upper[i] represents A[i,i+1] (i = 0..n-1)
+///
+/// Commonly used for:
+/// - Jacobian matrices in PDE solvers
+/// - Coefficient matrices in Thomas algorithm
+/// - Finite difference discretizations
+class TridiagonalMatrixView {
 public:
-    JacobianView(std::span<double> lower,
-                 std::span<double> diag,
-                 std::span<double> upper)
+    TridiagonalMatrixView(std::span<double> lower,
+                          std::span<double> diag,
+                          std::span<double> upper)
         : lower_(lower)
         , diag_(diag)
         , upper_(upper)
@@ -30,19 +35,19 @@ public:
         // Note: upper[n-1] is unused but present for alignment
     }
 
-    /// Access lower diagonal: J[i+1,i]
+    /// Access lower diagonal: A[i+1,i]
     std::span<double> lower() { return lower_; }
     std::span<const double> lower() const { return lower_; }
 
-    /// Access main diagonal: J[i,i]
+    /// Access main diagonal: A[i,i]
     std::span<double> diag() { return diag_; }
     std::span<const double> diag() const { return diag_; }
 
-    /// Access upper diagonal: J[i,i+1]
+    /// Access upper diagonal: A[i,i+1]
     std::span<double> upper() { return upper_; }
     std::span<const double> upper() const { return upper_; }
 
-    /// Grid size
+    /// Matrix size (number of rows/columns)
     size_t size() const { return diag_.size(); }
 
 private:

--- a/src/pde/core/BUILD.bazel
+++ b/src/pde/core/BUILD.bazel
@@ -43,7 +43,7 @@ cc_library(
 cc_library(
     name = "pde_workspace",
     hdrs = ["pde_workspace.hpp"],
-    deps = ["//src/math:jacobian_view"],
+    deps = ["//src/math:tridiagonal_matrix_view"],
     copts = ["-std=c++23", "-Wall", "-Wextra"],
     visibility = ["//visibility:public"],
 )
@@ -61,7 +61,7 @@ cc_library(
         ":trbdf2_config",
         "//src/math:thomas_solver",
         "//src/math:root_finding",
-        "//src/math:jacobian_view",
+        "//src/math:tridiagonal_matrix_view",
         "//src/support:error_types",
     ],
     copts = ["-std=c++23", "-Wall", "-Wextra"],

--- a/src/pde/core/pde_solver.hpp
+++ b/src/pde/core/pde_solver.hpp
@@ -9,7 +9,7 @@
 #include "src/pde/core/time_domain.hpp"
 #include "src/pde/core/trbdf2_config.hpp"
 #include "src/math/thomas_solver.hpp"
-#include "src/math/jacobian_view.hpp"
+#include "src/math/tridiagonal_matrix_view.hpp"
 #include <expected>
 #include "src/support/error_types.hpp"
 #include <memory>
@@ -26,7 +26,7 @@ namespace mango {
 
 /// Concept to detect spatial operators with analytical Jacobian capability
 template<typename SpatialOp>
-concept HasAnalyticalJacobian = requires(const SpatialOp op, double coeff_dt, JacobianView jac) {
+concept HasAnalyticalJacobian = requires(const SpatialOp op, double coeff_dt, TridiagonalMatrixView jac) {
     { op.assemble_jacobian(coeff_dt, jac) } -> std::same_as<void>;
 };
 
@@ -850,7 +850,7 @@ private:
     /// Used when spatial operator doesn't provide analytical Jacobian.
     void build_jacobian_finite_difference(double t, double coeff_dt,
                                           std::span<const double> u, double eps,
-                                          JacobianView jac) {
+                                          TridiagonalMatrixView jac) {
         // Initialize u_perturb and compute baseline L(u)
         std::copy(u.begin(), u.end(), workspace_.u_stage().begin());
         apply_operator_with_blocking(t, u, workspace_.lu());
@@ -884,7 +884,7 @@ private:
 
     void build_jacobian_boundaries(double t, double coeff_dt,
                                    std::span<const double> u, double eps,
-                                   JacobianView jac) {
+                                   TridiagonalMatrixView jac) {
         // Get BCs from derived class via CRTP (use const auto& to avoid copies!)
         const auto& left_bc = derived().left_boundary();
         const auto& right_bc = derived().right_boundary();

--- a/src/pde/core/pde_workspace.hpp
+++ b/src/pde/core/pde_workspace.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <format>
 #include <algorithm>
-#include "src/math/jacobian_view.hpp"
+#include "src/math/tridiagonal_matrix_view.hpp"
 
 namespace mango {
 
@@ -202,12 +202,12 @@ struct PDEWorkspace {
     std::span<double> tridiag_workspace() { return tridiag_workspace_.subspan(0, 2 * n_); }
     std::span<const double> tridiag_workspace() const { return tridiag_workspace_.subspan(0, 2 * n_); }
 
-    /// Get JacobianView providing unified access to tridiagonal Jacobian
+    /// Get TridiagonalMatrixView providing unified access to tridiagonal Jacobian
     ///
     /// This is the preferred way to access the Jacobian matrix. It provides
     /// type safety and clearer intent than accessing the three arrays separately.
-    JacobianView jacobian() {
-        return JacobianView(jacobian_lower(), jacobian_diag(), jacobian_upper());
+    TridiagonalMatrixView jacobian() {
+        return TridiagonalMatrixView(jacobian_lower(), jacobian_diag(), jacobian_upper());
     }
 
     size_t size() const { return n_; }

--- a/src/pde/operators/BUILD.bazel
+++ b/src/pde/operators/BUILD.bazel
@@ -18,7 +18,7 @@ cc_library(
     deps = [
         ":centered_difference_facade",
         "//src/pde/core:grid",
-        "//src/math:jacobian_view",
+        "//src/math:tridiagonal_matrix_view",
     ],
     copts = ["-std=c++23"],
     visibility = ["//visibility:public"],

--- a/src/pde/operators/spatial_operator.hpp
+++ b/src/pde/operators/spatial_operator.hpp
@@ -2,7 +2,7 @@
 
 #include "src/pde/core/grid.hpp"
 #include "centered_difference_facade.hpp"
-#include "src/math/jacobian_view.hpp"
+#include "src/math/tridiagonal_matrix_view.hpp"
 #include <span>
 #include <memory>
 #include <concepts>
@@ -124,9 +124,9 @@ public:
     /// Available only for PDEs satisfying HasJacobianCoefficients concept.
     ///
     /// @param coeff_dt TR-BDF2 weight coefficient
-    /// @param jac Jacobian view to populate
+    /// @param jac Tridiagonal matrix view to populate
     void assemble_jacobian([[maybe_unused]] double coeff_dt,
-                          JacobianView& jac) const
+                          TridiagonalMatrixView& jac) const
         requires HasJacobianCoefficients<PDE>
     {
         // Get PDE coefficients


### PR DESCRIPTION
## Summary
Refactored the PDE solver to use a unified `TridiagonalMatrixView` type throughout instead of passing three separate spans (lower, diag, upper). The class was moved to `src/math/` and renamed from `JacobianView` to reflect its general-purpose nature.

## Changes

### 1. Introduced TridiagonalMatrixView usage throughout
- **PDEWorkspace**: Added `jacobian()` method returning `TridiagonalMatrixView`
- **Thomas solver**: Added convenience overloads accepting `TridiagonalMatrixView`
  - `solve_thomas(const TridiagonalMatrixView& matrix, ...)`
  - `solve_thomas_projected(const TridiagonalMatrixView& matrix, ...)`
- **PDE solver**: Updated all Jacobian operations to use `TridiagonalMatrixView`
  - `solve_implicit_stage()` and `solve_implicit_stage_projected()`
  - `build_jacobian()`, `build_jacobian_finite_difference()`, `build_jacobian_boundaries()`
  - Deep ITM locking code

### 2. Moved from pde/core to math folder
- Moved `src/pde/core/jacobian_view.hpp` → `src/math/jacobian_view.hpp`
- Eliminates dependency cycle (math depending on pde/core)
- Better organization: general mathematical concept in math/

### 3. Renamed to TridiagonalMatrixView
- Renamed class: `JacobianView` → `TridiagonalMatrixView`
- Renamed file: `jacobian_view.hpp` → `tridiagonal_matrix_view.hpp`
- More general name reflects broader applicability
- Updated all includes, usages, and BUILD.bazel dependencies

## Benefits
- **Type Safety**: Can't accidentally swap parameters (lower/diag/upper)
- **Clearer Intent**: `TridiagonalMatrixView` vs 3 loose spans makes purpose explicit
- **Simpler API**: 1 parameter instead of 3 in function signatures
- **No Overhead**: Zero-cost abstraction with inline accessors
- **General Purpose**: Name reflects usage beyond just Jacobians
  - Jacobian matrices in PDE solvers
  - Coefficient matrices in Thomas algorithm
  - Any tridiagonal matrix representation

## Testing
All 37 tests pass:
```
bazel test //tests/... --test_tag_filters=-manual
Executed 3 out of 37 tests: 37 tests pass.
```

## Implementation Details
This refactoring eliminates the temporary view creation that was happening only for analytical Jacobians. Now all code paths use the same unified interface, and the class name properly reflects its general-purpose nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)