### PR TITLE
Optimize mdspan usage and expose parallelization knobs

### DIFF
--- a/src/option/iv_solver_fdm.hpp
+++ b/src/option/iv_solver_fdm.hpp
@@ -45,6 +45,20 @@ struct IVSolverFDMConfig {
     /// Root-finding configuration (Brent's method parameters)
     RootFindingConfig root_config;
 
+    /// Parallelization threshold for batch solving
+    ///
+    /// Batches smaller than this threshold use serial execution to avoid
+    /// parallel overhead. IV solves are expensive (multiple PDE solves),
+    /// so even small batches benefit from parallelization once overhead
+    /// is amortized.
+    ///
+    /// **Tuning guidance:**
+    /// - Default (4): Good balance for most workloads
+    /// - Larger (8-16): For systems with high parallel overhead
+    /// - Smaller (1-2): For systems with low parallel overhead or large batches
+    /// - Set to SIZE_MAX to force serial execution for all batch sizes
+    size_t batch_parallel_threshold = 4;
+
     /// Use manual grid specification instead of auto-estimation
     ///
     /// When false (default): Automatically estimate optimal grid based on option parameters


### PR DESCRIPTION
## Summary
Follow-up optimizations from PR #235: refactor to use C++20 ranges for cleaner code and expose parallelization threshold as a config parameter for workload tuning.

## Changes

### 1. C++20 Ranges Pipeline (price_table_extraction.cpp)
**Before (manual loop):**
```cpp
std::vector<size_t> step_indices(Nt);
for (size_t j = 0; j < Nt; ++j) {
    double step_exact = grid.maturity[j] / dt - 1.0;
    long long step_rounded = std::llround(step_exact);
    if (step_rounded < 0) {
        step_indices[j] = 0;
    } else if (step_rounded >= static_cast<long long>(n_time)) {
        step_indices[j] = n_time - 1;
    } else {
        step_indices[j] = static_cast<size_t>(step_rounded);
    }
}
```

**After (ranges pipeline):**
```cpp
auto compute_step_index = [dt, n_time](double maturity) -> size_t {
    double step_exact = maturity / dt - 1.0;
    long long step_rounded = std::llround(step_exact);
    if (step_rounded < 0) return 0;
    if (step_rounded >= static_cast<long long>(n_time)) return n_time - 1;
    return static_cast<size_t>(step_rounded);
};

auto step_indices_view = grid.maturity | std::views::transform(compute_step_index);
std::vector<size_t> step_indices(step_indices_view.begin(), step_indices_view.end());
```

**Benefits:**
- More concise and functional style
- Less room for off-by-one indexing errors
- Clearer separation of transformation logic from loop mechanics

### 2. Configurable Parallelization Threshold (IV Solver)
**Added to IVSolverFDMConfig:**
```cpp
/// Parallelization threshold for batch solving
size_t batch_parallel_threshold = 4;  // Default
```

**Usage in solve_batch_impl:**
```cpp
if (queries.size() < config_.batch_parallel_threshold) {
    // Serial path for batches below threshold
    ...
} else {
    // Parallel path
    MANGO_PRAGMA_PARALLEL_FOR
    ...
}
```

**Tuning Guidance:**
- **Default (4)**: Good balance for most workloads
- **Larger (8-16)**: Systems with high parallel overhead
- **Smaller (1-2)**: Systems with low overhead or large batches
- **SIZE_MAX**: Force serial execution for debugging/profiling

## Technical Details

### Zero-Cost Abstractions
- **Ranges pipeline**: Lazy evaluation, same codegen as manual loop
- **Config parameter**: Zero runtime overhead (threshold checked once per batch)

### Performance Impact
- No regression on existing workloads (default threshold = 4 matches previous hardcoded value)
- Enables optimal tuning for different deployment environments
- Small batches avoid parallel tax, large batches maximize parallelism

## Testing
All affected tests pass:
```
bazel test //tests:price_table_workspace_test  # PASSED
bazel test //tests:iv_solver_test               # PASSED
```

Build verification:
```
bazel build //src/option:price_table_extraction
bazel build //src/option:iv_solver_fdm
```

## Related Work
- PR #235: Initial mdspan refactoring and OpenMP parallelization
- This PR addresses follow-up optimization suggestions from code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)