### PR TITLE
Kokkos migration: Complete GPU-portable implementation

### DIFF
--- a/kokkos/benchmarks/BUILD.bazel
+++ b/kokkos/benchmarks/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "comparison_benchmark",
+    srcs = ["comparison_benchmark.cc"],
+    copts = ["-fopenmp", "-O3"],
+    linkopts = ["-fopenmp"],
+    deps = [
+        "//kokkos/src:american_option",
+        "//kokkos/src:batch_solver",
+        "@kokkos//:kokkos",
+    ],
+)

--- a/kokkos/benchmarks/comparison_benchmark.cc
+++ b/kokkos/benchmarks/comparison_benchmark.cc
@@ -1,0 +1,155 @@
+// Kokkos American option benchmark for comparison with original implementation
+#include <iostream>
+#include <chrono>
+#include <vector>
+#include <iomanip>
+#include "kokkos/src/option/american_option.hpp"
+#include "kokkos/src/option/batch_solver.hpp"
+
+using namespace mango::kokkos;
+
+int main() {
+    Kokkos::initialize();
+    {
+        std::cout << "=== Kokkos American Option Benchmark ===\n";
+        std::cout << "Execution space: " << Kokkos::DefaultExecutionSpace::name() << "\n\n";
+
+        // Match original benchmark parameters
+        PricingParams params{
+            .strike = 100.0,
+            .spot = 100.0,
+            .maturity = 1.0,
+            .volatility = 0.20,
+            .rate = 0.05,
+            .dividend_yield = 0.02,
+            .type = OptionType::Put
+        };
+
+        // Warm up
+        {
+            AmericanOptionSolver<Kokkos::HostSpace> solver(params);
+            (void)solver.solve();
+        }
+
+        // Show grid estimation
+        auto [grid_params, time_params] = estimate_grid_for_option(params);
+        std::cout << "Grid estimation:\n";
+        std::cout << "  Spatial points: " << grid_params.n_points << "\n";
+        std::cout << "  Time steps: " << time_params.n_steps << "\n";
+        std::cout << "  Domain: [" << grid_params.x_min << ", " << grid_params.x_max << "]\n\n";
+
+        // Single option benchmark
+        std::cout << "--- Single Option ---\n";
+        {
+            const int N_ITER = 100;
+            auto start = std::chrono::high_resolution_clock::now();
+
+            double price = 0, delta = 0;
+            for (int i = 0; i < N_ITER; ++i) {
+                AmericanOptionSolver<Kokkos::HostSpace> solver(params);
+                auto result = solver.solve();
+                if (result.has_value()) {
+                    price = result->price;
+                    delta = result->delta;
+                }
+            }
+
+            auto end = std::chrono::high_resolution_clock::now();
+            double total_ms = std::chrono::duration<double, std::milli>(end - start).count();
+            double per_option_ms = total_ms / N_ITER;
+
+            std::cout << "  Price: " << std::fixed << std::setprecision(4) << price << "\n";
+            std::cout << "  Delta: " << delta << "\n";
+            std::cout << "  Time:  " << per_option_ms << " ms per option\n";
+            std::cout << "  Throughput: " << (1000.0 / per_option_ms) << " options/sec\n";
+        }
+
+        // Batch benchmark (64 options sequential)
+        std::cout << "\n--- Sequential 64 Options ---\n";
+        {
+            std::vector<PricingParams> batch;
+            for (int i = 0; i < 64; ++i) {
+                double m = 0.8 + 0.4 * (i % 8) / 7.0;
+                batch.push_back(PricingParams{
+                    .strike = 100.0,
+                    .spot = m * 100.0,
+                    .maturity = 0.5 + 0.5 * ((i / 8) % 4) / 3.0,
+                    .volatility = 0.15 + 0.10 * ((i / 32) % 2),
+                    .rate = 0.05,
+                    .dividend_yield = 0.02,
+                    .type = OptionType::Put
+                });
+            }
+
+            const int N_ITER = 10;
+            auto start = std::chrono::high_resolution_clock::now();
+
+            for (int iter = 0; iter < N_ITER; ++iter) {
+                for (const auto& p : batch) {
+                    AmericanOptionSolver<Kokkos::HostSpace> solver(p);
+                    (void)solver.solve();
+                }
+            }
+
+            auto end = std::chrono::high_resolution_clock::now();
+            double total_ms = std::chrono::duration<double, std::milli>(end - start).count();
+            double per_batch_ms = total_ms / N_ITER;
+
+            std::cout << "  Time:  " << per_batch_ms << " ms per 64 options\n";
+            std::cout << "  Throughput: " << (64000.0 / per_batch_ms) << " options/sec\n";
+        }
+
+        // Batch benchmark using BatchAmericanSolver
+        std::cout << "\n--- Kokkos Batch Solver (64 Options, shared params) ---\n";
+        {
+            BatchPricingParams batch_params{
+                .maturity = 1.0,
+                .volatility = 0.20,
+                .rate = 0.05,
+                .dividend_yield = 0.02,
+                .is_put = true
+            };
+
+            Kokkos::View<double*, Kokkos::HostSpace> strikes("strikes", 64);
+            Kokkos::View<double*, Kokkos::HostSpace> spots("spots", 64);
+
+            for (int i = 0; i < 64; ++i) {
+                double m = 0.8 + 0.4 * i / 63.0;
+                strikes(i) = 100.0;
+                spots(i) = m * 100.0;
+            }
+
+            const int N_ITER = 20;
+            auto start = std::chrono::high_resolution_clock::now();
+
+            for (int iter = 0; iter < N_ITER; ++iter) {
+                BatchAmericanSolver<Kokkos::HostSpace> solver(batch_params, strikes, spots);
+                (void)solver.solve();
+            }
+
+            auto end = std::chrono::high_resolution_clock::now();
+            double total_ms = std::chrono::duration<double, std::milli>(end - start).count();
+            double per_batch_ms = total_ms / N_ITER;
+
+            std::cout << "  Time:  " << per_batch_ms << " ms per 64 options\n";
+            std::cout << "  Throughput: " << (64000.0 / per_batch_ms) << " options/sec\n";
+        }
+
+        std::cout << "\n=== Feature Parity Summary ===\n";
+        std::cout << "Grid estimation now matches original:\n";
+        std::cout << "  Original: 101 spatial points, 498 time steps, sinh grid (alpha=2.0)\n";
+        std::cout << "  Kokkos:   " << grid_params.n_points << " spatial points, "
+                  << time_params.n_steps << " time steps, sinh grid (alpha=" << grid_params.alpha << ")\n";
+        std::cout << "\n=== Performance Comparison ===\n";
+        std::cout << "Original (OpenMP+PMR, AVX2, TR-BDF2 Newton):\n";
+        std::cout << "  Single: ~1.27 ms, Batch 64: ~4.77 ms (13.4k/s)\n";
+        std::cout << "Kokkos (feature parity, no SIMD optimization yet):\n";
+        std::cout << "  Performance gap is expected - original uses:\n";
+        std::cout << "  - Analytical Jacobian with Newton iteration\n";
+        std::cout << "  - PMR memory pooling (no allocations per solve)\n";
+        std::cout << "  - AVX2/AVX-512 vectorization\n";
+        std::cout << "  - OpenMP SIMD for linear algebra\n";
+    }
+    Kokkos::finalize();
+    return 0;
+}

--- a/kokkos/src/pde/operators/black_scholes.hpp
+++ b/kokkos/src/pde/operators/black_scholes.hpp
@@ -29,17 +29,15 @@ public:
           half_sigma_sq_(0.5 * sigma * sigma),
           drift_(r - q - 0.5 * sigma * sigma) {}
 
-    /// Apply operator: Lu = L(u)
+    /// Apply operator: Lu = L(u) with non-uniform grid spacing
     ///
-    /// Uses second-order centered differences.
+    /// Uses second-order centered differences with local grid spacing.
     /// Boundary values are set to 0 (BCs handle them separately).
-    void apply(view_type x, view_type u, view_type Lu, double dx) const {
+    void apply(view_type x, view_type u, view_type Lu, double /*dx_avg*/) const {
         const size_t n = u.extent(0);
         const double half_sigma_sq = half_sigma_sq_;
         const double drift = drift_;
         const double r = r_;
-        const double dx_sq = dx * dx;
-        const double two_dx = 2.0 * dx;
 
         Kokkos::parallel_for("black_scholes_apply", n,
             KOKKOS_LAMBDA(const size_t i) {
@@ -47,11 +45,17 @@ public:
                     // Boundary values: set to 0 (BCs handle separately)
                     Lu(i) = 0.0;
                 } else {
-                    // Second derivative: (u[i+1] - 2*u[i] + u[i-1]) / dx^2
-                    double u_xx = (u(i + 1) - 2.0 * u(i) + u(i - 1)) / dx_sq;
+                    // Local grid spacings for non-uniform grid
+                    double dx_minus = x(i) - x(i - 1);
+                    double dx_plus = x(i + 1) - x(i);
 
-                    // First derivative: (u[i+1] - u[i-1]) / (2*dx)
-                    double u_x = (u(i + 1) - u(i - 1)) / two_dx;
+                    // Second derivative: non-uniform centered difference
+                    // u_xx ≈ 2 * [(u[i+1] - u[i])/dx_plus - (u[i] - u[i-1])/dx_minus] / (dx_plus + dx_minus)
+                    double u_xx = 2.0 * ((u(i + 1) - u(i)) / dx_plus - (u(i) - u(i - 1)) / dx_minus) / (dx_minus + dx_plus);
+
+                    // First derivative: non-uniform centered difference
+                    // u_x ≈ (u[i+1] - u[i-1]) / (dx_plus + dx_minus)
+                    double u_x = (u(i + 1) - u(i - 1)) / (dx_minus + dx_plus);
 
                     // L(u) = 0.5*sigma^2*u_xx + drift*u_x - r*u
                     Lu(i) = half_sigma_sq * u_xx + drift * u_x - r * u(i);
@@ -61,10 +65,70 @@ public:
         Kokkos::fence();
     }
 
-    /// Assemble Jacobian for implicit time stepping
+    /// Assemble Jacobian for implicit time stepping with non-uniform grid
     ///
     /// For u_t = L(u), implicit: (I - dt*L)u^{n+1} = u^n
     /// Jacobian J = I - dt*L in tridiagonal form.
+    ///
+    /// @param dt Time step coefficient
+    /// @param x Grid coordinates (for non-uniform spacing)
+    /// @param lower Sub-diagonal (size n-1)
+    /// @param diag Main diagonal (size n)
+    /// @param upper Super-diagonal (size n-1)
+    void assemble_jacobian(double dt, view_type x,
+                           view_type lower, view_type diag, view_type upper) const {
+        const size_t n = diag.extent(0);
+        const double half_sigma_sq = half_sigma_sq_;
+        const double drift = drift_;
+        const double r = r_;
+
+        Kokkos::parallel_for("assemble_jacobian", n,
+            KOKKOS_LAMBDA(const size_t i) {
+                if (i == 0 || i == n - 1) {
+                    // Boundary rows: identity (BCs set separately)
+                    diag(i) = 1.0;
+                    if (i > 0) {
+                        lower(i - 1) = 0.0;
+                    }
+                    if (i < n - 1) {
+                        upper(i) = 0.0;
+                    }
+                } else {
+                    // Local grid spacings for non-uniform grid
+                    double dx_minus = x(i) - x(i - 1);
+                    double dx_plus = x(i + 1) - x(i);
+                    double dx_sum = dx_minus + dx_plus;
+
+                    // Non-uniform FD coefficients for L
+                    // Second derivative: coeff_i-1 = 2/(dx_minus * dx_sum)
+                    //                    coeff_i = -2/(dx_minus * dx_plus)
+                    //                    coeff_i+1 = 2/(dx_plus * dx_sum)
+                    // First derivative:  coeff_i-1 = -1/dx_sum
+                    //                    coeff_i+1 = 1/dx_sum
+
+                    double c_xx_lower = 2.0 / (dx_minus * dx_sum);
+                    double c_xx_diag = -2.0 / (dx_minus * dx_plus);
+                    double c_xx_upper = 2.0 / (dx_plus * dx_sum);
+
+                    double c_x_lower = -1.0 / dx_sum;
+                    double c_x_upper = 1.0 / dx_sum;
+
+                    // L coefficients: L(u) = half_sigma_sq * u_xx + drift * u_x - r * u
+                    double L_lower = half_sigma_sq * c_xx_lower + drift * c_x_lower;
+                    double L_diag = half_sigma_sq * c_xx_diag - r;
+                    double L_upper = half_sigma_sq * c_xx_upper + drift * c_x_upper;
+
+                    // Jacobian J = I - dt * L
+                    diag(i) = 1.0 - dt * L_diag;
+                    lower(i - 1) = -dt * L_lower;
+                    upper(i) = -dt * L_upper;
+                }
+            });
+
+        Kokkos::fence();
+    }
+
+    /// Legacy interface for uniform grids (backward compatibility)
     void assemble_jacobian(double dt, double dx,
                            view_type lower, view_type diag, view_type upper) const {
         const size_t n = diag.extent(0);
@@ -74,16 +138,11 @@ public:
         const double dx_sq = dx * dx;
         const double two_dx = 2.0 * dx;
 
-        // Coefficients for L in tridiagonal form
-        // L_lower = 0.5*sigma^2/dx^2 - drift/(2*dx)
-        // L_diag = -sigma^2/dx^2 - r
-        // L_upper = 0.5*sigma^2/dx^2 + drift/(2*dx)
-
         const double L_lower = half_sigma_sq / dx_sq - drift / two_dx;
         const double L_diag = -2.0 * half_sigma_sq / dx_sq - r;
         const double L_upper = half_sigma_sq / dx_sq + drift / two_dx;
 
-        Kokkos::parallel_for("assemble_jacobian", n,
+        Kokkos::parallel_for("assemble_jacobian_uniform", n,
             KOKKOS_LAMBDA(const size_t i) {
                 diag(i) = 1.0 - dt * L_diag;
                 if (i > 0) {


### PR DESCRIPTION
## Summary

Complete Kokkos migration of the mango-iv library for GPU-portable option pricing and implied volatility calculation.

## Components Implemented

### Core Infrastructure
- **Grid** - Uniform grid generation with Kokkos Views
- **Workspace** - Memory management for PDE solver
- **Thomas Solver** - Tridiagonal system solver
- **Black-Scholes Operator** - PDE discretization
- **PDE Solver** - Crank-Nicolson time stepping

### Option Pricing
- **AmericanOptionSolver** - Single option pricing via PDE
- **BatchAmericanSolver** - Parallel pricing of multiple options
- **PriceTableBuilder4D** - 4D price table precomputation

### Interpolation
- **BSplineBasis** - Cox-de Boor B-spline evaluation
- **BSplineND** - N-dimensional tensor-product interpolation

### Root Finding
- **Brent's Method** - Bracketed root finding (host + device)
- **Newton-Raphson** - Derivative-based root finding (host + device)

### IV Solvers
- **IVSolverInterpolated** - Fast IV via price table (~microseconds)
- **IVSolverFDM** - Accurate IV via PDE solving (~milliseconds)

### High-Level API
- **PricingPipeline** - Unified orchestration of all components

## File Structure

```
kokkos/
├── src/
│   ├── math/
│   │   ├── bspline_basis.hpp
│   │   ├── bspline_nd.hpp
│   │   ├── root_finding.hpp
│   │   └── thomas_solver.hpp
│   ├── option/
│   │   ├── american_option.hpp
│   │   ├── batch_solver.hpp
│   │   ├── iv_common.hpp
│   │   ├── iv_solver_fdm.hpp
│   │   ├── iv_solver_interpolated.hpp
│   │   ├── price_table.hpp
│   │   └── pricing_pipeline.hpp
│   ├── pde/
│   │   ├── core/
│   │   │   ├── grid.hpp
│   │   │   ├── pde_solver.hpp
│   │   │   └── workspace.hpp
│   │   └── operators/
│   │       └── black_scholes.hpp
│   └── support/
│       └── execution_space.hpp
└── tests/
    └── 14 test files (all passing)
```

## Testing

All 14 test suites pass:
- `grid_test` - Grid generation
- `workspace_test` - Memory management
- `thomas_solver_test` - Tridiagonal solver
- `black_scholes_test` - PDE operator
- `pde_solver_test` - Time stepping
- `american_option_test` - Option pricing
- `bspline_basis_test` - B-spline basis
- `bspline_nd_test` - N-D interpolation
- `batch_solver_test` - Batch pricing
- `price_table_test` - Price table building
- `root_finding_test` - Brent & Newton
- `iv_solver_interpolated_test` - Fast IV
- `iv_solver_fdm_test` - FDM IV
- `pricing_pipeline_test` - End-to-end

```bash
bazel test //kokkos/tests/...  # All 14 tests pass
```

## Usage Example

```cpp
#include "kokkos/src/option/pricing_pipeline.hpp"

// Configure pipeline
mango::kokkos::PricingPipelineConfig config{
    .moneyness_min = 0.8, .moneyness_max = 1.2, .n_moneyness = 10,
    .maturity_min = 0.25, .maturity_max = 1.0, .n_maturity = 5,
    .vol_min = 0.10, .vol_max = 0.40, .n_vol = 10,
    .rate_min = 0.02, .rate_max = 0.08, .n_rate = 5,
    .n_space = 101, .n_time = 500,
    .K_ref = 100.0, .is_put = true
};

// Create pipeline
mango::kokkos::PricingPipeline<Kokkos::HostSpace> pipeline(config);

// Build price table (once at startup)
pipeline.build_price_table();

// Fast IV queries (microseconds each)
auto iv_results = pipeline.solve_iv_interpolated(queries);

// Ground truth IV for validation (milliseconds each)
auto iv_fdm_results = pipeline.solve_iv_fdm(queries);
```

## Notes

- All code is header-only for easy integration
- Template on `MemSpace` for CPU/GPU flexibility
- Uses `std::expected<T, E>` for error handling
- Device functions marked with `KOKKOS_INLINE_FUNCTION`
- Parallel kernels use `KOKKOS_LAMBDA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)