### PR TITLE
Add module declaration for Bzlmod compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,7 @@
-# This is a MODULE.bazel file
+module(
+    name = "mango-option",
+    version = "0.1.0",
+)
 
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "google_benchmark", version = "1.9.4")


### PR DESCRIPTION
## Summary
- Add `module()` declaration to MODULE.bazel

## Motivation
Required when mango-option is used as a `bazel_dep` with `local_path_override` from another Bazel module.

Without the module declaration, Bzlmod fails with:
```
ERROR: module() must be called before any other functions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)