### PR TITLE
Fix Docker build and use pre-built CI image

### DIFF
--- a/.github/CI_SETUP.md
+++ b/.github/CI_SETUP.md
@@ -4,152 +4,90 @@
 
 This project uses a multi-layer caching strategy to speed up CI runs:
 
-### 1. Docker Image Caching (System Dependencies)
+### 1. Docker Image (System Dependencies)
 
-**Problem:** Installing system dependencies (`apt-get install`) takes significant time on every CI run.
+**Problem:** Installing system dependencies (`apt-get install`) takes 2-3 minutes on every CI run.
 
-**Solution:** We maintain a custom Docker image with all dependencies pre-installed, using a combination of optimizations:
+**Solution:** A custom Docker image with all dependencies pre-installed.
 
-- **Base Image:** `debian:trixie-slim` (~40% smaller than full trixie)
+- **Base Image:** `debian:trixie-slim`
 - **Image Location:** `ghcr.io/<repo>/ci-env:latest`
 - **Dockerfile:** `.github/Dockerfile`
-- **Build Workflow:** `.github/workflows/docker-build.yml`
-- **Build Cache:** GitHub Actions cache (`type=gha`) for Docker layers
 
 The Docker image includes:
 - git, wget, ca-certificates
-- build-essential (gcc, g++, make)
-- python3
-- systemtap-sdt-dev (for USDT tracing)
-- libquantlib0-dev (for benchmarks)
-
-**Optimizations applied:**
-- `debian:trixie-slim` base (smaller footprint)
-- `--no-install-recommends` flag (minimal dependencies)
-- Aggressive cleanup (`apt-get clean`, remove temp files)
-- GitHub Actions cache for Docker build layers
+- build-essential, clang
+- python3, python3-numpy, python3-dev
+- systemtap-sdt-dev (USDT tracing)
+- libquantlib0-dev (benchmarks)
+- liblapacke-dev
+- libarrow-dev (Apache Arrow)
+- Bazelisk (as `/usr/local/bin/bazel`)
 
 **How it works:**
-1. When `Dockerfile` changes, `docker-build.yml` automatically builds and publishes a new image to GitHub Container Registry (GHCR)
-2. Docker build layers are cached in GitHub Actions cache (free, 10 GB limit)
-3. The CI workflow (`ci.yml`) uses this cached image, skipping dependency installation
-4. Subsequent builds reuse cached layers, making rebuilds very fast
-
-**Estimated image size:** 300-400 MB compressed (vs 500-650 MB with full trixie)
+1. The CI workflow checks if the image exists in GHCR
+2. If missing or Dockerfile changed, it builds and pushes automatically
+3. The build-and-test job runs inside this pre-built container
+4. Docker build layers are cached via GitHub Actions cache
 
 **Rebuilding the image:**
 ```bash
-# Automatic: Push changes to .github/Dockerfile
-git add .github/Dockerfile
-git commit -m "Update CI dependencies"
-git push
-
-# Manual trigger: Go to Actions → Build and Publish Docker Image → Run workflow
+# Automatic: push changes to .github/Dockerfile
+# Manual: Actions → Build and Publish Docker Image → Run workflow
+# Or: gh workflow run docker-build.yml
 ```
 
 ### 2. Bazel Caching
 
-The CI workflow caches three Bazel-related paths:
+The CI workflow caches two Bazel-related paths:
 
-1. **Bazelisk binary** (`~/.bazelisk-cache`) - The Bazel launcher itself
-2. **Bazel versions** (`~/.cache/bazelisk`) - Downloaded Bazel versions
-3. **Build artifacts** (`~/.cache/bazel`) - Compiled objects and dependencies
+1. **Bazel versions** (`~/.cache/bazelisk`) — keyed on `.bazelversion`
+2. **Build artifacts** (`~/.cache/bazel`) — keyed on `.bazelversion` + `MODULE.bazel` + commit SHA
 
-Key features:
-- Build cache key includes all Bazel config files (`.bazelversion`, `MODULE.bazel`, `**/*.bazel`, `**/*.bzl`)
-- Restore-keys provide fallback to partial cache hits
-- External dependencies (GoogleTest, Benchmark) are cached between runs
+The commit SHA in the cache key ensures each run can save fresh artifacts (GitHub Actions caches are immutable). The `restore-keys` prefix provides partial cache hits from prior runs.
 
-## Cache Hit Rates
+## Expected CI Times
 
-Typical CI run times:
-
-| Scenario | Time | Notes |
-|----------|------|-------|
-| Cold start (no cache) | ~5-7 min | First run ever |
-| Docker rebuild (Dockerfile changed) | ~3-4 min | GitHub Actions cache speeds up build |
-| Warm (full cache) | ~1-2 min | No code changes |
-| Partial (code changed) | ~2-4 min | Bazel rebuilds only changed targets |
-
-**Storage usage:**
-- GHCR image: ~300-400 MB (compressed)
-- GitHub Actions cache: ~500-800 MB (Docker layers)
-- Bazel cache: ~100-500 MB (build artifacts)
-- **Total: ~1-2 GB** (well within free tiers)
-
-## Cost Considerations
-
-**Public repositories:** FREE
-- GHCR storage: Unlimited
-- GHCR bandwidth: Unlimited
-- GitHub Actions cache: 10 GB free
-
-**Private repositories:**
-- GHCR storage: 500 MB free, then $0.25/GB/month
-  - Our image (~350 MB): **FREE** (under limit)
-- GHCR bandwidth: 1 GB free/month
-  - CI pulls are usually free (same network)
-- GitHub Actions cache: 10 GB free
-  - Our total usage (~1-2 GB): **FREE**
-
-**Bottom line:** Cost is $0 for most cases, or ~$0.05/month worst case for private repos.
+| Scenario | Time |
+|----------|------|
+| Cold start (no cache, no image) | ~5-7 min |
+| Image exists, no Bazel cache | ~3-4 min |
+| Warm (image + Bazel cache) | ~1-2 min |
+| Partial (code changed) | ~2-3 min |
 
 ## First-Time Setup
 
-The first time you push the Dockerfile, you need to:
+The first CI run builds and pushes the Docker image automatically. For public repos, make the GHCR package public:
 
-1. **Make the image public** (optional, for public repos):
-   - Go to `github.com/<org>/<repo>/packages`
-   - Find the `ci-env` package
-   - Settings → Change visibility → Public
-
-2. **Or ensure GHCR credentials work** (done automatically via `GITHUB_TOKEN`)
+1. Go to `github.com/<org>/<repo>/packages`
+2. Find the `ci-env` package
+3. Settings → Change visibility → Public
 
 ## Updating Dependencies
 
-To add or update system dependencies:
-
 1. Edit `.github/Dockerfile`
-2. Add the new package to the `apt-get install` line
-3. Commit and push
-4. The `docker-build.yml` workflow will automatically build and publish the new image
-5. Future CI runs will use the updated image
+2. Commit and push
+3. CI detects the Dockerfile change and rebuilds the image
 
-Example:
-```dockerfile
-RUN apt-get update && \
-    apt-get install -y \
-        git \
-        wget \
-        ca-certificates \
-        build-essential \
-        python3 \
-        systemtap-sdt-dev \
-        libquantlib0-dev \
-        NEW_PACKAGE_HERE && \
-    rm -rf /var/lib/apt/lists/*
+## Slow Tests
+
+Nightly coverage for slow Bazel targets runs via `.github/workflows/slow-tests.yml` (also supports manual trigger). Slow tests are tagged with `slow` and excluded from the fast CI job.
+
+```bash
+# Run locally
+bazel test //tests/... --test_tag_filters=slow
 ```
 
 ## Troubleshooting
-### Slow Test Workflow
-
-- Nightly coverage for the slow Bazel targets runs via `.github/workflows/slow-tests.yml`. The workflow also supports manual triggering through *Run workflow*.
-- Slow tests are the targets tagged with `slow` (currently `implied_volatility_test`, `adaptive_accuracy_test`, and `price_table_slow_test`). They stay out of the fast CI job to keep PR feedback tight.
-- To reproduce the nightly job locally:
-  ```bash
-  bazel test //tests:slow_tests
-  ```
 
 **CI fails with "image not found":**
-- The Docker image hasn't been built yet
-- Manually trigger `docker-build.yml` workflow
-- Or temporarily use `debian:trixie` as fallback image
+- First run: the `docker-image` job builds it automatically
+- Manual fix: trigger `docker-build.yml` via workflow_dispatch
 
 **Slow builds despite caching:**
-- Check if cache is being invalidated (Bazel config changes)
-- Verify Docker image is being pulled successfully
-- Check GitHub Actions cache size limits (10 GB per repository)
+- Check Bazel cache restore in CI logs ("Cache restored from key...")
+- Verify Docker image pull succeeds (check `docker-image` job)
+- Check GitHub Actions cache size (10 GB limit per repository)
 
 **Stale dependencies:**
-- Rebuild the Docker image by pushing an update to `Dockerfile`
-- Or trigger `docker-build.yml` manually with workflow_dispatch
+- Edit `.github/Dockerfile` and push — CI rebuilds the image automatically

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,25 +1,34 @@
 # Dockerfile for mango-option CI environment
 # This image pre-installs all dependencies to speed up CI runs
-# Uses trixie-slim base for smaller size (~40% reduction)
 FROM debian:trixie-slim
 
 # Install all required dependencies
-# Using --no-install-recommends to minimize image size
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git \
         wget \
         ca-certificates \
         build-essential \
+        clang \
         python3 \
+        python3-numpy \
+        python3-dev \
         systemtap-sdt-dev \
         libquantlib0-dev \
         liblapacke-dev && \
+    # Add Apache Arrow repository and install
+    wget -q https://apache.jfrog.io/artifactory/arrow/debian/apache-arrow-apt-source-latest-trixie.deb && \
+    apt-get install -y ./apache-arrow-apt-source-latest-trixie.deb && \
+    rm apache-arrow-apt-source-latest-trixie.deb && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libarrow-dev && \
+    # Install Bazelisk
+    wget -q https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 -O /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel && \
+    # Clean up
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Set working directory
 WORKDIR /workspace
 
-# Default command
 CMD ["/bin/bash"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,46 +11,79 @@ on:
       - master
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  # Build the CI Docker image if Dockerfile changed, otherwise use cached
+  docker-image:
+    name: CI Image
     runs-on: ubuntu-latest
-    container:
-      image: debian:trixie
-
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.image.outputs.name }}
     steps:
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y git wget ca-certificates build-essential clang systemtap-sdt-dev libquantlib0-dev liblapacke-dev python3 python3-numpy python3-dev
-
-          # Add Apache Arrow repository
-          wget https://apache.jfrog.io/artifactory/arrow/debian/apache-arrow-apt-source-latest-trixie.deb
-          apt-get install -y ./apache-arrow-apt-source-latest-trixie.deb
-          apt-get update
-
-          # Install Arrow
-          apt-get install -y libarrow-dev
-
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache Bazelisk binary
-        id: cache-bazelisk
-        uses: actions/cache@v4
+      - name: Set image name
+        id: image
+        run: echo "name=ghcr.io/${{ github.repository }}/ci-env:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Check if image exists
+        id: check
+        run: |
+          if docker pull ghcr.io/${{ github.repository }}/ci-env:latest 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Dockerfile changes
+        id: diff
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin ${{ github.base_ref }} --depth=1
+            if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '.github/Dockerfile'; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists != 'true' || steps.diff.outputs.changed == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.check.outputs.exists != 'true' || steps.diff.outputs.changed == 'true'
+        uses: docker/login-action@v3
         with:
-          path: ~/.bazelisk-cache
-          key: bazelisk-binary-${{ runner.os }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Bazelisk
-        if: steps.cache-bazelisk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.bazelisk-cache
-          wget -q https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 -O ~/.bazelisk-cache/bazelisk
-          chmod +x ~/.bazelisk-cache/bazelisk
+      - name: Build and push image
+        if: steps.check.outputs.exists != 'true' || steps.diff.outputs.changed == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .github
+          file: .github/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/ci-env:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Setup Bazelisk in PATH
-        run: |
-          ln -sf ~/.bazelisk-cache/bazelisk /usr/local/bin/bazel
+  build-and-test:
+    name: Build and Test
+    needs: docker-image
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/ci-env:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Cache Bazel versions
         uses: actions/cache@v4
@@ -65,10 +98,10 @@ jobs:
             ~/.cache/bazel
           # Unique key per run so each CI job can save updated artifacts.
           # restore-keys ensures partial cache hits from prior runs.
-          key: debian-trixie-bazel-v4-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-${{ github.sha }}
+          key: bazel-v5-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-${{ github.sha }}
           restore-keys: |
-            debian-trixie-bazel-v4-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-
-            debian-trixie-bazel-v4-
+            bazel-v5-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-
+            bazel-v5-
 
       - name: Build all targets
         run: bazel build //... --build_tag_filters=-benchmark
@@ -78,8 +111,6 @@ jobs:
 
       - name: Build benchmarks
         run: |
-          # Build all benchmarks to ensure they compile
-          # (tagged as manual, so not built by //...)
           bazel build //benchmarks:component_performance
           bazel build //benchmarks:readme_benchmarks
           bazel build //benchmarks:quantlib_performance
@@ -90,8 +121,6 @@ jobs:
 
       - name: Run test suite
         run: |
-          # Run all tests except those tagged as manual
-          # (manual tests are benchmarks and diagnostic tools)
           bazel test //tests/... --test_output=errors --test_tag_filters=-manual
 
       - name: Display test results

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -10,34 +10,11 @@ jobs:
     name: Run Slow Test Suite
     runs-on: ubuntu-latest
     container:
-      image: debian:trixie
+      image: ghcr.io/${{ github.repository }}/ci-env:latest
 
     steps:
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y git wget ca-certificates build-essential clang python3 systemtap-sdt-dev libquantlib0-dev liblapacke-dev
-
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Cache Bazelisk binary
-        id: cache-bazelisk
-        uses: actions/cache@v4
-        with:
-          path: ~/.bazelisk-cache
-          key: bazelisk-binary-${{ runner.os }}
-
-      - name: Install Bazelisk
-        if: steps.cache-bazelisk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.bazelisk-cache
-          wget -q https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 -O ~/.bazelisk-cache/bazelisk
-          chmod +x ~/.bazelisk-cache/bazelisk
-
-      - name: Setup Bazelisk in PATH
-        run: |
-          ln -sf ~/.bazelisk-cache/bazelisk /usr/local/bin/bazel
 
       - name: Cache Bazel versions
         uses: actions/cache@v4
@@ -50,10 +27,10 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: debian-trixie-bazel-slow-v2-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-${{ github.sha }}
+          key: bazel-slow-v2-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-${{ github.sha }}
           restore-keys: |
-            debian-trixie-bazel-slow-v2-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-
-            debian-trixie-bazel-slow-v2-
+            bazel-slow-v2-${{ hashFiles('.bazelversion', 'MODULE.bazel') }}-
+            bazel-slow-v2-
 
       - name: Build all targets
         run: bazel build //... --build_tag_filters=-benchmark


### PR DESCRIPTION
## Summary
- Fix Dockerfile: add missing clang, python3-numpy, python3-dev, libarrow-dev, Bazelisk
- CI auto-builds and pushes Docker image when missing or Dockerfile changes
- Remove per-run `apt-get install` (~2-3 min savings per CI job)
- Apply same changes to slow-tests workflow

## Test plan
- [x] First run: `docker-image` job builds and pushes to GHCR
- [ ] Second run: skips image build, pulls from GHCR
- [ ] Verify all tests pass inside the container
- [ ] Verify Bazel cache key with `github.sha` saves fresh artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)