### PR TITLE
Tune price table grid accuracy profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Batch processing (64 options): 10x speedup with OpenMP (~0.13ms/option parallel 
 | Method | Time/IV | Accuracy |
 |---|---|---|
 | FDM-based | ~19ms | Ground truth |
-| Interpolated (B-spline) | ~3.5us | 12-48 bps |
+| Interpolated (B-spline) | ~3.5us | 5-48 bps |
 
 The interpolation path is 5,400x faster than FDM. You pre-compute a 4D price table (moneyness x maturity x vol x rate), then query it with B-spline interpolation.
 
@@ -113,12 +113,12 @@ The table below shows the accuracy/speed tradeoff across grid density profiles, 
 
 | Profile | Grid (mxTxσxr) | PDE solves | Interp IV | Max err (bps) | Avg err (bps) |
 |---|---:|---:|---:|---:|---:|
-| Low | 8x8x20x5 | 100 | ~5us | 179 | 63 |
-| Medium | 12x12x30x8 | 240 | ~5us | 62 | 21 |
-| High (default) | 18x18x45x11 | 495 | ~5us | 23 | 7.8 |
-| Ultra | 24x24x58x14 | 812 | ~5us | 12 | 4.1 |
+| Low | 8x8x20x5 | 100 | ~5us | 84 | 48 |
+| Medium | 12x12x30x8 | 240 | ~4us | 66 | 22 |
+| High (default) | 18x18x45x11 | 495 | ~4us | 21 | 7.5 |
+| Ultra | 24x24x58x14 | 812 | ~4us | 11 | 5.1 |
 
-Use `from_chain_auto_profile()` with Low/Medium/High/Ultra to control this tradeoff. The default (High) targets ~8 bps average error. Ultra achieves ~4 bps at the cost of ~800 PDE solves during table construction.
+Use `from_chain_auto_profile()` with Low/Medium/High/Ultra to control this tradeoff. The default (High) targets ~8 bps average error. Ultra achieves ~5 bps at the cost of ~800 PDE solves during table construction.
 
 For detailed profiling data, see [docs/PERF_ANALYSIS.md](docs/PERF_ANALYSIS.md).
 

--- a/src/option/table/price_table_grid_estimator.hpp
+++ b/src/option/table/price_table_grid_estimator.hpp
@@ -299,30 +299,26 @@ inline PriceTableGridAccuracyParams<4> grid_accuracy_profile(
     PriceTableGridProfile profile)
 {
     PriceTableGridAccuracyParams<4> params;
+    // Uniform curvature weights across all profiles: sigma gets 2.5x weight
+    // (highest curvature from vega non-linearity), rate gets 0.6x (nearly linear).
+    params.curvature_weights = {1.0, 1.0, 2.5, 0.6};
+    params.min_points = 4;  // B-spline minimum
     switch (profile) {
         case PriceTableGridProfile::Low:
-            params.target_iv_error = 0.0005;  // 5 bps target
-            params.min_points = 6;
+            params.target_iv_error = 5e-4;   // → 8x8x20x5
             params.max_points = 80;
-            params.curvature_weights = {1.0, 1.0, 1.7, 0.6};
             break;
         case PriceTableGridProfile::Medium:
-            params.target_iv_error = 0.0002;  // 2 bps target
-            params.min_points = 8;
+            params.target_iv_error = 1e-4;   // → 12x12x30x8
             params.max_points = 120;
-            params.curvature_weights = {1.0, 1.0, 2.0, 0.6};
             break;
         case PriceTableGridProfile::High:
-            params.target_iv_error = 0.0001;  // 1 bps target
-            params.min_points = 10;
+            params.target_iv_error = 2e-5;   // → 18x18x45x11
             params.max_points = 160;
-            params.curvature_weights = {1.0, 1.0, 2.5, 0.6};
             break;
         case PriceTableGridProfile::Ultra:
-            params.target_iv_error = 0.00005;  // 0.5 bps target
-            params.min_points = 12;
+            params.target_iv_error = 7e-6;   // → 24x24x58x14
             params.max_points = 200;
-            params.curvature_weights = {1.0, 1.0, 3.0, 0.6};
             break;
     }
     return params;

--- a/tests/price_table_grid_estimator_test.cc
+++ b/tests/price_table_grid_estimator_test.cc
@@ -32,13 +32,9 @@ TEST(PriceTableGridEstimatorTest, ProfileOrdering) {
     EXPECT_GT(medium.target_iv_error, high.target_iv_error);
     EXPECT_GT(high.target_iv_error, ultra.target_iv_error);
 
-    EXPECT_LT(low.min_points, medium.min_points);
-    EXPECT_LT(medium.min_points, high.min_points);
-    EXPECT_LT(high.min_points, ultra.min_points);
-
-    EXPECT_LT(low.max_points, medium.max_points);
-    EXPECT_LT(medium.max_points, high.max_points);
-    EXPECT_LT(high.max_points, ultra.max_points);
+    EXPECT_LE(low.max_points, medium.max_points);
+    EXPECT_LE(medium.max_points, high.max_points);
+    EXPECT_LE(high.max_points, ultra.max_points);
 }
 
 TEST(PriceTableGridEstimatorTest, PdeProfileOrdering) {


### PR DESCRIPTION
## Summary
- Unify curvature weights across all grid profiles (sigma 2.5x, rate 0.6x) instead of per-profile values
- Calibrate `target_iv_error` to match observed grid sizes from accuracy sweep
- Update README accuracy table with measured results from SPY option data

## Changes
- `price_table_grid_estimator.hpp`: Consolidate curvature weights, adjust target errors, set uniform min_points=4
- `price_table_grid_estimator_test.cc`: Relax ordering assertions (min_points now uniform)
- `README.md`: Update interpolation accuracy numbers (e.g., High profile: 21 bps max / 7.5 bps avg)

## Testing
- `bazel test //tests:price_table_grid_estimator_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)