### PR TITLE
Add ThreadWorkspaceBuffer design doc

### DIFF
--- a/docs/plans/2025-11-27-thread-workspace-buffer-design.md
+++ b/docs/plans/2025-11-27-thread-workspace-buffer-design.md
@@ -72,7 +72,7 @@ namespace mango {
 /// Per-thread workspace buffer with 64-byte alignment guarantee
 ///
 /// Primary: pmr::monotonic_buffer_resource over 64-byte aligned storage (Linux/glibc via std::aligned_alloc)
-/// Fallback: thread-local pmr::synchronized_pool_resource (if exhausted)
+/// Fallback: thread-local pmr::unsynchronized_pool_resource (if exhausted)
 ///
 /// Design principles:
 /// - Buffer provides raw byte storage (std::byte) with 64-byte alignment
@@ -145,7 +145,9 @@ private:
     }
 
     static std::pmr::memory_resource* get_fallback_pool() {
-        thread_local std::pmr::synchronized_pool_resource pool;
+        // unsynchronized_pool_resource is safe here because the pool is thread_local
+        // No synchronization overhead needed for single-threaded access
+        thread_local std::pmr::unsynchronized_pool_resource pool;
         return &pool;
     }
 


### PR DESCRIPTION
## Summary

Design document for `ThreadWorkspaceBuffer<T>` - a reusable per-thread memory buffer for parallel algorithms.

## Key Components

- **ThreadWorkspaceBuffer<T>**: PMR monotonic buffer with synchronized_pool fallback
- **BSplineCollocationWorkspace**: Zero-allocation workspace for B-spline fitting
- **OpenMP Pattern Analysis**: Audit of all parallel patterns, identifying migration targets
- **Static Dispatch**: Requirement for hot-path function calls to enable inlining

## Impact

For 4D price table (20×10×20×10):
- Before: ~24,000 allocations during B-spline fitting
- After: N (number of threads) allocations

## Migration Plan

- P0: `american_option_batch.cpp`, `bspline_nd_separable.hpp`
- P2 (optional): `iv_solver_fdm.cpp`, `price_table_builder.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)