### PR TITLE
Add OptionType to OptionLeg for self-describing options

### DIFF
--- a/examples/simple_yfinance_example.cpp
+++ b/examples/simple_yfinance_example.cpp
@@ -6,6 +6,7 @@
 #include "src/simple/simple.hpp"
 #include <iostream>
 #include <iomanip>
+#include <ranges>
 
 using namespace mango::simple;
 
@@ -81,9 +82,9 @@ int main() {
         std::cout << "## Settlement: "
                   << (*expiry.settlement == Settlement::PM ? "PM" : "AM") << "\n\n";
 
-        std::cout << "### Calls (" << expiry.calls.size() << " strikes)\n";
+        std::cout << "### Calls (" << std::ranges::distance(expiry.calls()) << " strikes)\n";
         std::cout << "strike,bid,ask,last,volume,oi,moneyness\n";
-        for (const auto& call : expiry.calls) {
+        for (const auto& call : expiry.calls()) {
             double strike = call.strike.to_double();
             double moneyness = std::log(strike / chain.spot->to_double());
             std::cout << std::setprecision(2) << std::fixed << strike << ","
@@ -95,9 +96,9 @@ int main() {
                       << std::setprecision(6) << moneyness << "\n";
         }
 
-        std::cout << "\n### Puts (" << expiry.puts.size() << " strikes)\n";
+        std::cout << "\n### Puts (" << std::ranges::distance(expiry.puts()) << " strikes)\n";
         std::cout << "strike,bid,ask,last,volume,oi,moneyness\n";
-        for (const auto& put : expiry.puts) {
+        for (const auto& put : expiry.puts()) {
             double strike = put.strike.to_double();
             double moneyness = std::log(strike / chain.spot->to_double());
             std::cout << std::setprecision(2) << std::fixed << strike << ","
@@ -112,8 +113,8 @@ int main() {
 
     std::cout << "\nChain built successfully!\n";
     std::cout << "- Expiries: " << chain.expiries.size() << "\n";
-    std::cout << "- Total calls: " << chain.expiries[0].calls.size() << "\n";
-    std::cout << "- Total puts: " << chain.expiries[0].puts.size() << "\n";
+    std::cout << "- Total calls: " << std::ranges::distance(chain.expiries[0].calls()) << "\n";
+    std::cout << "- Total puts: " << std::ranges::distance(chain.expiries[0].puts()) << "\n";
     std::cout << "\nTo compute implied volatilities, provide an IVSolverInterpolated\n";
     std::cout << "with a precomputed price table to compute_vol_surface().\n";
 

--- a/src/simple/BUILD.bazel
+++ b/src/simple/BUILD.bazel
@@ -27,6 +27,7 @@ cc_library(
     deps = [
         ":price",
         ":timestamp",
+        "//src/option:option_spec",
     ],
 )
 

--- a/src/simple/chain_builder.hpp
+++ b/src/simple/chain_builder.hpp
@@ -50,7 +50,9 @@ public:
     ChainBuilder& add_call(T&& expiry, const RawOpt& opt) {
         auto ts = Conv::to_timestamp(std::forward<T>(expiry));
         auto& slice = get_or_create_slice(ts);
-        slice.calls.push_back(Conv::to_leg(opt));
+        auto leg = Conv::to_leg(opt);
+        leg.type = OptionType::CALL;
+        slice.options.push_back(std::move(leg));
         return *this;
     }
 
@@ -58,7 +60,9 @@ public:
     ChainBuilder& add_put(T&& expiry, const RawOpt& opt) {
         auto ts = Conv::to_timestamp(std::forward<T>(expiry));
         auto& slice = get_or_create_slice(ts);
-        slice.puts.push_back(Conv::to_leg(opt));
+        auto leg = Conv::to_leg(opt);
+        leg.type = OptionType::PUT;
+        slice.options.push_back(std::move(leg));
         return *this;
     }
 

--- a/src/simple/vol_surface.hpp
+++ b/src/simple/vol_surface.hpp
@@ -10,6 +10,7 @@
 #include "src/option/iv_solver_fdm.hpp"
 #include <expected>
 #include <memory>
+#include <ranges>
 #include <vector>
 
 namespace mango::simple {
@@ -21,16 +22,30 @@ struct VolatilitySmile {
     Price spot{0.0};
 
     struct Point {
+        OptionType type;          // CALL or PUT
         Price strike{0.0};
-        double moneyness = 0.0;  // log(K/S)
+        double moneyness = 0.0;   // log(K/S)
         std::optional<double> iv_bid;
         std::optional<double> iv_ask;
         std::optional<double> iv_mid;
         std::optional<double> iv_last;
     };
 
-    std::vector<Point> calls;
-    std::vector<Point> puts;
+    std::vector<Point> points;  // All points (calls and puts together)
+
+    /// Get filtered view of calls only
+    [[nodiscard]] auto calls() const {
+        return points | std::views::filter([](const Point& pt) {
+            return pt.type == OptionType::CALL;
+        });
+    }
+
+    /// Get filtered view of puts only
+    [[nodiscard]] auto puts() const {
+        return points | std::views::filter([](const Point& pt) {
+            return pt.type == OptionType::PUT;
+        });
+    }
 };
 
 /// Complete volatility surface

--- a/tests/simple_chain_builder_test.cc
+++ b/tests/simple_chain_builder_test.cc
@@ -50,6 +50,8 @@ TEST(ChainBuilderTest, AddOptions) {
         .build();
 
     EXPECT_EQ(chain.expiries.size(), 1);
-    EXPECT_EQ(chain.expiries[0].calls.size(), 1);
-    EXPECT_DOUBLE_EQ(chain.expiries[0].calls[0].strike.to_double(), 580.0);
+    EXPECT_EQ(chain.expiries[0].options.size(), 1);
+    EXPECT_EQ(std::ranges::distance(chain.expiries[0].calls()), 1);
+    EXPECT_EQ(chain.expiries[0].options[0].type, OptionType::CALL);
+    EXPECT_DOUBLE_EQ(chain.expiries[0].options[0].strike.to_double(), 580.0);
 }

--- a/tests/simple_option_chain_test.cc
+++ b/tests/simple_option_chain_test.cc
@@ -20,16 +20,18 @@ TEST(SimpleOptionChainTest, ChainWithData) {
     slice.settlement = Settlement::PM;
 
     OptionLeg call;
+    call.type = OptionType::CALL;
     call.strike = Price{580.0};
     call.bid = Price{2.85};
     call.ask = Price{2.92};
-    slice.calls.push_back(call);
+    slice.options.push_back(call);
 
     chain.expiries.push_back(std::move(slice));
 
     EXPECT_EQ(chain.symbol, "SPY");
     EXPECT_EQ(chain.expiries.size(), 1);
-    EXPECT_EQ(chain.expiries[0].calls.size(), 1);
+    EXPECT_EQ(chain.expiries[0].options.size(), 1);
+    EXPECT_EQ(std::ranges::distance(chain.expiries[0].calls()), 1);
 }
 
 TEST(SimpleMarketContextTest, DefaultContext) {

--- a/tests/simple_vol_surface_test.cc
+++ b/tests/simple_vol_surface_test.cc
@@ -21,10 +21,11 @@ TEST(VolSurfaceTest, ComputeSmileFromChain) {
     slice.settlement = Settlement::PM;
 
     OptionLeg call;
+    call.type = OptionType::CALL;
     call.strike = Price{580.0};
     call.bid = Price{5.50};
     call.ask = Price{5.70};
-    slice.calls.push_back(call);
+    slice.options.push_back(call);
 
     chain.expiries.push_back(std::move(slice));
 
@@ -43,10 +44,12 @@ TEST(VolSurfaceTest, ComputeSmileFromChain) {
 
 TEST(VolSmileTest, SmilePointStructure) {
     VolatilitySmile::Point pt;
+    pt.type = OptionType::CALL;
     pt.strike = Price{580.0};
     pt.moneyness = 0.0;  // ATM
     pt.iv_mid = 0.15;
 
+    EXPECT_EQ(pt.type, OptionType::CALL);
     EXPECT_DOUBLE_EQ(pt.strike.to_double(), 580.0);
     EXPECT_TRUE(pt.iv_mid.has_value());
 }


### PR DESCRIPTION
## Summary
Fixes API design flaw where `OptionLeg` didn't carry call/put type info, requiring callers to track option type externally.

## Changes
- Add `OptionType type` field to `OptionLeg` struct (mandatory)
- Consolidate separate `calls`/`puts` vectors to single `options` vector
- Add `calls()` and `puts()` filter methods using `std::views::filter`
- Apply same pattern to `VolatilitySmile::Point` and `VolatilitySurface`
- `ChainBuilder::add_call()`/`add_put()` now set the type automatically
- Update all tests and examples to use new API

## API Changes

Before:
```cpp
ExpirySlice slice;
slice.calls.push_back(call_leg);  // Caller tracks type externally
slice.puts.push_back(put_leg);
```

After:
```cpp
ExpirySlice slice;
OptionLeg leg;
leg.type = OptionType::CALL;  // Self-describing
slice.options.push_back(leg);

// Filter views for iteration
for (const auto& call : slice.calls()) { ... }
for (const auto& put : slice.puts()) { ... }
```

## Testing
- All 77 tests pass
- Example builds and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)