### PR TITLE
Update performance numbers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Designed for research, prototyping, and production use with a focus on **correct
 
 ### Key Features
 
-- **Fast American Pricing** – 5-20ms per option via PDE solver
-- **Implied Volatility** – FDM-based (143ms) or interpolation-based (12ms)
-- **Price Tables** – Pre-compute 4D B-spline surfaces for sub-microsecond queries
+- **Fast American Pricing** – ~1.3ms per option via PDE solver
+- **Implied Volatility** – FDM-based (~15ms) or interpolation-based (~2.1µs)
+- **Price Tables** – Pre-compute 4D B-spline surfaces for sub-microsecond queries (~193ns)
 - **Modern C++23** – std::expected error handling, PMR memory management, SIMD vectorization
 - **General PDE Toolkit** – Custom PDEs, boundary conditions, spatial operators
-- **Production Ready** – OpenMP batching, USDT tracing, zero-allocation solves
+- **Production Ready** – OpenMP batching (10× speedup), USDT tracing, zero-allocation solves
 
 ---
 
@@ -141,27 +141,32 @@ if (result.has_value()) {
 
 ### American Option Pricing
 
-| Configuration | Time/Option | Use Case |
-|---|---|---|
-| Fast (tol=1e-2) | ~5ms | Quick estimates |
-| Standard (tol=1e-3) | ~20ms | Production |
-| High Accuracy (tol=1e-6) | ~80ms | Validation |
+| Configuration | Grid | Time/Option | Use Case |
+|---|---|---|---|
+| Standard (auto) | 101×498 | ~1.3ms | Typical case |
+| Custom fine | 201×2k | ~8-10ms | High accuracy |
 
-**Batch processing:** ~0.3ms/option on 32 cores (15× speedup)
+**Batch processing (64 options):**
+- Sequential: ~81ms total (~1.26ms/option)
+- Parallel: ~7.7ms total (~0.12ms/option)
+- **10.4× speedup** with parallelization
 
 ### Implied Volatility
 
 | Method | Time/IV | Accuracy |
 |---|---|---|
-| FDM-based | ~143ms | Ground truth |
-| Interpolated | ~12ms | <1bp error (95%) |
+| FDM-based (101×1k) | ~15ms | Ground truth |
+| FDM-based (201×2k) | ~61ms | High accuracy |
+| Interpolated (B-spline) | ~2.1µs | <1bp error (95%) |
+
+**Speedup:** 7,000× for interpolated vs FDM
 
 ### Price Table Pre-Computation
 
 - **Grid size:** 300K points (50×30×20×10)
 - **Pre-compute:** 15-20 min (32 cores)
-- **Query:** ~500ns (price or Greeks)
-- **Speedup:** 43,400× vs FDM
+- **Query:** ~193ns (price), ~952ns (vega+gamma)
+- **Speedup:** 77,000× vs FDM
 
 ---
 


### PR DESCRIPTION
## Summary

Updates all performance numbers in README.md to reflect latest benchmark results from `readme_benchmarks` (built with `-c opt`).

## Changes

### Key Features Section
- American pricing: **5-20ms → ~1.3ms** (4-15× improvement)
- FDM-based IV: **143ms → ~15ms** (9.5× improvement)
- Interpolated IV: **12ms → ~2.1µs** (5,700× improvement)
- Price table queries: **500ns → ~193ns** (2.6× improvement)
- Batch speedup: **15× → 10.4×** (actual measured value)

### Performance Section
- Added grid size context (101×498 auto, 201×2k fine)
- Batch processing details: Sequential ~81ms, Parallel ~7.7ms, 10.4× speedup
- FDM IV: Added 201×2k option (~61ms) for high accuracy use cases
- Interpolated IV: **7,000× speedup** vs FDM
- Greeks computation: ~952ns for vega+gamma
- Price table speedup: **43,400× → 77,000×** (updated calculation)

## Benchmark Data

All numbers from:
```bash
bazel build //benchmarks:readme_benchmarks -c opt
./bazel-bin/benchmarks/readme_benchmarks
```

Key results:
- Single American option (101×498): **1.28ms**
- Batch 64 sequential: **80.76ms** (~1.26ms/option)
- Batch 64 parallel: **7.75ms** (~0.12ms/option)
- FDM IV (101×1k): **15.33ms**
- FDM IV (201×2k): **60.92ms**
- B-spline IV: **2.14µs**
- Price interpolation: **193ns**
- Greeks (vega+gamma): **952ns**

## Consistency

Performance numbers now match:
- ✅ `docs/ARCHITECTURE.md` (updated in PR #240)
- ✅ Latest benchmark results
- ✅ Recent optimizations: Projected Thomas, OpenMP SIMD, banded B-spline solver

🤖 Generated with [Claude Code](https://claude.com/claude-code)