### PR TITLE
Rename project from mango-iv to mango-option

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile for mango-iv CI environment
+# Dockerfile for mango-option CI environment
 # This image pre-installs all dependencies to speed up CI runs
 # Uses trixie-slim base for smaller size (~40% reduction)
 FROM debian:trixie-slim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: bazel build //... --build_tag_filters=-benchmark
 
       - name: Build Python bindings
-        run: bazel build //python:mango_iv
+        run: bazel build //python:mango_option
 
       - name: Build benchmarks
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guide for Claude Code when working with this repository.
 
 ## Project Overview
 
-**mango-iv** is a C++23 library for pricing American options using finite difference methods. The core solver uses TR-BDF2 time-stepping with Newton iteration. The library provides high-level APIs for option pricing, implied volatility calculation (FDM and interpolation-based), and price table pre-computation.
+**mango-option** is a C++23 library for pricing American options using finite difference methods. The core solver uses TR-BDF2 time-stepping with Newton iteration. The library provides high-level APIs for option pricing, implied volatility calculation (FDM and interpolation-based), and price table pre-computation.
 
 **Key capabilities:**
 - American option pricing via PDE solver (~5-20ms per option)
@@ -47,7 +47,7 @@ bazel clean
 ## Project Structure
 
 ```
-mango-iv/
+mango-option/
 ├── src/
 │   ├── pde/
 │   │   ├── core/          # Grid, boundary conditions, PDE solver, time domain
@@ -217,7 +217,7 @@ Before creating a pull request, verify **all CI checks pass locally**:
 - [ ] All tests pass: `bazel test //...`
 - [ ] All examples compile: `bazel build //examples/...`
 - [ ] All benchmarks compile: `bazel build //benchmarks/...`
-- [ ] Python bindings compile: `bazel build //python:mango_iv`
+- [ ] Python bindings compile: `bazel build //python:mango_option`
 - [ ] Code builds without warnings
 - [ ] Documentation updated if API changed
 
@@ -236,7 +236,7 @@ git checkout -b feature/descriptive-name
 bazel test //...
 bazel build //examples/...
 bazel build //benchmarks/...
-bazel build //python:mango_iv
+bazel build //python:mango_option
 
 git add <files>
 git commit -m "Imperative mood message"
@@ -321,7 +321,7 @@ sudo ./scripts/mango-trace monitor ./my_program --preset=debug
 | Run all tests | `bazel test //...` |
 | Run single test | `bazel test //tests:pde_solver_test` |
 | Run example | `bazel run //examples:example_newton_solver` |
-| Build Python bindings | `bazel build //python:mango_iv` |
+| Build Python bindings | `bazel build //python:mango_option` |
 | Trace execution | `sudo ./scripts/mango-trace monitor ./program` |
 | Create PR | `gh pr create --title "..." --body "..."` |
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "google_benchmark", version = "1.9.4")
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")
 bazel_dep(name = "rules_python", version = "0.34.0")
+bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 
 # Register C++ toolchain with C++23 support
@@ -17,10 +18,14 @@ python.toolchain(
 )
 use_repo(python, "python_3_11")
 
+# Non-BCR dependencies (mdspan, etc.)
+non_bcr_deps = use_extension("//:deps.bzl", "non_bcr_deps")
+use_repo(non_bcr_deps, "mdspan")
+
 # Apache Arrow C++ (required for price table persistence)
 # NOTE: Using system-installed Arrow packages in CI (libarrow-dev)
 # For local development, run: ./tools/enable_arrow.sh
-# See CONAN_SETUP.md for details
+# See CONAN_SETUP.MD for details
 # conan_extension = use_extension("//conan_deps:conan_deps_module_extension.bzl", "conan_extension")
 # use_repo(
 #     conan_extension,

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -6,33 +6,48 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
     "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
-    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/source.json": "14892cc698e02ffedf4967546e6bedb7245015906888d3465fcf27c90a26da10",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
     "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
     "https://bcr.bazel.build/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
-    "https://bcr.bazel.build/modules/bazel_features/1.19.0/source.json": "d7bf14517c1b25b9d9c580b0f8795fceeae08a7590f507b76aace528e941375d",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/source.json": "3e8379efaaef53ce35b7b8ba419df829315a880cb0a030e5bb45c96d6d5ecb5f",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
     "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
     "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/google_benchmark/1.9.4/MODULE.bazel": "3bab7c17c10580f87b647478a72a05621f88abc275afb97b578c828f56e59d45",
     "https://bcr.bazel.build/modules/google_benchmark/1.9.4/source.json": "8e0036f76a5c2aa9c16ca0da57d8065cff69edeed58f1f85584c588c0ef723a5",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
-    "https://bcr.bazel.build/modules/googletest/1.14.0/source.json": "2478949479000fdd7de9a3d0107ba2c85bb5f961c3ecb1aa448f52549ce310b5",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/MODULE.bazel": "e5362dadc90aab6724c83a2cc1e67cbed9c89a05d97fb1f90053c8deb1e445c8",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/source.json": "0646414d9037f8aad148781dd760bec90b0b25ac12fda5e03f8aadbd6b9c61e6",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
@@ -46,52 +61,123 @@
     "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
     "https://bcr.bazel.build/modules/protobuf/24.4/MODULE.bazel": "7bc7ce5f2abf36b3b7b7c8218d3acdebb9426aeb35c2257c96445756f970eb12",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
-    "https://bcr.bazel.build/modules/protobuf/27.0/source.json": "1acf3d080c728d42f423fde5422fd0a1a24f44c15908124ce12363a253384193",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/source.json": "c16a6488fb279ef578da7098e605082d72ed85fc8d843eaae81e7d27d0f4625d",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.13.6/MODULE.bazel": "2d746fda559464b253b2b2e6073cb51643a2ac79009ca02100ebbc44b4548656",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.13.6/source.json": "6aa0703de8efb20cc897bbdbeb928582ee7beaf278bcd001ac253e1605bddfae",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
     "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel": "30d9135a2b6561c761bd67bd4990da591e6bdc128790ce3e7afd6a3558b2fb64",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
     "https://bcr.bazel.build/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
-    "https://bcr.bazel.build/modules/rules_java/7.6.5/source.json": "a805b889531d1690e3c72a7a7e47a870d00323186a9904b36af83aa3d053ee8d",
+    "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/source.json": "db1a77d81b059e0f84985db67a22f3f579a529a86b7997605be3d214a0abe38e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
-    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/source.json": "5abb45cc9beb27b77aec6a65a11855ef2b55d95dfdc358e9f312b78ae0ba32d5",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
-    "https://bcr.bazel.build/modules/rules_license/0.0.7/source.json": "355cc5737a0f294e560d52b1b7a6492d4fff2caf0bef1a315df5a298fca2d34a",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
-    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/source.json": "c2557066e0c0342223ba592510ad3d812d4963b9024831f7f66fd0584dd8c66c",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.1.0/MODULE.bazel": "9db8031e71b6ef32d1846106e10dd0ee2deac042bd9a2de22b4761b0c3036453",
+    "https://bcr.bazel.build/modules/rules_pkg/1.1.0/source.json": "fef768df13a92ce6067e1cd0cdc47560dace01354f1d921cfb1d632511f7d608",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
-    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/source.json": "8d8448e71706df7450ced227ca6b3812407ff5e2ccad74a43a9fbe79c84e34e0",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.34.0/MODULE.bazel": "1d623d026e075b78c9fde483a889cda7996f5da4f36dffb24c246ab30f06513a",
-    "https://bcr.bazel.build/modules/rules_python/0.34.0/source.json": "113116e287eec64a7d005a9db44865d810499fdc4f621e352aff58214f5ea2d8",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/1.0.0/MODULE.bazel": "898a3d999c22caa585eb062b600f88654bf92efb204fa346fb55f6f8edffca43",
+    "https://bcr.bazel.build/modules/rules_python/1.0.0/source.json": "b0162a65c6312e45e7912e39abd1a7f8856c2c7e41ecc9b6dc688a6f6400a917",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/source.json": "7f27af3c28037d9701487c4744b5448d26537cc66cdef0d8df7ae85411f8de95",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
-    "https://bcr.bazel.build/modules/stardoc/0.5.3/source.json": "cd53fe968dc8cd98197c052db3db6d82562960c87b61e7a90ee96f8e4e0dda97",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d"
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//:deps.bzl%non_bcr_deps": {
+      "general": {
+        "bzlTransitiveDigest": "D2RhUPmekZlREThDxfuEhKBNA7RvfkFdNnJyDxpom3I=",
+        "usagesDigest": "HYSoHElTYTalb9zSrsOsIzv0QY5DQMwecFyN8HlRMWM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "mdspan": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/kokkos/mdspan/archive/refs/tags/mdspan-0.6.0.tar.gz"
+              ],
+              "strip_prefix": "mdspan-mdspan-0.6.0",
+              "sha256": "79f94d7f692cbabfbaff6cd0d3434704435c853ee5087b182965fa929a48a592",
+              "build_file_content": "\ncc_library(\n    name = \"mdspan\",\n    hdrs = glob([\n        \"include/**/*.hpp\",\n        \"include/**/*\",\n    ], exclude = [\"include/**/*.txt\"]),\n    strip_include_prefix = \"include\",\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
@@ -142,6 +228,98 @@
         "recordedRepoMappingEntries": [
           [
             "pybind11_bazel~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_java~//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "KIX40nDfygEWbU+rq3nYpt3tVgTK/iO8PKh5VMBlN7M=",
+        "usagesDigest": "pwHZ+26iLgQdwvdZeA5wnAjKnNI3y6XO2VbhOTeo5h8=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "bzlFile": "@@rules_java~//java:rules_java_deps.bzl",
+            "ruleClassName": "_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin~//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "fus14IFJ/1LGWWGKPH/U18VnJCoMjfDt1ckahqCnM0A=",
+        "usagesDigest": "aJF6fLy82rR95Ff5CZPAqxNoFgOMLMN5ImfBS0nhnkg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:compiler.bzl",
+            "ruleClassName": "kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:compiler.bzl",
+            "ruleClassName": "kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "bzlFile": "@@rules_kotlin~//src/main/starlark/core/repositories:ksp.bzl",
+            "ruleClassName": "ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin~",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for mango-iv PDE Solver
+# Makefile for mango-option PDE Solver
 # Alternative to Bazel for environments without Bazel support
 
 # Compiler settings
@@ -58,7 +58,7 @@ all: lib examples
 
 # Help target
 help:
-	@echo "Makefile for mango-iv PDE Solver"
+	@echo "Makefile for mango-option PDE Solver"
 	@echo ""
 	@echo "Targets:"
 	@echo "  all           - Build library and examples (default)"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mango-iv
+# mango-option
 
 Modern C++23 library for American option pricing and implied volatility calculation.
 
@@ -6,9 +6,9 @@ Modern C++23 library for American option pricing and implied volatility calculat
 
 ---
 
-## What is mango-iv?
+## What is mango-option?
 
-**mango-iv** solves two fundamental problems in quantitative finance:
+**mango-option** solves two fundamental problems in quantitative finance:
 
 1. **American Option Pricing** – Finite difference PDE solver with TR-BDF2 time stepping
 2. **Implied Volatility Calculation** – Extract implied volatility from market prices
@@ -42,8 +42,8 @@ Optional:
 
 ```bash
 # Clone repository
-git clone https://github.com/your-org/mango-iv.git
-cd mango-iv
+git clone https://github.com/your-org/mango-option.git
+cd mango-option
 
 # Build everything
 bazel build //...
@@ -173,7 +173,7 @@ if (result.has_value()) {
 ## Project Structure
 
 ```
-mango-iv/
+mango-option/
 ├── src/
 │   ├── pde/
 │   │   ├── core/          # Grid, PDESolver, boundary conditions

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,23 +1,2 @@
-# Workspace file for external dependencies not in Bazel Central Registry
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-# mdspan reference implementation (header-only)
-# Provides C++23 std::mdspan polyfill for GCC + libstdc++
-http_archive(
-    name = "mdspan",
-    urls = ["https://github.com/kokkos/mdspan/archive/refs/tags/mdspan-0.6.0.tar.gz"],
-    strip_prefix = "mdspan-mdspan-0.6.0",
-    sha256 = "79f94d7f692cbabfbaff6cd0d3434704435c853ee5087b182965fa929a48a592",
-    build_file_content = """
-cc_library(
-    name = "mdspan",
-    hdrs = glob([
-        "include/**/*.hpp",
-        "include/**/*",
-    ], exclude = ["include/**/*.txt"]),
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)
-""",
-)
+# This project uses Bzlmod (MODULE.bazel) for dependency management.
+# See MODULE.bazel and deps.bzl for external dependencies.

--- a/benchmarks/BENCHMARK_RESULTS.md
+++ b/benchmarks/BENCHMARK_RESULTS.md
@@ -64,14 +64,14 @@ Grid: 101x1000 for all parallel benchmarks
 ## 2. Performance vs QuantLib
 
 ### Direct Comparison (101x1000 grid, single-threaded)
-| Scenario | mango-iv | QuantLib | Slowdown |
+| Scenario | mango-option | QuantLib | Slowdown |
 |----------|----------|----------|----------|
 | ATM Put | 13.0ms | 3.0ms | **4.4x** |
 | OTM Put | 13.2ms | 3.0ms | **4.4x** |
 | ITM Put | 13.0ms | 3.0ms | **4.4x** |
 
 ### Grid Resolution Scaling (single-threaded)
-| Grid Size | mango-iv | QuantLib | Slowdown |
+| Grid Size | mango-option | QuantLib | Slowdown |
 |-----------|----------|----------|----------|
 | 101x1000 | 13.8ms | 3.0ms | **4.6x** |
 | 201x2000 | 78.3ms | 11.1ms | **7.1x** |
@@ -80,19 +80,19 @@ Grid: 101x1000 for all parallel benchmarks
 **Critical Finding:** The performance gap **widens dramatically** with larger grids, suggesting algorithmic inefficiency rather than just slower execution.
 
 ### Parallel Batch Performance (32 cores, 101x1000 grid)
-| Workload | mango-iv (parallel) | QuantLib (single) | Comparison |
+| Workload | mango-option (parallel) | QuantLib (single) | Comparison |
 |----------|---------------------|-------------------|------------|
 | 100 options | 118ms (848 opts/sec) | 297ms (337 opts/sec) | **2.5x faster** ✅ |
 | 100 IVs | 931ms (107 IVs/sec) | N/A | - |
 
-**Key Finding:** With OpenMP parallelization, mango-iv can **outperform QuantLib** on batch workloads by leveraging multi-core hardware.
+**Key Finding:** With OpenMP parallelization, mango-option can **outperform QuantLib** on batch workloads by leveraging multi-core hardware.
 
 ---
 
 ## 3. Accuracy vs QuantLib
 
 ### Price Accuracy (201x2000 grid)
-| Scenario | mango-iv | QuantLib | Error | Rel Error |
+| Scenario | mango-option | QuantLib | Error | Rel Error |
 |----------|----------|----------|-------|-----------|
 | ATM Put 1Y | 6.637 | 6.660 | 0.023 | **0.35%** ✅ |
 | OTM Put 3M | 2.289 | 2.292 | 0.004 | **0.17%** ✅ |
@@ -105,7 +105,7 @@ Grid: 101x1000 for all parallel benchmarks
 **All scenarios < 2% error** - excellent agreement with QuantLib reference.
 
 ### Greeks Accuracy (201x2000 grid, ATM Put 1Y)
-| Greek | mango-iv | QuantLib | Rel Error |
+| Greek | mango-option | QuantLib | Rel Error |
 |-------|----------|----------|-----------|
 | Delta | -0.423 | -0.423 | **0.004%** ⭐ |
 | Gamma | 0.02154 | 0.02148 | **0.29%** ✅ |
@@ -129,7 +129,7 @@ Reference (QuantLib 1001x10000): 6.661
 
 ## Analysis
 
-### Why Is mango-iv Slower?
+### Why Is mango-option Slower?
 
 **Scaling Analysis:**
 - 101 → 201 points (2x): **5.7x slower** (13.8ms → 78.3ms)
@@ -229,7 +229,7 @@ The C++20 implementation is **numerically excellent** with demonstrated **parall
 ### Next Steps
 **Priority 1:** Add OpenMP to source code spatial loops
 - Benchmark shows 12-15x speedup potential
-- Could make mango-iv **10x faster than QuantLib** on batch workloads
+- Could make mango-option **10x faster than QuantLib** on batch workloads
 
 **Priority 2:** Profile and fix O(n²) scaling behavior
 - Would improve both single and parallel performance

--- a/benchmarks/quantlib_accuracy.cc
+++ b/benchmarks/quantlib_accuracy.cc
@@ -1,6 +1,6 @@
 /**
  * @file quantlib_accuracy.cc
- * @brief Accuracy comparison between mango-iv and QuantLib
+ * @brief Accuracy comparison between mango-option and QuantLib
  *
  * Compares numerical accuracy of American option pricing:
  * - Uses QuantLib as reference implementation
@@ -108,7 +108,7 @@ static void compare_scenario(
     double dividend_yield,
     bool is_call)
 {
-    // Mango-IV pricing with workspace
+    // Mango-Option pricing with workspace
     AmericanOptionParams mango_params(
         spot,
         strike,
@@ -244,7 +244,7 @@ static void BM_Convergence_GridResolution(benchmark::State& state) {
         ql_reference = ref.price;
     }
 
-    // Mango-IV pricing at automatically determined resolution
+    // Mango-Option pricing at automatically determined resolution
     AmericanOptionParams params(
         100.0,  // spot
         100.0,  // strike

--- a/benchmarks/quantlib_performance.cc
+++ b/benchmarks/quantlib_performance.cc
@@ -1,9 +1,9 @@
 /**
  * @file quantlib_performance.cc
- * @brief Performance comparison between mango-iv and QuantLib
+ * @brief Performance comparison between mango-option and QuantLib
  *
  * Compares performance of American option pricing between:
- * - mango-iv (C++20 FDM implementation)
+ * - mango-option (C++20 FDM implementation)
  * - QuantLib (FDM implementation)
  *
  * Both use similar grid sizes for fair comparison.
@@ -113,7 +113,7 @@ static void BM_Mango_AmericanPut_ATM(benchmark::State& state) {
         benchmark::DoNotOptimize(price);
     }
 
-    state.SetLabel("mango-iv");
+    state.SetLabel("mango-option");
 }
 BENCHMARK(BM_Mango_AmericanPut_ATM);
 
@@ -173,7 +173,7 @@ static void BM_Mango_AmericanPut_OTM(benchmark::State& state) {
         benchmark::DoNotOptimize(price);
     }
 
-    state.SetLabel("mango-iv");
+    state.SetLabel("mango-option");
 }
 BENCHMARK(BM_Mango_AmericanPut_OTM);
 
@@ -233,7 +233,7 @@ static void BM_Mango_AmericanPut_ITM(benchmark::State& state) {
         benchmark::DoNotOptimize(price);
     }
 
-    state.SetLabel("mango-iv");
+    state.SetLabel("mango-option");
 }
 BENCHMARK(BM_Mango_AmericanPut_ITM);
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,0 +1,29 @@
+"""Module extension for non-BCR dependencies."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _non_bcr_deps_impl(ctx):
+    """Fetch non-BCR dependencies."""
+    # mdspan reference implementation (header-only)
+    # Provides C++23 std::mdspan polyfill for GCC + libstdc++
+    http_archive(
+        name = "mdspan",
+        urls = ["https://github.com/kokkos/mdspan/archive/refs/tags/mdspan-0.6.0.tar.gz"],
+        strip_prefix = "mdspan-mdspan-0.6.0",
+        sha256 = "79f94d7f692cbabfbaff6cd0d3434704435c853ee5087b182965fa929a48a592",
+        build_file_content = """
+cc_library(
+    name = "mdspan",
+    hdrs = glob([
+        "include/**/*.hpp",
+        "include/**/*",
+    ], exclude = ["include/**/*.txt"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
+non_bcr_deps = module_extension(
+    implementation = _non_bcr_deps_impl,
+)

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -1,6 +1,6 @@
 # API Usage Guide
 
-Practical examples and common usage patterns for the mango-iv library.
+Practical examples and common usage patterns for the mango-option library.
 
 **For software architecture, see [ARCHITECTURE.md](ARCHITECTURE.md)**
 **For mathematical formulations, see [MATHEMATICAL_FOUNDATIONS.md](MATHEMATICAL_FOUNDATIONS.md)**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Software Architecture
 
-Software design patterns, implementation strategies, and performance characteristics of the mango-iv library.
+Software design patterns, implementation strategies, and performance characteristics of the mango-option library.
 
 **For mathematical formulations, see [MATHEMATICAL_FOUNDATIONS.md](MATHEMATICAL_FOUNDATIONS.md)**
 **For usage examples, see [API_GUIDE.md](API_GUIDE.md)**

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -1,4 +1,4 @@
-# Makefile Build System for mango-iv
+# Makefile Build System for mango-option
 
 This is an alternative build system using standard Make, designed as a workaround for environments where Bazel is not available (e.g., Claude Code web interface).
 

--- a/docs/MATHEMATICAL_FOUNDATIONS.md
+++ b/docs/MATHEMATICAL_FOUNDATIONS.md
@@ -1,6 +1,6 @@
 # Mathematical Foundations
 
-Mathematical formulations and numerical methods underlying the mango-iv library.
+Mathematical formulations and numerical methods underlying the mango-option library.
 
 **For software architecture, see [ARCHITECTURE.md](ARCHITECTURE.md)**
 **For usage examples, see [API_GUIDE.md](API_GUIDE.md)**

--- a/docs/archive/notes/FASTVOL_ANALYSIS_AND_PLAN.md
+++ b/docs/archive/notes/FASTVOL_ANALYSIS_AND_PLAN.md
@@ -1,8 +1,8 @@
-# FastVol Analysis and Optimization Plan for mango-iv
+# FastVol Analysis and Optimization Plan for mango-option
 
 ## Executive Summary
 
-After analyzing the fastvol repository (https://github.com/vgalanti/fastvol), I've identified several CPU optimization techniques that could significantly improve mango-iv's performance. Fastvol achieves impressive speeds through memory optimization, algorithmic improvements, and careful SIMD utilization.
+After analyzing the fastvol repository (https://github.com/vgalanti/fastvol), I've identified several CPU optimization techniques that could significantly improve mango-option's performance. Fastvol achieves impressive speeds through memory optimization, algorithmic improvements, and careful SIMD utilization.
 
 ---
 
@@ -142,7 +142,7 @@ for (size_t i = 0; i < batch_size; i++) {
 
 ---
 
-## Performance Comparison: FastVol vs mango-iv
+## Performance Comparison: FastVol vs mango-option
 
 ### FastVol Benchmarks (CPU, fp64)
 
@@ -173,7 +173,7 @@ Even accounting for batch vs scalar differences:
 
 ---
 
-## Optimization Plan for mango-iv
+## Optimization Plan for mango-option
 
 Based on fastvol analysis, here's a prioritized plan with estimated impact:
 
@@ -466,12 +466,12 @@ This would bring us much closer to fastvol's performance levels (~140 µs for co
 
 Current benchmark:
 - QuantLib: 10.4 ms
-- mango-iv: 21.7 ms
+- mango-option: 21.7 ms
 - Ratio: 2.1x slower
 
 After optimizations:
 - QuantLib: 10.4 ms
-- mango-iv (optimized): 2-3 ms
+- mango-option (optimized): 2-3 ms
 - Ratio: **3-5x FASTER than QuantLib** 🎯
 
 ---

--- a/docs/archive/plans/2025-10-31-american-iv-implementation-design.md
+++ b/docs/archive/plans/2025-10-31-american-iv-implementation-design.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-Implement implied volatility calculation for **American options** as the primary scope of the mango-iv project. This design removes the European option module and replaces it with:
+Implement implied volatility calculation for **American options** as the primary scope of the mango-option project. This design removes the European option module and replaces it with:
 
 1. **FDM-based American IV** - Reference implementation using nested Brent + PDE solver (~200-300ms)
 2. **Interpolation-based American IV** - Fast queries via 3D precomputed price tables (~7.5µs)

--- a/docs/archive/plans/2025-10-31-vega-interpolation-p1.md
+++ b/docs/archive/plans/2025-10-31-vega-interpolation-p1.md
@@ -1026,7 +1026,7 @@ git commit -m "bench: add vega interpolation performance benchmark
 
 **Step 1: Update PROJECT_OVERVIEW.md**
 
-Add to the "What mango-iv Provides" section:
+Add to the "What mango-option Provides" section:
 
 ```markdown
 #### Greeks Calculation via Vega Interpolation

--- a/docs/archive/plans/2025-11-01-rust-gpu-rewrite.md
+++ b/docs/archive/plans/2025-11-01-rust-gpu-rewrite.md
@@ -2,7 +2,7 @@
 
 **Date**: 2025-11-01
 **Status**: Design
-**Goal**: Rewrite mango-iv in Rust with unified CPU/GPU kernels for trading applications
+**Goal**: Rewrite mango-option in Rust with unified CPU/GPU kernels for trading applications
 
 ## Problem
 
@@ -30,7 +30,7 @@ Computational kernels compile to both native code (CPU) and SPIR-V (GPU) from si
 ### Project Structure
 
 ```
-mango-iv-rs/
+mango-option-rs/
 ├── crates/
 │   ├── types/            # Shared types (OptionParams, Grid, etc.)
 │   ├── kernel/           # GPU-compatible kernels (#[no_std])

--- a/docs/archive/plans/2025-11-01-rust-phase1-bazel-types.md
+++ b/docs/archive/plans/2025-11-01-rust-phase1-bazel-types.md
@@ -81,7 +81,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-authors = ["mango-iv contributors"]
+authors = ["mango-option contributors"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
@@ -133,7 +133,7 @@ path = "src/lib.rs"
 **Step 2: Create crates/types/src/lib.rs with OptionType**
 
 ```rust
-//! Core types for mango-iv option pricing
+//! Core types for mango-option option pricing
 //!
 //! These types are `#[repr(C)]` compatible with the existing C codebase.
 
@@ -461,7 +461,7 @@ git commit -m "Add GridParams and TimeParams types
 ```markdown
 # mango-types
 
-Core type definitions for mango-iv option pricing library.
+Core type definitions for mango-option option pricing library.
 
 ## Overview
 
@@ -513,7 +513,7 @@ Add after `[workspace.package]`:
 ```toml
 [workspace.metadata]
 description = "Rust+GPU option pricing library"
-repository = "https://github.com/yourusername/mango-iv"
+repository = "https://github.com/yourusername/mango-option"
 readme = "README.md"
 keywords = ["options", "pricing", "finance", "gpu", "rust"]
 categories = ["science", "mathematics"]
@@ -559,7 +559,7 @@ Add after "## Project Structure" section:
 Rust rewrite for GPU acceleration is in progress. See `docs/plans/2025-11-01-rust-gpu-rewrite.md` for the full design.
 
 ```
-mango-iv-rs/
+mango-option-rs/
 ├── Cargo.toml           # Workspace root
 └── crates/
     └── types/           # Core type definitions (#[repr(C)] for FFI)

--- a/docs/archive/plans/2025-11-03-cpp-migration-design.md
+++ b/docs/archive/plans/2025-11-03-cpp-migration-design.md
@@ -1,4 +1,4 @@
-# C++20 Migration Design: mango-iv
+# C++20 Migration Design: mango-option
 
 **Date:** 2025-11-03
 **Status:** Design Phase
@@ -11,7 +11,7 @@
 
 ## Executive Summary
 
-We migrate mango-iv from C23 to C++20 to achieve three goals **(v2.0 - CPU-only):**
+We migrate mango-option from C23 to C++20 to achieve three goals **(v2.0 - CPU-only):**
 
 1. **Type-safe boundary conditions** via compile-time policies (eliminate enum-based branching)
 2. **Better callback ergonomics** via lambdas with captures (eliminate `void*` user_data)

--- a/docs/archive/plans/2025-11-12-option-chain-batch-solver.md
+++ b/docs/archive/plans/2025-11-12-option-chain-batch-solver.md
@@ -1086,7 +1086,7 @@ m.def("solve_option_chains",
 
 Run:
 ```bash
-bazel build //python:mango_iv
+bazel build //python:mango_option
 ```
 
 Expected: Build succeeds
@@ -1096,19 +1096,19 @@ Expected: Build succeeds
 Run:
 ```bash
 python3 -c "
-import mango_iv
+import mango_option
 
-chain = mango_iv.AmericanOptionChain()
+chain = mango_option.AmericanOptionChain()
 chain.spot = 100.0
 chain.maturity = 1.0
 chain.volatility = 0.20
 chain.rate = 0.05
 chain.continuous_dividend_yield = 0.02
-chain.option_type = mango_iv.OptionType.PUT
+chain.option_type = mango_option.OptionType.PUT
 chain.strikes = [90.0, 95.0, 100.0, 105.0, 110.0]
 
-grid = mango_iv.AmericanOptionGrid()
-results = mango_iv.solve_option_chain(chain, grid)
+grid = mango_option.AmericanOptionGrid()
+results = mango_option.solve_option_chain(chain, grid)
 
 print(f'Solved {len(results)} strikes')
 for r in results:

--- a/docs/archive/plans/2025-11-22-mdspan-adoption-strategy.md
+++ b/docs/archive/plans/2025-11-22-mdspan-adoption-strategy.md
@@ -1,4 +1,4 @@
-# mdspan Adoption Strategy for mango-iv
+# mdspan Adoption Strategy for mango-option
 
 **Date:** 2025-11-22
 **Status:** ✅ Implemented (2025-11-22)

--- a/docs/plans/2025-11-25-kokkos-migration-design.md
+++ b/docs/plans/2025-11-25-kokkos-migration-design.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Rewrite mango-iv core to use Kokkos for:
+Rewrite mango-option core to use Kokkos for:
 - **GPU acceleration** — SYCL primary, CUDA/HIP supported
 - **Portable parallelism** — Replace OpenMP with Kokkos::parallel_for
 - **Unified memory model** — Kokkos::View replaces mdspan + PMR arenas
@@ -288,7 +288,7 @@ bazel test //kokkos/... --config=openmp    # Tests
 ### During Development
 
 ```
-mango-iv/
+mango-option/
 ├── src/                    # Current code (untouched)
 ├── tests/                  # Current tests (untouched)
 ├── benchmarks/             # Current benchmarks (untouched)
@@ -312,7 +312,7 @@ mango-iv/
 ### After Switchover
 
 ```
-mango-iv/
+mango-option/
 ├── src/                    # Was kokkos/src/
 ├── tests/                  # Was kokkos/tests/
 ├── benchmarks/             # Was kokkos/benchmarks/

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1,0 +1,136 @@
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+
+# Combined library target that exports all public APIs
+cc_library(
+    name = "mango_option",
+    visibility = ["//visibility:public"],
+    deps = [
+        # Core option pricing
+        "//src/option:american_option",
+        "//src/option:american_option_batch",
+        "//src/option:iv_solver_fdm",
+        "//src/option:iv_solver_interpolated",
+        "//src/option:option_spec",
+        # Price tables
+        "//src/option/table:price_table_builder",
+        "//src/option/table:price_table_surface",
+        "//src/option/table:price_table_axes",
+        # Data source integration (mango::simple namespace)
+        "//src/simple",
+        # Supporting utilities
+        "//src/support:error_types",
+        "//src/pde/core:grid",
+        "//src/pde/core:time_domain",
+        "//src/math:yield_curve",
+    ],
+)
+
+# Collect headers with proper directory structure
+pkg_files(
+    name = "headers_option",
+    srcs = ["//src/option:public_headers"],
+    prefix = "mango/option",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_files(
+    name = "headers_option_table",
+    srcs = ["//src/option/table:public_headers"],
+    prefix = "mango/option/table",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_files(
+    name = "headers_pde_core",
+    srcs = ["//src/pde/core:public_headers"],
+    prefix = "mango/pde/core",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_files(
+    name = "headers_pde_operators",
+    srcs = ["//src/pde/operators:public_headers"],
+    prefix = "mango/pde/operators",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_files(
+    name = "headers_math",
+    srcs = ["//src/math:public_headers"],
+    prefix = "mango/math",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_files(
+    name = "headers_support",
+    srcs = ["//src/support:public_headers"],
+    prefix = "mango/support",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_files(
+    name = "headers_simple",
+    srcs = ["//src/simple:public_headers"],
+    prefix = "mango/simple",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+# pkg-config file
+genrule(
+    name = "mango_option_pc",
+    outs = ["mango-option.pc"],
+    cmd = """
+cat > $@ << 'EOF'
+prefix=@PREFIX@
+exec_prefix=$${prefix}
+libdir=$${exec_prefix}/lib
+includedir=$${prefix}/include
+
+Name: mango-option
+Description: C++23 American option pricing library with FDM solvers and B-spline interpolation
+Version: 0.1.0
+Requires:
+Libs: -L$${libdir} -lmango_option -llapacke -fopenmp
+Cflags: -I$${includedir} -std=c++23
+EOF
+""",
+    visibility = ["//visibility:public"],
+)
+
+# Header tarball
+pkg_tar(
+    name = "mango_option_headers",
+    srcs = [
+        ":headers_math",
+        ":headers_option",
+        ":headers_option_table",
+        ":headers_pde_core",
+        ":headers_pde_operators",
+        ":headers_simple",
+        ":headers_support",
+    ],
+    extension = "tar.gz",
+    package_dir = "include",
+    visibility = ["//visibility:public"],
+)
+
+# pkg-config tarball
+pkg_tar(
+    name = "mango_option_pkgconfig",
+    srcs = [":mango_option_pc"],
+    extension = "tar.gz",
+    package_dir = "lib/pkgconfig",
+    visibility = ["//visibility:public"],
+)
+
+# Full distribution tarball (headers + pkg-config)
+pkg_tar(
+    name = "mango_option_dist",
+    extension = "tar.gz",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":mango_option_headers",
+        ":mango_option_pkgconfig",
+    ],
+)

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 
 pybind_extension(
-    name = "mango_iv",
+    name = "mango_option",
     srcs = ["mango_bindings.cpp"],
     deps = [
         "//src/option:iv_solver_fdm",

--- a/python/mango_bindings.cpp
+++ b/python/mango_bindings.cpp
@@ -1,6 +1,6 @@
 /**
  * @file mango_bindings.cpp
- * @brief Python bindings for mango-iv library using pybind11
+ * @brief Python bindings for mango-option library using pybind11
  */
 
 #include <pybind11/pybind11.h>
@@ -54,8 +54,8 @@ std::string rate_spec_to_string(const mango::RateSpec& spec) {
     }, spec);
 }
 
-PYBIND11_MODULE(mango_iv, m) {
-    m.doc() = "Python bindings for mango-iv American option pricing and IV solver";
+PYBIND11_MODULE(mango_option, m) {
+    m.doc() = "Python bindings for mango-option American option pricing and IV solver";
 
     // OptionType enum
     py::enum_<mango::OptionType>(m, "OptionType")

--- a/python/test_bindings.py
+++ b/python/test_bindings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Tests for mango-iv Python bindings
+Tests for mango-option Python bindings
 """
 
 import sys
@@ -10,22 +10,22 @@ import numpy as np
 
 # Try different import paths
 try:
-    import mango_iv
+    import mango_option
 except ImportError:
     try:
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'bazel-bin', 'python'))
-        import mango_iv
+        import mango_option
     except ImportError as e:
-        print(f"Failed to import mango_iv: {e}")
-        print("Run: bazel build //python:mango_iv")
+        print(f"Failed to import mango_option: {e}")
+        print("Run: bazel build //python:mango_option")
         sys.exit(1)
 
 
 def test_option_types():
     """Test OptionType enum"""
     print("Testing OptionType enum...")
-    assert mango_iv.OptionType.CALL is not None
-    assert mango_iv.OptionType.PUT is not None
+    assert mango_option.OptionType.CALL is not None
+    assert mango_option.OptionType.PUT is not None
     print("✓ OptionType enum works")
 
 
@@ -34,7 +34,7 @@ def test_yield_curve():
     print("Testing YieldCurve...")
 
     # Flat curve
-    flat = mango_iv.YieldCurve.flat(0.05)
+    flat = mango_option.YieldCurve.flat(0.05)
     assert abs(flat.rate(1.0) - 0.05) < 1e-10
     assert abs(flat.zero_rate(1.0) - 0.05) < 1e-10
     print("✓ Flat YieldCurve works")
@@ -42,7 +42,7 @@ def test_yield_curve():
     # From discounts
     tenors = [0.25, 0.5, 1.0, 2.0]
     discounts = [0.9876, 0.9753, 0.9512, 0.9048]
-    curve = mango_iv.YieldCurve.from_discounts(tenors, discounts)
+    curve = mango_option.YieldCurve.from_discounts(tenors, discounts)
     assert curve.discount(1.0) > 0
     print("✓ YieldCurve from discounts works")
 
@@ -51,13 +51,13 @@ def test_iv_query():
     """Test IVQuery construction"""
     print("Testing IVQuery...")
 
-    query = mango_iv.IVQuery()
+    query = mango_option.IVQuery()
     query.spot = 100.0
     query.strike = 100.0
     query.maturity = 1.0
     query.rate = 0.05
     query.dividend_yield = 0.02
-    query.type = mango_iv.OptionType.PUT
+    query.type = mango_option.OptionType.PUT
     query.market_price = 10.0
 
     assert query.spot == 100.0
@@ -69,16 +69,16 @@ def test_iv_solver_fdm():
     """Test IVSolverFDM"""
     print("Testing IVSolverFDM...")
 
-    config = mango_iv.IVSolverFDMConfig()
-    solver = mango_iv.IVSolverFDM(config)
+    config = mango_option.IVSolverFDMConfig()
+    solver = mango_option.IVSolverFDM(config)
 
-    query = mango_iv.IVQuery()
+    query = mango_option.IVQuery()
     query.spot = 100.0
     query.strike = 100.0
     query.maturity = 1.0
     query.rate = 0.05
     query.dividend_yield = 0.02
-    query.type = mango_iv.OptionType.PUT
+    query.type = mango_option.OptionType.PUT
     query.market_price = 10.0
 
     success, result, error = solver.solve_impl(query)
@@ -92,16 +92,16 @@ def test_american_option_price():
     """Test american_option_price function"""
     print("Testing american_option_price...")
 
-    params = mango_iv.AmericanOptionParams()
+    params = mango_option.AmericanOptionParams()
     params.strike = 100.0
     params.spot = 100.0
     params.maturity = 1.0
     params.volatility = 0.20
     params.rate = 0.05
     params.dividend_yield = 0.02
-    params.type = mango_iv.OptionType.PUT
+    params.type = mango_option.OptionType.PUT
 
-    result = mango_iv.american_option_price(params)
+    result = mango_option.american_option_price(params)
     delta = result.delta()
     print(f"✓ American option price computed, delta = {delta:.4f}")
 
@@ -121,7 +121,7 @@ def test_price_table_workspace():
     coeffs = np.random.rand(n_coeffs) * 10.0
 
     # Create workspace
-    ws = mango_iv.PriceTableWorkspace.create(
+    ws = mango_option.PriceTableWorkspace.create(
         log_m, tau, sigma, r, coeffs,
         K_ref=100.0,
         dividend_yield=0.02,
@@ -148,7 +148,7 @@ def test_price_table_workspace():
         ws.save(filepath, "TEST", 0)  # 0 = PUT
         print(f"✓ Saved to {filepath}")
 
-        loaded = mango_iv.PriceTableWorkspace.load(filepath)
+        loaded = mango_option.PriceTableWorkspace.load(filepath)
         print(f"✓ Loaded: {loaded}")
 
         # Verify loaded data matches
@@ -167,7 +167,7 @@ def test_price_table_surface():
     print("Testing PriceTableSurface4D...")
 
     # Create axes
-    axes = mango_iv.PriceTableAxes4D()
+    axes = mango_option.PriceTableAxes4D()
     axes.grids = [
         np.array([0.8, 0.9, 1.0, 1.1, 1.2]),  # moneyness
         np.array([0.1, 0.25, 0.5, 1.0]),       # maturity
@@ -177,7 +177,7 @@ def test_price_table_surface():
     axes.names = ["moneyness", "maturity", "volatility", "rate"]
 
     # Create metadata
-    meta = mango_iv.PriceTableMetadata()
+    meta = mango_option.PriceTableMetadata()
     meta.K_ref = 100.0
     meta.dividend_yield = 0.02
     meta.m_min = 0.8
@@ -189,7 +189,7 @@ def test_price_table_surface():
     coeffs = np.random.rand(n_coeffs) * 10.0
 
     # Build surface
-    surface = mango_iv.PriceTableSurface4D.build(axes, coeffs, meta)
+    surface = mango_option.PriceTableSurface4D.build(axes, coeffs, meta)
     print(f"✓ Built surface")
 
     # Query value
@@ -206,7 +206,7 @@ def test_iv_solver_interpolated():
     print("Testing IVSolverInterpolated...")
 
     # Build a surface first
-    axes = mango_iv.PriceTableAxes4D()
+    axes = mango_option.PriceTableAxes4D()
     axes.grids = [
         np.array([0.8, 0.9, 1.0, 1.1, 1.2]),
         np.array([0.1, 0.25, 0.5, 1.0]),
@@ -214,7 +214,7 @@ def test_iv_solver_interpolated():
         np.array([0.01, 0.03, 0.05, 0.07])
     ]
 
-    meta = mango_iv.PriceTableMetadata()
+    meta = mango_option.PriceTableMetadata()
     meta.K_ref = 100.0
     meta.dividend_yield = 0.02
     meta.m_min = 0.8
@@ -223,25 +223,25 @@ def test_iv_solver_interpolated():
     shape = axes.shape
     coeffs = np.random.rand(shape[0] * shape[1] * shape[2] * shape[3]) * 10.0
 
-    surface = mango_iv.PriceTableSurface4D.build(axes, coeffs, meta)
+    surface = mango_option.PriceTableSurface4D.build(axes, coeffs, meta)
 
     # Create solver
-    config = mango_iv.IVSolverInterpolatedConfig()
+    config = mango_option.IVSolverInterpolatedConfig()
     config.max_iterations = 50
     config.tolerance = 1e-6
 
-    solver = mango_iv.IVSolverInterpolated.create(surface, config)
+    solver = mango_option.IVSolverInterpolated.create(surface, config)
     print("✓ Created IVSolverInterpolated")
 
     # Note: With random coefficients, the solver may not converge
     # but we can verify the API works
-    query = mango_iv.IVQuery()
+    query = mango_option.IVQuery()
     query.spot = 100.0
     query.strike = 100.0
     query.maturity = 0.5
     query.rate = 0.05
     query.dividend_yield = 0.02
-    query.type = mango_iv.OptionType.PUT
+    query.type = mango_option.OptionType.PUT
     query.market_price = 5.0
 
     success, result, error = solver.solve_impl(query)
@@ -257,9 +257,9 @@ def test_load_error_enum():
     """Test PriceTableLoadError enum"""
     print("Testing PriceTableLoadError enum...")
 
-    assert mango_iv.PriceTableLoadError.FILE_NOT_FOUND is not None
-    assert mango_iv.PriceTableLoadError.CORRUPTED_COEFFICIENTS is not None
-    assert mango_iv.PriceTableLoadError.NOT_ARROW_FILE is not None
+    assert mango_option.PriceTableLoadError.FILE_NOT_FOUND is not None
+    assert mango_option.PriceTableLoadError.CORRUPTED_COEFFICIENTS is not None
+    assert mango_option.PriceTableLoadError.NOT_ARROW_FILE is not None
     print("✓ PriceTableLoadError enum accessible")
 
 
@@ -269,7 +269,7 @@ def test_error_handling():
 
     # Load non-existent file
     try:
-        mango_iv.PriceTableWorkspace.load("/nonexistent/path.arrow")
+        mango_option.PriceTableWorkspace.load("/nonexistent/path.arrow")
         assert False, "Should have raised ValueError"
     except ValueError as e:
         assert "File not found" in str(e)
@@ -277,7 +277,7 @@ def test_error_handling():
 
     # Insufficient grid points (< 4)
     try:
-        mango_iv.PriceTableWorkspace.create(
+        mango_option.PriceTableWorkspace.create(
             np.array([-0.1, 0.0, 0.1]),  # Only 3 points
             np.array([0.1, 0.25, 0.5, 1.0]),
             np.array([0.1, 0.2, 0.3, 0.4]),
@@ -290,7 +290,7 @@ def test_error_handling():
         print(f"✓ Insufficient grid points raises ValueError: {e}")
 
     # PriceTableAxes with wrong number of grids
-    axes = mango_iv.PriceTableAxes4D()
+    axes = mango_option.PriceTableAxes4D()
     try:
         axes.grids = [np.array([1.0, 2.0, 3.0, 4.0])]  # Only 1 grid instead of 4
         assert False, "Should have raised ValueError"
@@ -304,7 +304,7 @@ def test_surface_to_solver_integration():
     print("Testing surface to solver integration...")
 
     # Build surface
-    axes = mango_iv.PriceTableAxes4D()
+    axes = mango_option.PriceTableAxes4D()
     axes.grids = [
         np.array([0.8, 0.9, 1.0, 1.1, 1.2]),
         np.array([0.1, 0.25, 0.5, 1.0]),
@@ -312,7 +312,7 @@ def test_surface_to_solver_integration():
         np.array([0.01, 0.03, 0.05, 0.07])
     ]
 
-    meta = mango_iv.PriceTableMetadata()
+    meta = mango_option.PriceTableMetadata()
     meta.K_ref = 100.0
     meta.dividend_yield = 0.02
     meta.m_min = 0.8
@@ -321,11 +321,11 @@ def test_surface_to_solver_integration():
     shape = axes.shape
     coeffs = np.random.rand(shape[0] * shape[1] * shape[2] * shape[3]) * 10.0
 
-    surface = mango_iv.PriceTableSurface4D.build(axes, coeffs, meta)
+    surface = mango_option.PriceTableSurface4D.build(axes, coeffs, meta)
 
     # Verify surface can be passed to IVSolverInterpolated (tests shared_ptr const conversion)
-    config = mango_iv.IVSolverInterpolatedConfig()
-    solver = mango_iv.IVSolverInterpolated.create(surface, config)
+    config = mango_option.IVSolverInterpolatedConfig()
+    solver = mango_option.IVSolverInterpolated.create(surface, config)
     assert solver is not None
     print("✓ Surface correctly passes to IVSolverInterpolated.create()")
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Option IV Surface Calculator Scripts
 
-Python scripts for downloading option data from Yahoo Finance and calculating implied volatility surfaces using the mango-iv C++ library.
+Python scripts for downloading option data from Yahoo Finance and calculating implied volatility surfaces using the `mango-option` C++ library.
 
 ## Overview
 
@@ -36,11 +36,11 @@ This collection of scripts provides an end-to-end workflow for:
 
 ### 1. Build the C++ Python Bindings
 
-First, build the mango-iv Python module:
+First, build the mango-option Python module:
 
 ```bash
 # From repository root
-bazel build //python:mango_iv
+bazel build //python:mango_option
 ```
 
 This creates a Python extension module that wraps the C++ IV solver.
@@ -87,7 +87,7 @@ Or install the module in development mode (recommended):
 
 ```bash
 # Create a symlink in your Python environment
-ln -s ${BAZEL_BIN}/python/mango_iv.so $(python -c "import site; print(site.getsitepackages()[0])")/
+ln -s ${BAZEL_BIN}/python/mango_option.so $(python -c "import site; print(site.getsitepackages()[0])")/
 ```
 
 ## Quick Start
@@ -282,12 +282,12 @@ with OptionDatabase("spy.db") as db:
 
 ## Troubleshooting
 
-### Import Error: mango_iv not found
+### Import Error: mango_option not found
 
 Make sure you've built the Python module and set PYTHONPATH:
 
 ```bash
-bazel build //python:mango_iv
+bazel build //python:mango_option
 export PYTHONPATH="$(bazel info bazel-bin)/python:${PYTHONPATH}"
 ```
 

--- a/scripts/data/export_real_option_data.py
+++ b/scripts/data/export_real_option_data.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Download real market option data, price it with the mango_iv Python binding,
+Download real market option data, price it with the mango_option Python binding,
 and persist the snapshot as an Arrow IPC (Feather) file.
 """
 
@@ -24,10 +24,10 @@ if BAZEL_PYTHON_DIR.exists():
     sys.path.append(str(BAZEL_PYTHON_DIR))
 
 try:
-    import mango_iv
+    import mango_option
 except ImportError as exc:  # pragma: no cover - handled in CLI
     raise SystemExit(
-        "mango_iv module not available. Build it with: bazel build //python:mango_iv"
+        "mango_option module not available. Build it with: bazel build //python:mango_option"
     ) from exc
 
 
@@ -77,9 +77,9 @@ def _estimate_rate() -> float:
 
 
 def _build_params(
-    sample: OptionSample, option_kind: mango_iv.OptionType
-) -> mango_iv.AmericanOptionParams:
-    params = mango_iv.AmericanOptionParams()
+    sample: OptionSample, option_kind: mango_option.OptionType
+) -> mango_option.AmericanOptionParams:
+    params = mango_option.AmericanOptionParams()
     params.spot = sample.spot
     params.strike = sample.strike
     params.maturity = sample.time_to_maturity
@@ -91,9 +91,9 @@ def _build_params(
 
 
 def _price_option(sample: OptionSample) -> float:
-    option_kind = mango_iv.OptionType.CALL if sample.option_type == 1 else mango_iv.OptionType.PUT
+    option_kind = mango_option.OptionType.CALL if sample.option_type == 1 else mango_option.OptionType.PUT
     params = _build_params(sample, option_kind)
-    result = mango_iv.american_option_price(params)
+    result = mango_option.american_option_price(params)
     return float(result.value)
 
 

--- a/scripts/examples/README.md
+++ b/scripts/examples/README.md
@@ -1,13 +1,13 @@
 # IV Surface Calculator Examples
 
-This directory contains example scripts demonstrating how to use the mango-iv option data downloader and IV calculator.
+This directory contains example scripts demonstrating how to use the mango-option option data downloader and IV calculator.
 
 ## Prerequisites
 
 1. **Build the C++ bindings:**
    ```bash
    # From repository root
-   bazel build //python:mango_iv.so
+   bazel build //python:mango_option.so
    ```
 
 2. **Install Python dependencies:**
@@ -255,10 +255,10 @@ Summary:
 
 ### Common Issues
 
-**Import Error: mango_iv not found**
+**Import Error: mango_option not found**
 ```bash
 # Make sure you built the C++ module and set PYTHONPATH
-bazel build //python:mango_iv.so
+bazel build //python:mango_option.so
 export PYTHONPATH="$(bazel info bazel-bin)/python:${PYTHONPATH}"
 ```
 

--- a/scripts/examples/iv_price_table_example.py
+++ b/scripts/examples/iv_price_table_example.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 try:
     from iv_surface import OptionDataDownloader
-    import mango_iv
+    import mango_option
 except ImportError as e:
     print(f"Error: Required modules not found: {e}")
     print("Please ensure:")
@@ -92,11 +92,11 @@ def build_price_table(spot_price, min_vol=0.10, max_vol=0.80, n_vol=20,
 
 def calculate_iv_via_fdm(option_params, grid_n_space=101, grid_n_time=1000):
     """Calculate IV using direct FDM solver (slow method)."""
-    config = mango_iv.IVConfig()
+    config = mango_option.IVConfig()
     config.grid_n_space = grid_n_space
     config.grid_n_time = grid_n_time
 
-    solver = mango_iv.IVSolver(option_params, config)
+    solver = mango_option.IVSolver(option_params, config)
     result = solver.solve()
 
     return result
@@ -227,7 +227,7 @@ Examples:
 
         # Method 1: Direct FDM (slow)
         print(f"  Method 1: Direct FDM solver...")
-        params = mango_iv.IVParams()
+        params = mango_option.IVParams()
         params.spot_price = float(spot_price)
         params.strike = float(strike)
         params.time_to_maturity = float(ttm)

--- a/scripts/iv_surface/__init__.py
+++ b/scripts/iv_surface/__init__.py
@@ -2,7 +2,7 @@
 IV Surface Calculator - Python package for option data and implied volatility.
 
 This package provides tools to download option chain data from Yahoo Finance
-and calculate implied volatility surfaces using the mango-iv C++ library.
+and calculate implied volatility surfaces using the mango-option C++ library.
 
 Modules:
     database: SQLite3 database schema and utilities

--- a/scripts/iv_surface/calculate_iv_surface.py
+++ b/scripts/iv_surface/calculate_iv_surface.py
@@ -4,7 +4,7 @@ Main script to download option data and calculate IV surface.
 
 This script:
 1. Downloads option chain data from Yahoo Finance
-2. Calculates implied volatility using mango-iv C++ solver
+2. Calculates implied volatility using mango-option C++ solver
 3. Stores results and raw data in SQLite3 database
 
 Usage:

--- a/scripts/iv_surface/iv_calculator.py
+++ b/scripts/iv_surface/iv_calculator.py
@@ -1,5 +1,5 @@
 """
-IV surface calculation using mango-iv C++ library.
+IV surface calculation using mango-option C++ library.
 
 This module provides functions to:
 - Calculate implied volatility for individual options
@@ -13,15 +13,15 @@ import numpy as np
 
 # Import the C++ bindings (will be built with Bazel)
 try:
-    import mango_iv
+    import mango_option
 except ImportError:
-    print("Warning: mango_iv module not found. Please build with: bazel build //python:mango_iv")
+    print("Warning: mango_option module not found. Please build with: bazel build //python:mango_option")
     print("Using mock implementation for development")
-    mango_iv = None
+    mango_option = None
 
 
 class IVCalculator:
-    """Calculate implied volatility using mango-iv C++ solver."""
+    """Calculate implied volatility using mango-option C++ solver."""
 
     def __init__(self, grid_n_space: int = 101, grid_n_time: int = 1000,
                  max_iter: int = 100, tolerance: float = 1e-6):
@@ -34,11 +34,11 @@ class IVCalculator:
             max_iter: Maximum iterations for root-finding
             tolerance: Convergence tolerance
         """
-        if mango_iv is None:
-            raise ImportError("mango_iv module not available. Build with Bazel first.")
+        if mango_option is None:
+            raise ImportError("mango_option module not available. Build with Bazel first.")
 
         # Create solver configuration
-        self.config = mango_iv.IVSolverFDMConfig()
+        self.config = mango_option.IVSolverFDMConfig()
         self.config.grid_n_space = grid_n_space
         self.config.grid_n_time = grid_n_time
         self.config.root_config.max_iter = max_iter
@@ -68,17 +68,17 @@ class IVCalculator:
             - vega: Vega at the solution (if available)
         """
         # Create IV query
-        query = mango_iv.IVQuery()
+        query = mango_option.IVQuery()
         query.spot = float(spot_price)
         query.strike = float(strike)
         query.maturity = float(time_to_maturity)
         query.rate = float(risk_free_rate)
         query.market_price = float(market_price)
-        query.type = mango_iv.OptionType.CALL if is_call else mango_iv.OptionType.PUT
+        query.type = mango_option.OptionType.CALL if is_call else mango_option.OptionType.PUT
         query.dividend_yield = 0.0  # Default to 0
 
         # Create solver and solve
-        solver = mango_iv.IVSolverFDM(self.config)
+        solver = mango_option.IVSolverFDM(self.config)
         result = solver.solve(query)
 
         # Convert result to dict

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
-name = "mango-iv-scripts"
+name = "mango-option-scripts"
 version = "0.1.0"
-description = "Option data downloader and IV surface calculator using mango-iv"
+description = "Option data downloader and IV surface calculator using mango-option"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [
-    { name = "mango-iv contributors" }
+    { name = "mango-option contributors" }
 ]
 
 dependencies = [

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-# Python dependencies for mango-iv option data downloader
+# Python dependencies for mango-option option data downloader
 #
 # Recommended: Use uv (fast, modern package manager)
 #   uv sync

--- a/src/math/BUILD.bazel
+++ b/src/math/BUILD.bazel
@@ -1,3 +1,12 @@
+# Export headers for packaging
+exports_files(glob(["*.hpp"]))
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["*.hpp"]),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "safe_math",
     hdrs = ["safe_math.hpp"],

--- a/src/option/BUILD.bazel
+++ b/src/option/BUILD.bazel
@@ -1,3 +1,12 @@
+# Export headers for packaging
+exports_files(glob(["*.hpp"]))
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["*.hpp"]),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "option_chain",
     hdrs = ["option_chain.hpp"],

--- a/src/option/table/BUILD.bazel
+++ b/src/option/table/BUILD.bazel
@@ -1,3 +1,12 @@
+# Export headers for packaging
+exports_files(glob(["*.hpp"]))
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["*.hpp"]),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "price_table_axes",
     hdrs = ["price_table_axes.hpp"],

--- a/src/pde/core/BUILD.bazel
+++ b/src/pde/core/BUILD.bazel
@@ -1,3 +1,12 @@
+# Export headers for packaging
+exports_files(glob(["*.hpp"]))
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["*.hpp"]),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "grid",
     hdrs = ["grid.hpp"],

--- a/src/pde/operators/BUILD.bazel
+++ b/src/pde/operators/BUILD.bazel
@@ -1,3 +1,12 @@
+# Export headers for packaging
+exports_files(glob(["*.hpp"]))
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["*.hpp"]),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "laplacian_pde",
     hdrs = ["laplacian_pde.hpp"],

--- a/src/simple/BUILD.bazel
+++ b/src/simple/BUILD.bazel
@@ -1,5 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
+# Export headers for packaging
+exports_files(glob(["*.hpp"]))
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["*.hpp"]) + glob(["sources/*.hpp"]),
+)
+
 cc_library(
     name = "price",
     hdrs = ["price.hpp"],

--- a/src/support/BUILD.bazel
+++ b/src/support/BUILD.bazel
@@ -1,3 +1,12 @@
+# Export headers for packaging
+exports_files(glob(["*.hpp"]))
+
+filegroup(
+    name = "public_headers",
+    srcs = glob(["*.hpp"]),
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "aligned_arena",
     srcs = ["memory/aligned_arena.cpp"],

--- a/tests/QUANTLIB_VALIDATION_README.md
+++ b/tests/QUANTLIB_VALIDATION_README.md
@@ -1,6 +1,6 @@
 # QuantLib Validation Framework
 
-Unified testing framework for validating mango-iv pricing and implied volatility solvers against QuantLib reference implementation.
+Unified testing framework for validating mango-option pricing and implied volatility solvers against QuantLib reference implementation.
 
 ## Overview
 
@@ -112,7 +112,7 @@ The `DISABLED_StandardScenarios_IV_Interpolated` test validates the B-spline-bas
 
 - **QuantLib** - Reference implementation (`libquantlib0-dev`)
 - **GoogleTest** - Testing framework
-- **mango-iv** - Option pricing library
+- **mango-option** - Option pricing library
   - `american_option` - FDM pricing solver
   - `iv_solver_fdm` - FDM-based IV solver
   - `iv_solver_interpolated` - B-spline IV solver

--- a/tests/quantlib_accuracy_batch_test.cc
+++ b/tests/quantlib_accuracy_batch_test.cc
@@ -1,6 +1,6 @@
 /**
  * @file quantlib_accuracy_batch_test.cc
- * @brief Batch validation of mango-iv pricing and IV solvers against QuantLib
+ * @brief Batch validation of mango-option pricing and IV solvers against QuantLib
  *
  * Tests:
  * - FDM pricing accuracy (auto-estimation mode)

--- a/tests/quantlib_accuracy_test.cc
+++ b/tests/quantlib_accuracy_test.cc
@@ -3,7 +3,7 @@
  * @brief Accuracy validation against QuantLib reference implementation
  *
  * This test ensures numerical accuracy doesn't regress by comparing
- * mango-iv American option prices against QuantLib.
+ * mango-option American option prices against QuantLib.
  *
  * Key scenarios tested:
  * - ATM/ITM/OTM options
@@ -100,7 +100,7 @@ void test_scenario(
 {
     SCOPED_TRACE(name);
 
-    // Mango-IV pricing with auto-estimation (production mode)
+    // Mango-Option pricing with auto-estimation (production mode)
     AmericanOptionParams mango_params(
         spot, strike, maturity, rate, dividend_yield,
         is_call ? OptionType::CALL : OptionType::PUT, volatility);

--- a/tests/quantlib_validation_framework.hpp
+++ b/tests/quantlib_validation_framework.hpp
@@ -1,6 +1,6 @@
 /**
  * @file quantlib_validation_framework.hpp
- * @brief Unified testing framework for validating mango-iv against QuantLib
+ * @brief Unified testing framework for validating mango-option against QuantLib
  *
  * Provides generic testing utilities for:
  * - American option pricing accuracy
@@ -8,7 +8,7 @@
  * - Greeks accuracy
  * - Batch processing validation
  *
- * Supports multiple mango-iv solvers:
+ * Supports multiple mango-option solvers:
  * - FDM-based pricing (auto-estimation)
  * - FDM-based IV (ground truth)
  * - Interpolated IV (B-spline, fast)
@@ -114,7 +114,7 @@ struct OptionTestScenario {
 };
 
 // ============================================================================
-// Mango-IV Pricing Validation
+// Mango-Option Pricing Validation
 // ============================================================================
 
 struct PricingValidationResult {
@@ -133,7 +133,7 @@ inline PricingValidationResult validate_pricing(
 
     PricingValidationResult validation;
 
-    // Mango-IV pricing with auto-estimation
+    // Mango-Option pricing with auto-estimation
     AmericanOptionParams mango_params(
         scenario.spot, scenario.strike, scenario.maturity,
         scenario.rate, scenario.dividend_yield,
@@ -185,7 +185,7 @@ inline PricingValidationResult validate_pricing(
 }
 
 // ============================================================================
-// Mango-IV Implied Volatility Validation (FDM)
+// Mango-Option Implied Volatility Validation (FDM)
 // ============================================================================
 
 struct IVValidationResult {

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -1,4 +1,4 @@
-# C++ Toolchain for mango-iv
+# C++ Toolchain for mango-option
 #
 # Configures GCC 14+ with C++23 support as the default toolchain.
 # Includes features for:
@@ -12,13 +12,13 @@ load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 package(default_visibility = ["//visibility:public"])
 
 # Toolchain configuration
-cc_toolchain_config(name = "mango_iv_toolchain_config")
+cc_toolchain_config(name = "mango_option_toolchain_config")
 
 # Toolchain definition
 cc_toolchain(
-    name = "mango_iv_cc_toolchain",
-    toolchain_identifier = "mango-iv-toolchain",
-    toolchain_config = ":mango_iv_toolchain_config",
+    name = "mango_option_cc_toolchain",
+    toolchain_identifier = "mango-option-toolchain",
+    toolchain_config = ":mango_option_toolchain_config",
     all_files = ":empty",
     compiler_files = ":empty",
     dwp_files = ":empty",
@@ -39,7 +39,7 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    toolchain = ":mango_iv_cc_toolchain",
+    toolchain = ":mango_option_cc_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -1,4 +1,4 @@
-"""C++ toolchain configuration for mango-iv with C++23 support."""
+"""C++ toolchain configuration for mango-option with C++23 support."""
 
 load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
      "feature",
@@ -242,7 +242,7 @@ def _impl(ctx):
 
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
-        toolchain_identifier = "mango-iv-toolchain",
+        toolchain_identifier = "mango-option-toolchain",
         host_system_name = "local",
         target_system_name = "local",
         target_cpu = "k8",


### PR DESCRIPTION
## Summary
- Rename project from **mango-iv** to **mango-option** throughout codebase
- Migrate mdspan dependency from WORKSPACE to Bzlmod (MODULE.bazel)
- Add packaging targets for library distribution

## Changes

### Project Rename
- Python module: `mango_iv` → `mango_option` (PYBIND11_MODULE)
- Bazel targets: `//python:mango_iv` → `//python:mango_option`
- Toolchain: `mango-iv-toolchain` → `mango-option-toolchain`
- All documentation updated (CLAUDE.md, README.md, API_GUIDE.md, etc.)

### Bzlmod Migration
- Move mdspan `http_archive` from WORKSPACE to MODULE.bazel via module extension
- Add `deps.bzl` with `non_bcr_deps` extension for non-BCR dependencies
- Clear WORKSPACE file (now uses Bzlmod exclusively)

### Packaging Support
- Add `pkg/BUILD.bazel` with combined library target (`mango_option`)
- Add pkg-config template (`mango_option.pc`)
- Add distribution tarball (`mango_option_dist.tar.gz`)
- Add `filegroup` exports in source BUILD files for header collection
- Uses rules_pkg v1.1.0

## Test plan
- [x] `bazel build //python:mango_option` builds successfully
- [x] `bazel build //pkg:mango_option` builds combined library
- [x] `bazel build //pkg:mango_option_dist` creates distribution tarball
- [x] Core tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)