### PR TITLE
Reduce allocations in math utilities

### DIFF
--- a/src/math/cubic_spline_solver.hpp
+++ b/src/math/cubic_spline_solver.hpp
@@ -148,8 +148,8 @@ public:
             return "Y size must match existing grid";
         }
 
-        // Update y-values
-        y_.assign(y.begin(), y.end());
+        // Update y-values in-place (size already verified)
+        std::copy(y.begin(), y.end(), y_.begin());
 
         // Rebuild spline using cached interval widths
         if (config_.boundary_type == SplineBoundary::NATURAL) {


### PR DESCRIPTION
## Summary
- `banded_norm1()`: Add workspace overload and use thread-local buffer to avoid allocating on every call
- `rebuild_same_grid()`: Use `std::copy` instead of `assign()` since size is already verified

## Changes
- `src/math/banded_matrix_solver.hpp`: Added `banded_norm1(A, workspace)` overload; original now uses thread-local cache
- `src/math/cubic_spline_solver.hpp`: Replaced `y_.assign()` with `std::copy()` in `rebuild_same_grid()`

## Test plan
- [x] All 65 tests pass
- [x] All examples and benchmarks build

🤖 Generated with [Claude Code](https://claude.com/claude-code)