### PR TITLE
Add hedron_compile_commands for IDE support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     version = "0.1.0",
 )
 
-bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1")
 bazel_dep(name = "google_benchmark", version = "1.9.4")
 
 # FuzzTest for property-based fuzz testing
@@ -14,9 +14,17 @@ bazel_dep(name = "google_benchmark", version = "1.9.4")
 # Run fuzz tests via: earthly +fuzz-test
 bazel_dep(name = "fuzztest", version = "20241028.0")
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")
-bazel_dep(name = "rules_python", version = "0.34.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "platforms", version = "0.0.11")
+
+# Compile commands for IDE support (clangd, etc.)
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+    commit = "abb61a688167623088f8768cc9264798df6a9d10",
+)
 
 # Register C++ toolchain with C++23 support
 register_toolchains("//toolchain:cc_toolchain_for_k8")


### PR DESCRIPTION
## Summary

Add compile_commands.json generation for IDE support (clangd, etc.)

## Changes

- Add `hedron_compile_commands` dev dependency
- Update `googletest` to 1.14.0.bcr.1 (eliminates version warning)
- Update `rules_python` to 1.0.0 (eliminates version warning)

## Usage

```bash
bazel run @hedron_compile_commands//:refresh_all
```

## Test Plan

- [x] `bazel build //...` succeeds
- [x] `bazel test //...` passes
- [x] `compile_commands.json` generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)