### PR TITLE
Add simple API convenience functions and price table wrapper

### DIFF
--- a/src/simple/BUILD.bazel
+++ b/src/simple/BUILD.bazel
@@ -71,9 +71,18 @@ cc_library(
     name = "pricing",
     srcs = ["pricing.cpp"],
     hdrs = ["pricing.hpp"],
+    copts = [
+        "-fopenmp",
+        "-pthread",
+    ],
+    linkopts = [
+        "-fopenmp",
+        "-pthread",
+    ],
     deps = [
         ":option_types",
         "//src/option:american_option",
+        "//src/option:american_option_batch",
         "//src/option:iv_solver_fdm",
         "//src/option:option_spec",
         "//src/pde/core:grid",

--- a/src/simple/pricing.hpp
+++ b/src/simple/pricing.hpp
@@ -4,10 +4,13 @@
 #include "src/option/option_spec.hpp"
 #include <expected>
 #include <string>
+#include <vector>
 
 namespace mango::simple {
 
 using mango::OptionType;
+using mango::PricingParams;
+using mango::IVQuery;
 
 /// Price an American option using finite difference methods
 ///
@@ -44,5 +47,36 @@ std::expected<double, std::string> implied_vol(
     double market_price, double rate,
     double dividend_yield = 0.0,
     OptionType type = OptionType::PUT);
+
+/// Result for a single option in a batch
+struct BatchPriceResult {
+    std::vector<std::expected<double, std::string>> prices;
+    size_t failed_count = 0;
+};
+
+/// Result for a single IV query in a batch
+struct BatchIVResult {
+    std::vector<std::expected<double, std::string>> vols;
+    size_t failed_count = 0;
+};
+
+/// Price a batch of American options in parallel
+///
+/// Uses BatchAmericanOptionSolver with automatic routing to the
+/// normalized chain solver when eligible (same maturity, no discrete
+/// dividends). This provides up to 19,000x speedup for option chains.
+///
+/// @param params Vector of pricing parameters
+/// @return BatchPriceResult with per-option prices and failure count
+BatchPriceResult price_batch(const std::vector<PricingParams>& params);
+
+/// Compute implied volatility for a batch of options in parallel
+///
+/// Uses IVSolverFDM with OpenMP parallelization. Each query is solved
+/// independently using Brent's method.
+///
+/// @param queries Vector of IV queries
+/// @return BatchIVResult with per-query IVs and failure count
+BatchIVResult implied_vol_batch(const std::vector<IVQuery>& queries);
 
 }  // namespace mango::simple


### PR DESCRIPTION
## Summary
- Add `mango::simple::price()` and `implied_vol()` free functions for one-liner American option pricing and IV calculation
- Add `PriceTable` wrapper with `build_price_table()`, `save()`/`load_price_table()` (Arrow IPC), and `make_iv_solver()`
- Add `coefficients()` accessor to `PriceTableSurface` for serialization support

## Changes
- **New**: `src/simple/pricing.hpp` + `.cpp` — convenience pricing and IV functions
- **New**: `src/simple/price_table.hpp` + `.cpp` — PriceTable wrapper with persistence
- **Modified**: `src/option/table/price_table_surface.hpp` — added `coefficients()` accessor
- **Modified**: `src/simple/BUILD.bazel` — added `pricing` and `price_table` targets
- **Modified**: `src/simple/simple.hpp` — umbrella header includes new modules
- **New**: `tests/simple_pricing_test.cc` — 8 tests (ATM/ITM/OTM pricing, invalid inputs, IV roundtrip)
- **New**: `tests/simple_price_table_test.cc` — 4 tests (build, query, save/load roundtrip, make_iv_solver)
- **New**: `docs/SIMPLE_API.md` — usage guide

## Test plan
- [x] All 102 tests pass: `bazel test //...`
- [x] Benchmarks compile: `bazel build //benchmarks/...`
- [x] Python bindings compile: `bazel build //src/python:mango_option`

🤖 Generated with [Claude Code](https://claude.com/claude-code)