### PR TITLE
feat: add autogrid profiles and python builder wrapper

### DIFF
--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -399,6 +399,42 @@ auto result3 = mango::PriceTableBuilder<4>::from_chain(
 // All return std::expected<std::pair<builder, axes>, std::string>
 ```
 
+### Automatic Grid Profiles
+
+**Use profiles to auto-estimate both table grids and PDE grid/time steps:**
+
+```cpp
+auto result = mango::PriceTableBuilder<4>::from_chain_auto_profile(
+    option_chain,
+    mango::PriceTableGridProfile::Medium,
+    mango::GridAccuracyProfile::Medium,
+    mango::OptionType::PUT);
+
+auto [builder, axes] = result.value();
+auto surface_result = builder.build(axes);
+```
+
+**Python convenience wrapper:**
+
+```python
+import mango_option as mo
+
+chain = mo.OptionChain()
+chain.spot = 100.0
+chain.strikes = [90, 95, 100, 105, 110]
+chain.maturities = [0.25, 0.5, 1.0]
+chain.implied_vols = [0.15, 0.20, 0.25]
+chain.rates = [0.02, 0.03]
+chain.dividend_yield = 0.0
+
+surface = mo.build_price_table_surface_from_chain(
+    chain,
+    option_type=mo.OptionType.PUT,
+    grid_profile=mo.PriceTableGridProfile.MEDIUM,
+    pde_profile=mo.GridAccuracyProfile.MEDIUM,
+)
+```
+
 ### Batch Queries on Price Surface
 
 **Evaluate many points efficiently:**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -483,6 +483,36 @@ auto [builder, axes] = PriceTableBuilder<4>::from_chain_auto(
 ).value();
 ```
 
+Or use the top-level wrapper that estimates both table grids and PDE grid/time steps:
+```cpp
+auto [builder, axes] = PriceTableBuilder<4>::from_chain_auto_profile(
+    chain,
+    PriceTableGridProfile::Medium,
+    GridAccuracyProfile::Medium,
+    OptionType::PUT
+).value();
+```
+
+Python helper (builds the surface directly):
+```python
+import mango_option as mo
+
+chain = mo.OptionChain()
+chain.spot = 100.0
+chain.strikes = [90, 95, 100, 105, 110]
+chain.maturities = [0.25, 0.5, 1.0]
+chain.implied_vols = [0.15, 0.20, 0.25]
+chain.rates = [0.02, 0.03]
+chain.dividend_yield = 0.0
+
+surface = mo.build_price_table_surface_from_chain(
+    chain,
+    option_type=mo.OptionType.PUT,
+    grid_profile=mo.PriceTableGridProfile.MEDIUM,
+    pde_profile=mo.GridAccuracyProfile.MEDIUM,
+)
+```
+
 Grid density is determined by curvature-based budget allocation:
 - σ (volatility): 1.5× weight (highest curvature, vega non-linearity)
 - m (moneyness): 1.0× (ATM gamma peak handled by log-transform)

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -7,6 +7,8 @@ pybind_extension(
         "//src/option:iv_solver_fdm",
         "//src/option:iv_solver_interpolated",
         "//src/option:american_option",
+        "//src/option:option_chain",
+        "//src/option/table:price_table_builder",
         "//src/option/table:price_table_workspace",
         "//src/option/table:price_table_surface",
         "//src/math:root_finding",

--- a/src/option/american_option.hpp
+++ b/src/option/american_option.hpp
@@ -61,6 +61,37 @@ struct GridAccuracyParams {
     size_t max_time_steps = 5000;
 };
 
+enum class GridAccuracyProfile {
+    Fast,
+    Medium,
+    Accurate
+};
+
+inline GridAccuracyParams grid_accuracy_profile(GridAccuracyProfile profile) {
+    GridAccuracyParams params;
+    switch (profile) {
+        case GridAccuracyProfile::Fast:
+            params.tol = 1e-2;
+            params.min_spatial_points = 100;
+            params.max_spatial_points = 800;
+            params.max_time_steps = 3000;
+            break;
+        case GridAccuracyProfile::Medium:
+            params.tol = 5e-3;
+            params.min_spatial_points = 150;
+            params.max_spatial_points = 1500;
+            params.max_time_steps = 6000;
+            break;
+        case GridAccuracyProfile::Accurate:
+            params.tol = 5e-5;
+            params.min_spatial_points = 201;
+            params.max_spatial_points = 2500;
+            params.max_time_steps = 12000;
+            break;
+    }
+    return params;
+}
+
 /**
  * Estimate grid specification from option parameters.
  *

--- a/src/option/table/price_table_builder.hpp
+++ b/src/option/table/price_table_builder.hpp
@@ -168,6 +168,23 @@ public:
         OptionType type = OptionType::PUT,
         const PriceTableGridAccuracyParams<4>& accuracy = {});
 
+    /// Top-level wrapper: estimate both price table grids and PDE grid from profiles
+    ///
+    /// Uses grid estimation for table axes (m, tau, sigma, r) and
+    /// computes a PDE grid/time domain via compute_global_grid_for_batch().
+    ///
+    /// @param chain Option chain (provides domain bounds)
+    /// @param grid_profile Accuracy profile for price table grid estimation
+    /// @param pde_profile Accuracy profile for PDE grid/time domain estimation
+    /// @param type Option type (PUT or CALL)
+    /// @return Pair of (builder, axes) or error
+    static std::expected<std::pair<PriceTableBuilder<4>, PriceTableAxes<4>>, PriceTableError>
+    from_chain_auto_profile(
+        const OptionChain& chain,
+        PriceTableGridProfile grid_profile = PriceTableGridProfile::Medium,
+        GridAccuracyProfile pde_profile = GridAccuracyProfile::Medium,
+        OptionType type = OptionType::PUT);
+
     /// For testing: expose make_batch method
     [[nodiscard]] std::vector<AmericanOptionParams> make_batch_for_testing(
         const PriceTableAxes<N>& axes) const {

--- a/src/option/table/price_table_grid_estimator.hpp
+++ b/src/option/table/price_table_grid_estimator.hpp
@@ -22,6 +22,12 @@
 
 namespace mango {
 
+enum class PriceTableGridProfile {
+    Fast,
+    Medium,
+    Accurate
+};
+
 /**
  * @brief Grid estimation accuracy parameters for N-dimensional price table
  *
@@ -285,6 +291,33 @@ inline PriceTableGridEstimate<4> estimate_grid_from_chain_bounds(
         sigma_min, sigma_max,
         r_min, r_max,
         params);
+}
+
+inline PriceTableGridAccuracyParams<4> grid_accuracy_profile(
+    PriceTableGridProfile profile)
+{
+    PriceTableGridAccuracyParams<4> params;
+    switch (profile) {
+        case PriceTableGridProfile::Fast:
+            params.target_iv_error = 0.001;  // 10 bps target
+            params.min_points = 4;
+            params.max_points = 50;
+            params.curvature_weights = {1.0, 1.0, 1.5, 0.6};
+            break;
+        case PriceTableGridProfile::Medium:
+            params.target_iv_error = 0.0005;  // 5 bps target
+            params.min_points = 6;
+            params.max_points = 80;
+            params.curvature_weights = {1.0, 1.0, 1.7, 0.6};
+            break;
+        case PriceTableGridProfile::Accurate:
+            params.target_iv_error = 0.0002;  // 2 bps target
+            params.min_points = 8;
+            params.max_points = 120;
+            params.curvature_weights = {1.0, 1.0, 2.0, 0.6};
+            break;
+    }
+    return params;
 }
 
 }  // namespace mango

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -199,6 +199,7 @@ cc_test(
     srcs = ["price_table_grid_estimator_test.cc"],
     deps = [
         "//src/option/table:price_table_grid_estimator",
+        "//src/option:american_option",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/tests/price_table_grid_estimator_test.cc
+++ b/tests/price_table_grid_estimator_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "src/option/table/price_table_grid_estimator.hpp"
+#include "src/option/american_option.hpp"
 
 namespace mango {
 namespace {
@@ -18,6 +19,36 @@ TEST(PriceTableGridEstimatorTest, DefaultParamsAre4D) {
     EXPECT_DOUBLE_EQ(params.curvature_weights[1], 1.0);   // maturity
     EXPECT_DOUBLE_EQ(params.curvature_weights[2], 1.5);   // volatility (highest)
     EXPECT_DOUBLE_EQ(params.curvature_weights[3], 0.6);   // rate (lowest)
+}
+
+TEST(PriceTableGridEstimatorTest, ProfileOrdering) {
+    auto fast = grid_accuracy_profile(PriceTableGridProfile::Fast);
+    auto medium = grid_accuracy_profile(PriceTableGridProfile::Medium);
+    auto accurate = grid_accuracy_profile(PriceTableGridProfile::Accurate);
+
+    EXPECT_GT(fast.target_iv_error, medium.target_iv_error);
+    EXPECT_GT(medium.target_iv_error, accurate.target_iv_error);
+
+    EXPECT_LT(fast.min_points, medium.min_points);
+    EXPECT_LT(medium.min_points, accurate.min_points);
+
+    EXPECT_LT(fast.max_points, medium.max_points);
+    EXPECT_LT(medium.max_points, accurate.max_points);
+}
+
+TEST(PriceTableGridEstimatorTest, PdeProfileOrdering) {
+    auto fast = grid_accuracy_profile(GridAccuracyProfile::Fast);
+    auto medium = grid_accuracy_profile(GridAccuracyProfile::Medium);
+    auto accurate = grid_accuracy_profile(GridAccuracyProfile::Accurate);
+
+    EXPECT_GT(fast.tol, medium.tol);
+    EXPECT_GT(medium.tol, accurate.tol);
+
+    EXPECT_LT(fast.min_spatial_points, medium.min_spatial_points);
+    EXPECT_LT(medium.min_spatial_points, accurate.min_spatial_points);
+
+    EXPECT_LT(fast.max_spatial_points, medium.max_spatial_points);
+    EXPECT_LT(medium.max_spatial_points, accurate.max_spatial_points);
 }
 
 TEST(PriceTableGridEstimatorTest, EstimateGridForPriceTable_DefaultParams) {


### PR DESCRIPTION
## Summary
- add autogrid profiles for price-table grids and PDE grids
- add top-level C++ wrapper `from_chain_auto_profile` that chooses grids/time steps via profiles
- expose Python bindings for OptionChain + chain-based surface builder and profile enums
- update docs (README, API_GUIDE, ARCHITECTURE) with C++/Python examples
- add tests for profile ordering; adjust QuantLib interpolated IV test to use accurate profiles

## Testing
- bazel test //tests:price_table_grid_estimator_test
- bazel build //python:mango_option
