### PR TITLE
Refactor include paths from src/ to mango/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ mango-option/
 ### Pricing American Options
 
 ```cpp
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 
 // Define option parameters
 mango::PricingParams params(
@@ -113,7 +113,7 @@ All tests use GoogleTest:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 
 TEST(AmericanOptionTest, ATMPut) {
     mango::PricingParams params{...};
@@ -166,7 +166,7 @@ TEST(RateSpecTest, TimeConversionForUpslopingCurve) {
 
 **Pattern 1: American IV Calculation**
 ```cpp
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 
 mango::IVQuery query(spec, 10.45);
 mango::IVSolver solver(config);
@@ -175,9 +175,9 @@ auto result = solver.solve(query);
 
 **Pattern 2: Price Table Pre-computation and Interpolated IV**
 ```cpp
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
 
 // Build price table (always uses EEP for ~5x better interpolation accuracy)
 auto [builder, axes] = mango::PriceTableBuilder<4>::from_vectors(
@@ -197,7 +197,7 @@ auto iv_result = iv_solver.solve(iv_query);
 
 **Pattern 3: Discrete Dividend IV Calculation**
 ```cpp
-#include "src/option/iv_solver_factory.hpp"
+#include "mango/option/iv_solver_factory.hpp"
 
 mango::IVSolverFactoryConfig config{
     .option_type = mango::OptionType::PUT,
@@ -219,7 +219,7 @@ auto result = solver->solve(query);
 
 **Pattern 4: Discrete Dividend IV with Adaptive Grid**
 ```cpp
-#include "src/option/iv_solver_factory.hpp"
+#include "mango/option/iv_solver_factory.hpp"
 
 mango::IVSolverFactoryConfig config{
     .option_type = mango::OptionType::PUT,
@@ -239,7 +239,7 @@ auto solver = mango::make_interpolated_iv_solver(config);
 
 **Pattern 5: Probe-Based FDM IV Solver (Simple API)**
 ```cpp
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 
 // Just specify target accuracy - no grid parameters needed
 mango::IVSolverConfig config{.target_price_error = 0.01};  // $0.01 accuracy

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ bazel test //...    # run all tests
 ### C++
 
 ```cpp
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 
 mango::PricingParams params(
     mango::OptionSpec{

--- a/benchmarks/bspline_cache_locality.cc
+++ b/benchmarks/bspline_cache_locality.cc
@@ -13,7 +13,7 @@
  * - Speedup: Hardware-dependent, typically 1.5-3x for large grids
  */
 
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <algorithm>
 #include <chrono>
 #include <iostream>

--- a/benchmarks/bspline_fitter_hardcoded_vs_template.cc
+++ b/benchmarks/bspline_fitter_hardcoded_vs_template.cc
@@ -11,8 +11,8 @@
  */
 
 #include <benchmark/benchmark.h>
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <vector>
 #include <random>
 #include <cmath>

--- a/benchmarks/bspline_move_semantics_demo.cc
+++ b/benchmarks/bspline_move_semantics_demo.cc
@@ -7,7 +7,7 @@
  * when the caller doesn't need the input values after fitting.
  */
 
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <benchmark/benchmark.h>
 #include <vector>
 #include <random>

--- a/benchmarks/bspline_nd_optimization_bench.cc
+++ b/benchmarks/bspline_nd_optimization_bench.cc
@@ -9,7 +9,7 @@
  * 3. OpenMP SIMD for slice extraction/write-back
  */
 
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <benchmark/benchmark.h>
 #include <vector>
 #include <random>

--- a/benchmarks/bspline_template_vs_hardcoded.cc
+++ b/benchmarks/bspline_template_vs_hardcoded.cc
@@ -4,8 +4,8 @@
 // Kept for historical reference but no longer builds.
 
 #include <benchmark/benchmark.h>
-#include "src/math/bspline_nd.hpp"
-#include "src/math/bspline_basis.hpp"
+#include "mango/math/bspline_nd.hpp"
+#include "mango/math/bspline_basis.hpp"
 #include <vector>
 #include <random>
 

--- a/benchmarks/component_performance.cc
+++ b/benchmarks/component_performance.cc
@@ -11,14 +11,14 @@
  * Run with: bazel run //benchmarks:component_performance
  */
 
-#include "src/option/american_option.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/option/iv_solver.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/option/iv_solver.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 #include <benchmark/benchmark.h>
 #include <chrono>
 #include <cmath>

--- a/benchmarks/cubic_spline_template_vs_hardcoded.cc
+++ b/benchmarks/cubic_spline_template_vs_hardcoded.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <benchmark/benchmark.h>
-#include "src/math/cubic_spline_solver.hpp"
-#include "src/math/cubic_spline_nd.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
+#include "mango/math/cubic_spline_nd.hpp"
 #include <vector>
 #include <random>
 #include <cmath>

--- a/benchmarks/grid_sweep.cc
+++ b/benchmarks/grid_sweep.cc
@@ -5,12 +5,12 @@
 //
 // Sweeps PriceTableGridAccuracyParams.target_iv_error from coarse to fine,
 // measuring interpolated IV accuracy against FDM ground truth.
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/price_table_grid_estimator.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/iv_solver.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_grid_estimator.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/iv_solver.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
 #include <cstdio>
 #include <chrono>
 #include <cmath>

--- a/benchmarks/interpolation_greek_accuracy.cc
+++ b/benchmarks/interpolation_greek_accuracy.cc
@@ -13,10 +13,10 @@
  *   bazel run //benchmarks:interpolation_greek_accuracy
  */
 
-#include "src/option/american_option.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 #include <benchmark/benchmark.h>
 #include <algorithm>
 #include <cmath>

--- a/benchmarks/iv_interpolation_profile.cc
+++ b/benchmarks/iv_interpolation_profile.cc
@@ -12,10 +12,10 @@
  * Run with: bazel run -c opt //benchmarks:iv_interpolation_profile -- --benchmark_filter="Vega"
  */
 
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_metadata.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
 #include <benchmark/benchmark.h>
 #include <memory>
 #include <vector>

--- a/benchmarks/market_iv_e2e_benchmark.cc
+++ b/benchmarks/market_iv_e2e_benchmark.cc
@@ -48,11 +48,11 @@
  * ```
  */
 
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <benchmark/benchmark.h>
 #include <iostream>
 #include <vector>

--- a/benchmarks/openmp_simd_benchmark.cc
+++ b/benchmarks/openmp_simd_benchmark.cc
@@ -15,8 +15,8 @@
  */
 
 #include <benchmark/benchmark.h>
-#include "src/pde/operators/centered_difference_scalar.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/operators/centered_difference_scalar.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <vector>
 #include <cmath>
 

--- a/benchmarks/quantlib_accuracy.cc
+++ b/benchmarks/quantlib_accuracy.cc
@@ -14,8 +14,8 @@
  * Requires: libquantlib0-dev
  */
 
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
 #include <benchmark/benchmark.h>
 #include <iostream>
 #include <iomanip>

--- a/benchmarks/quantlib_performance.cc
+++ b/benchmarks/quantlib_performance.cc
@@ -13,8 +13,8 @@
  * Requires: libquantlib-dev (apt-get install libquantlib-dev)
  */
 
-#include "src/option/american_option.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <benchmark/benchmark.h>
 #include <memory_resource>
 #include <stdexcept>

--- a/benchmarks/readme_benchmarks.cc
+++ b/benchmarks/readme_benchmarks.cc
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/option/iv_solver.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/option/iv_solver.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 #include <benchmark/benchmark.h>
 #include <algorithm>
 #include <cmath>

--- a/benchmarks/real_data_benchmark.cc
+++ b/benchmarks/real_data_benchmark.cc
@@ -11,17 +11,17 @@
  */
 
 #include "benchmarks/real_market_data.hpp"
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
-#include "src/option/iv_solver.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/option_grid.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_grid_estimator.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/math/black_scholes_analytics.hpp"
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/option/table/price_table_surface.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/option/iv_solver.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/option_grid.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_grid_estimator.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/math/black_scholes_analytics.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/option/table/price_table_surface.hpp"
 #include <benchmark/benchmark.h>
 #include <algorithm>
 #include <cmath>

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -25,7 +25,7 @@ Practical examples and common usage patterns for the mango-option library.
 ### Minimal American Option Example
 
 ```cpp
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 #include <iostream>
 
 int main() {
@@ -53,7 +53,7 @@ int main() {
 ### Minimal IV Calculation Example
 
 ```cpp
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 #include <iostream>
 
 int main() {
@@ -94,7 +94,7 @@ int main() {
 **Recommended for most use cases:**
 
 ```cpp
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 
 // Define option
 mango::PricingParams params(
@@ -177,7 +177,7 @@ if (result.has_value()) {
 **Uses Brent's method with nested PDE pricing:**
 
 ```cpp
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 
 // Option specification
 mango::OptionSpec spec{
@@ -268,8 +268,8 @@ auto result = solver.solve(query);
 **Pre-compute American option prices across parameter space:**
 
 ```cpp
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 // Define 4D parameter grids
 std::vector<double> moneyness_grid = {0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3};  // m = S/K
@@ -413,7 +413,7 @@ surface = mo.build_price_table_surface_from_grid(
 ### Using Price Surface with InterpolatedIVSolver
 
 ```cpp
-#include "src/option/interpolated_iv_solver.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
 
 // Create IV solver from AmericanPriceSurface
 auto iv_solver = mango::InterpolatedIVSolver::create(std::move(aps)).value();
@@ -451,7 +451,7 @@ A cash dividend at time t creates a discontinuity: at the ex-dividend instant, t
 Pass discrete dividends to `PricingParams`:
 
 ```cpp
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 
 mango::PricingParams params(
     mango::OptionSpec{
@@ -520,7 +520,7 @@ The result is a `SegmentedPriceSurface` — an ordered list of segments that tog
 The `make_interpolated_iv_solver` factory handles all the segmented construction:
 
 ```cpp
-#include "src/option/iv_solver_factory.hpp"
+#include "mango/option/iv_solver_factory.hpp"
 
 mango::IVSolverFactoryConfig config{
     .option_type = mango::OptionType::PUT,
@@ -647,7 +647,7 @@ if (result.has_value()) {
 **Parallel batch solver with automatic optimization:**
 
 ```cpp
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option_batch.hpp"
 
 // Build batch of options
 std::vector<mango::PricingParams> batch;
@@ -807,10 +807,10 @@ Use FDM batch when you need exact PDE accuracy or have few queries. Use the pric
 **Solve simple diffusion PDE:**
 
 ```cpp
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/operators/laplacian_pde.hpp"
-#include "src/pde/operators/operator_factory.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/operators/laplacian_pde.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
 
 // Define derived solver class using CRTP
 class HeatSolver : public mango::PDESolver<HeatSolver> {
@@ -972,8 +972,8 @@ if (!validation_result.has_value()) {
 **Zero-allocation parallel workloads with 64-byte alignment:**
 
 ```cpp
-#include "src/support/thread_workspace.hpp"
-#include "src/math/bspline_collocation_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
+#include "mango/math/bspline_collocation_workspace.hpp"
 
 // Example: Parallel B-spline fitting with zero allocations per iteration
 const size_t n_axis = 100;
@@ -1001,7 +1001,7 @@ MANGO_PRAGMA_PARALLEL
 **For PDE solving in parallel:**
 
 ```cpp
-#include "src/pde/core/american_pde_workspace.hpp"
+#include "mango/pde/core/american_pde_workspace.hpp"
 
 MANGO_PRAGMA_PARALLEL
 {

--- a/docs/archive/2025-01-25-yield-curve-implementation.md
+++ b/docs/archive/2025-01-25-yield-curve-implementation.md
@@ -20,7 +20,7 @@
 Create `tests/yield_curve_test.cc`:
 
 ```cpp
-#include "src/math/yield_curve.hpp"
+#include "mango/math/yield_curve.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -418,8 +418,8 @@ git commit -m "test: add YieldCurve interpolation and extrapolation tests"
 Create `tests/rate_spec_test.cc`:
 
 ```cpp
-#include "src/option/option_spec.hpp"
-#include "src/math/yield_curve.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/math/yield_curve.hpp"
 #include <gtest/gtest.h>
 
 TEST(RateSpecTest, DefaultIsDouble) {
@@ -482,7 +482,7 @@ Modify `src/option/option_spec.hpp`:
 Add includes at top:
 ```cpp
 #include <variant>
-#include "src/math/yield_curve.hpp"
+#include "mango/math/yield_curve.hpp"
 ```
 
 Add before `OptionSpec` struct:
@@ -566,8 +566,8 @@ git commit -m "feat: add RateSpec variant for constant rate or yield curve"
 Create `tests/black_scholes_pde_rate_fn_test.cc`:
 
 ```cpp
-#include "src/pde/operators/black_scholes_pde.hpp"
-#include "src/math/yield_curve.hpp"
+#include "mango/pde/operators/black_scholes_pde.hpp"
+#include "mango/math/yield_curve.hpp"
 #include <gtest/gtest.h>
 
 TEST(BlackScholesPDERateFnTest, ConstantRateFnViaLambda) {

--- a/docs/archive/2025-11-24-price-table-builder-impl.md
+++ b/docs/archive/2025-11-24-price-table-builder-impl.md
@@ -26,7 +26,7 @@ Extract `OptionChain` from specialized builder before any other changes (Step 5 
 ```cpp
 // tests/option_chain_test.cc
 #include <gtest/gtest.h>
-#include "src/option/option_chain.hpp"
+#include "mango/option/option_chain.hpp"
 
 TEST(OptionChainTest, DefaultConstruction) {
     mango::OptionChain chain;
@@ -126,7 +126,7 @@ Expected: PASS
 
 ```cpp
 // In src/option/price_table_4d_builder.hpp, replace inline OptionChain with:
-#include "src/option/option_chain.hpp"
+#include "mango/option/option_chain.hpp"
 
 // Remove the struct OptionChain { ... } definition (lines ~87-95)
 ```
@@ -165,7 +165,7 @@ Add diagnostic struct for B-spline fitting results (Step 2 in design, part 1).
 ```cpp
 // tests/bspline_fitting_stats_test.cc
 #include <gtest/gtest.h>
-#include "src/option/price_table_builder.hpp"
+#include "mango/option/price_table_builder.hpp"
 
 TEST(BSplineFittingStatsTest, DefaultConstruction) {
     mango::BSplineFittingStats stats;
@@ -267,7 +267,7 @@ Add the result struct with surface pointer and diagnostics (Step 2 in design, pa
 ```cpp
 // tests/price_table_result_test.cc
 #include <gtest/gtest.h>
-#include "src/option/price_table_builder.hpp"
+#include "mango/option/price_table_builder.hpp"
 
 TEST(PriceTableResultTest, DefaultConstruction) {
     mango::PriceTableResult<4> result;
@@ -491,9 +491,9 @@ Change build() to return PriceTableResult<N> with full instrumentation (Step 2 i
 ```cpp
 // tests/price_table_builder_result_test.cc
 #include <gtest/gtest.h>
-#include "src/option/price_table_builder.hpp"
-#include "src/option/price_table_axes.hpp"
-#include "src/option/price_table_config.hpp"
+#include "mango/option/price_table_builder.hpp"
+#include "mango/option/price_table_axes.hpp"
+#include "mango/option/price_table_config.hpp"
 
 TEST(PriceTableBuilderResultTest, BuildReturnsDiagnostics) {
     // Create minimal valid axes (4 points per axis for B-spline)
@@ -635,9 +635,9 @@ Add custom_grid parameter to public solve_batch() methods.
 ```cpp
 // tests/batch_solver_custom_grid_test.cc
 #include <gtest/gtest.h>
-#include "src/option/american_option_batch.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 
 TEST(BatchSolverCustomGridTest, AcceptsCustomGrid) {
     std::vector<mango::AmericanOptionParams> batch;
@@ -852,9 +852,9 @@ Fix the grid configuration bug by passing complete GridSpec to solver.
 ```cpp
 // tests/price_table_builder_grid_test.cc
 #include <gtest/gtest.h>
-#include "src/option/price_table_builder.hpp"
-#include "src/option/price_table_axes.hpp"
-#include "src/option/price_table_config.hpp"
+#include "mango/option/price_table_builder.hpp"
+#include "mango/option/price_table_axes.hpp"
+#include "mango/option/price_table_config.hpp"
 
 TEST(PriceTableBuilderGridTest, RespectsUserGridBounds) {
     // Create axes with specific moneyness range
@@ -996,9 +996,9 @@ Add comprehensive input validation from specialized builder.
 ```cpp
 // tests/price_table_builder_validation_test.cc
 #include <gtest/gtest.h>
-#include "src/option/price_table_builder.hpp"
-#include "src/option/price_table_axes.hpp"
-#include "src/option/price_table_config.hpp"
+#include "mango/option/price_table_builder.hpp"
+#include "mango/option/price_table_axes.hpp"
+#include "mango/option/price_table_config.hpp"
 
 class PriceTableValidationTest : public ::testing::Test {
 protected:
@@ -1197,8 +1197,8 @@ Add from_vectors, from_strikes, from_chain factory methods.
 ```cpp
 // tests/price_table_builder_factories_test.cc
 #include <gtest/gtest.h>
-#include "src/option/price_table_builder.hpp"
-#include "src/option/option_chain.hpp"
+#include "mango/option/price_table_builder.hpp"
+#include "mango/option/option_chain.hpp"
 
 TEST(PriceTableFactoriesTest, FromVectorsCreatesBuilderAndAxes) {
     std::vector<double> moneyness = {0.8, 0.9, 1.0, 1.1};
@@ -1281,7 +1281,7 @@ Expected: FAIL (factories not defined)
 ```cpp
 // In src/option/price_table_builder.hpp, add to PriceTableBuilder class:
 
-#include "src/option/option_chain.hpp"
+#include "mango/option/option_chain.hpp"
 
 template <size_t N>
 class PriceTableBuilder {
@@ -1516,12 +1516,12 @@ Migrate the most critical consumer before deletion.
 // In src/option/iv_solver_interpolated.hpp and .cpp, change:
 
 // BEFORE:
-#include "src/option/price_table_4d_builder.hpp"
+#include "mango/option/price_table_4d_builder.hpp"
 
 // AFTER:
-#include "src/option/price_table_builder.hpp"
-#include "src/option/price_table_axes.hpp"
-#include "src/option/price_table_surface.hpp"
+#include "mango/option/price_table_builder.hpp"
+#include "mango/option/price_table_axes.hpp"
+#include "mango/option/price_table_surface.hpp"
 ```
 
 **Step 10.2: Update surface storage type**

--- a/docs/archive/2025-11-24-price-table-builder-phase2-impl.md
+++ b/docs/archive/2025-11-24-price-table-builder-phase2-impl.md
@@ -75,7 +75,7 @@ git commit -m "build: add OpenMP flags to price_table_builder target"
 
 ```cpp
 // At top of src/option/price_table_builder.cpp, add:
-#include "src/support/parallel.hpp"
+#include "mango/support/parallel.hpp"
 #include <mutex>
 #include <tuple>
 #include <map>

--- a/docs/archive/2025-11-24-price-table-builder-phase2.md
+++ b/docs/archive/2025-11-24-price-table-builder-phase2.md
@@ -65,7 +65,7 @@ This codebase uses abstraction macros from `src/support/parallel.hpp` for portab
 // src/option/price_table_builder.cpp
 
 // Add includes (NOT <omp.h> directly)
-#include "src/support/parallel.hpp"
+#include "mango/support/parallel.hpp"
 #include <mutex>           // std::mutex, std::lock_guard
 #include <tuple>           // std::tuple
 #include <map>             // std::map

--- a/docs/archive/2025-11-24-price-table-builder-refactor.md
+++ b/docs/archive/2025-11-24-price-table-builder-refactor.md
@@ -613,7 +613,7 @@ struct OptionChain {
 **Location:** `src/option/price_table_builder.hpp`
 
 ```cpp
-#include "src/option/option_chain.hpp"  // NEW: Include shared OptionChain type
+#include "mango/option/option_chain.hpp"  // NEW: Include shared OptionChain type
 
 template <size_t N>
 class PriceTableBuilder {
@@ -782,12 +782,12 @@ double price = surface->eval(m, tau, sigma, r);  // Note: -> not .
 1. **Update includes** (src/option/iv_solver_interpolated.cpp, iv_solver_interpolated.hpp):
    ```cpp
    // BEFORE:
-   #include "src/option/price_table_4d_builder.hpp"
+   #include "mango/option/price_table_4d_builder.hpp"
 
    // AFTER:
-   #include "src/option/price_table_builder.hpp"
-   #include "src/option/price_table_axes.hpp"
-   #include "src/option/price_table_surface.hpp"
+   #include "mango/option/price_table_builder.hpp"
+   #include "mango/option/price_table_axes.hpp"
+   #include "mango/option/price_table_surface.hpp"
    ```
 
 2. **Update surface storage** (if storing PriceTableSurface):

--- a/docs/archive/2025-11-25-mango-simple-namespace.md
+++ b/docs/archive/2025-11-25-mango-simple-namespace.md
@@ -24,7 +24,7 @@ Create `tests/simple_price_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/simple/price.hpp"
+#include "mango/simple/price.hpp"
 
 TEST(SimplePriceTest, ConstructFromDouble) {
     mango::simple::Price p{100.50};
@@ -208,7 +208,7 @@ Create `tests/simple_timestamp_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/simple/timestamp.hpp"
+#include "mango/simple/timestamp.hpp"
 #include <chrono>
 
 using namespace mango::simple;
@@ -350,7 +350,7 @@ double compute_tau(const Timestamp& valuation, const Timestamp& expiry);
 Create `src/simple/timestamp.cpp`:
 
 ```cpp
-#include "src/simple/timestamp.hpp"
+#include "mango/simple/timestamp.hpp"
 #include <charconv>
 #include <ctime>
 #include <iomanip>
@@ -526,7 +526,7 @@ Create `tests/simple_option_types_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/simple/option_types.hpp"
+#include "mango/simple/option_types.hpp"
 
 using namespace mango::simple;
 
@@ -607,8 +607,8 @@ Create `src/simple/option_types.hpp`:
 
 #pragma once
 
-#include "src/simple/price.hpp"
-#include "src/simple/timestamp.hpp"
+#include "mango/simple/price.hpp"
+#include "mango/simple/timestamp.hpp"
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -750,7 +750,7 @@ Create `tests/simple_option_chain_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/simple/option_chain.hpp"
+#include "mango/simple/option_chain.hpp"
 
 using namespace mango::simple;
 
@@ -824,9 +824,9 @@ Create `src/simple/option_chain.hpp`:
 
 #pragma once
 
-#include "src/simple/option_types.hpp"
-#include "src/math/yield_curve.hpp"
-#include "src/option/option_spec.hpp"  // For RateSpec
+#include "mango/simple/option_types.hpp"
+#include "mango/math/yield_curve.hpp"
+#include "mango/option/option_spec.hpp"  // For RateSpec
 #include <optional>
 #include <string>
 #include <vector>
@@ -962,10 +962,10 @@ Create `tests/simple_converter_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/simple/converter.hpp"
-#include "src/simple/sources/yfinance.hpp"
-#include "src/simple/sources/databento.hpp"
-#include "src/simple/sources/ibkr.hpp"
+#include "mango/simple/converter.hpp"
+#include "mango/simple/sources/yfinance.hpp"
+#include "mango/simple/sources/databento.hpp"
+#include "mango/simple/sources/ibkr.hpp"
 
 using namespace mango::simple;
 
@@ -1042,10 +1042,10 @@ Create `src/simple/converter.hpp`:
 
 #pragma once
 
-#include "src/simple/price.hpp"
-#include "src/simple/timestamp.hpp"
-#include "src/simple/option_types.hpp"
-#include "src/option/option_spec.hpp"
+#include "mango/simple/price.hpp"
+#include "mango/simple/timestamp.hpp"
+#include "mango/simple/option_types.hpp"
+#include "mango/option/option_spec.hpp"
 #include <concepts>
 #include <stdexcept>
 
@@ -1090,7 +1090,7 @@ Create `src/simple/sources/yfinance.hpp`:
 
 #pragma once
 
-#include "src/simple/converter.hpp"
+#include "mango/simple/converter.hpp"
 
 namespace mango::simple {
 
@@ -1154,7 +1154,7 @@ Create `src/simple/sources/databento.hpp`:
 
 #pragma once
 
-#include "src/simple/converter.hpp"
+#include "mango/simple/converter.hpp"
 
 namespace mango::simple {
 
@@ -1211,7 +1211,7 @@ Create `src/simple/sources/ibkr.hpp`:
 
 #pragma once
 
-#include "src/simple/converter.hpp"
+#include "mango/simple/converter.hpp"
 
 namespace mango::simple {
 
@@ -1360,9 +1360,9 @@ Create `tests/simple_chain_builder_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/simple/chain_builder.hpp"
-#include "src/simple/sources/yfinance.hpp"
-#include "src/simple/sources/databento.hpp"
+#include "mango/simple/chain_builder.hpp"
+#include "mango/simple/sources/yfinance.hpp"
+#include "mango/simple/sources/databento.hpp"
 
 using namespace mango::simple;
 
@@ -1433,8 +1433,8 @@ Create `src/simple/chain_builder.hpp`:
 
 #pragma once
 
-#include "src/simple/option_chain.hpp"
-#include "src/simple/converter.hpp"
+#include "mango/simple/option_chain.hpp"
+#include "mango/simple/converter.hpp"
 #include <map>
 
 namespace mango::simple {
@@ -1580,9 +1580,9 @@ Create `tests/simple_vol_surface_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/simple/vol_surface.hpp"
-#include "src/simple/chain_builder.hpp"
-#include "src/simple/sources/yfinance.hpp"
+#include "mango/simple/vol_surface.hpp"
+#include "mango/simple/chain_builder.hpp"
+#include "mango/simple/sources/yfinance.hpp"
 
 using namespace mango::simple;
 
@@ -1650,9 +1650,9 @@ Create `src/simple/vol_surface.hpp`:
 
 #pragma once
 
-#include "src/simple/option_chain.hpp"
-#include "src/option/iv_solver_interpolated.hpp"
-#include "src/option/iv_solver_fdm.hpp"
+#include "mango/simple/option_chain.hpp"
+#include "mango/option/iv_solver_interpolated.hpp"
+#include "mango/option/iv_solver_fdm.hpp"
 #include <expected>
 #include <memory>
 #include <vector>
@@ -1739,7 +1739,7 @@ std::expected<VolatilitySurface, ComputeError> compute_vol_surface(
 Create `src/simple/vol_surface.cpp`:
 
 ```cpp
-#include "src/simple/vol_surface.hpp"
+#include "mango/simple/vol_surface.hpp"
 #include <cmath>
 
 namespace mango::simple {
@@ -1975,16 +1975,16 @@ Create `src/simple/simple.hpp`:
 
 #pragma once
 
-#include "src/simple/price.hpp"
-#include "src/simple/timestamp.hpp"
-#include "src/simple/option_types.hpp"
-#include "src/simple/option_chain.hpp"
-#include "src/simple/converter.hpp"
-#include "src/simple/chain_builder.hpp"
-#include "src/simple/vol_surface.hpp"
-#include "src/simple/sources/yfinance.hpp"
-#include "src/simple/sources/databento.hpp"
-#include "src/simple/sources/ibkr.hpp"
+#include "mango/simple/price.hpp"
+#include "mango/simple/timestamp.hpp"
+#include "mango/simple/option_types.hpp"
+#include "mango/simple/option_chain.hpp"
+#include "mango/simple/converter.hpp"
+#include "mango/simple/chain_builder.hpp"
+#include "mango/simple/vol_surface.hpp"
+#include "mango/simple/sources/yfinance.hpp"
+#include "mango/simple/sources/databento.hpp"
+#include "mango/simple/sources/ibkr.hpp"
 ```
 
 **Step 7: Add test target**
@@ -2033,7 +2033,7 @@ Create `examples/simple_yfinance_example.cpp`:
  * @brief End-to-end example: yfinance data → volatility smile
  */
 
-#include "src/simple/simple.hpp"
+#include "mango/simple/simple.hpp"
 #include <iostream>
 #include <iomanip>
 
@@ -2177,7 +2177,7 @@ Create `examples/simple_databento_example.cpp`:
  * @brief End-to-end example: Databento fixed-point data → volatility smile
  */
 
-#include "src/simple/simple.hpp"
+#include "mango/simple/simple.hpp"
 #include <iostream>
 #include <iomanip>
 

--- a/docs/archive/2025-11-27-adaptive-grid-builder-impl.md
+++ b/docs/archive/2025-11-27-adaptive-grid-builder-impl.md
@@ -23,7 +23,7 @@ In `tests/black_scholes_analytics_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/math/black_scholes_analytics.hpp"
+#include "mango/math/black_scholes_analytics.hpp"
 #include <cmath>
 
 namespace mango {
@@ -174,7 +174,7 @@ In `tests/latin_hypercube_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/math/latin_hypercube.hpp"
+#include "mango/math/latin_hypercube.hpp"
 #include <algorithm>
 #include <set>
 
@@ -373,7 +373,7 @@ In `tests/error_attribution_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/table/error_attribution.hpp"
+#include "mango/option/table/error_attribution.hpp"
 
 namespace mango {
 namespace {
@@ -602,7 +602,7 @@ In `tests/slice_cache_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/table/slice_cache.hpp"
+#include "mango/option/table/slice_cache.hpp"
 
 namespace mango {
 namespace {
@@ -706,7 +706,7 @@ In `src/option/table/slice_cache.hpp`:
 ```cpp
 #pragma once
 
-#include "src/option/american_option_result.hpp"
+#include "mango/option/american_option_result.hpp"
 #include <map>
 #include <optional>
 #include <vector>
@@ -873,7 +873,7 @@ In `tests/adaptive_grid_types_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/table/adaptive_grid_types.hpp"
+#include "mango/option/table/adaptive_grid_types.hpp"
 
 namespace mango {
 namespace {
@@ -923,8 +923,8 @@ In `src/option/table/adaptive_grid_types.hpp`:
 ```cpp
 #pragma once
 
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_surface.hpp"
 #include <array>
 #include <memory>
 #include <vector>
@@ -1058,7 +1058,7 @@ In `tests/adaptive_grid_builder_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/table/adaptive_grid_builder.hpp"
+#include "mango/option/table/adaptive_grid_builder.hpp"
 
 namespace mango {
 namespace {
@@ -1096,13 +1096,13 @@ In `src/option/table/adaptive_grid_builder.hpp`:
 ```cpp
 #pragma once
 
-#include "src/option/table/adaptive_grid_types.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/slice_cache.hpp"
-#include "src/option/table/error_attribution.hpp"
-#include "src/option/option_chain.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/adaptive_grid_types.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/slice_cache.hpp"
+#include "mango/option/table/error_attribution.hpp"
+#include "mango/option/option_chain.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/support/error_types.hpp"
 #include <expected>
 
 namespace mango {
@@ -1165,10 +1165,10 @@ private:
 In `src/option/table/adaptive_grid_builder.cpp`:
 
 ```cpp
-#include "src/option/table/adaptive_grid_builder.hpp"
-#include "src/math/black_scholes_analytics.hpp"
-#include "src/math/latin_hypercube.hpp"
-#include "src/option/table/price_table_grid_estimator.hpp"
+#include "mango/option/table/adaptive_grid_builder.hpp"
+#include "mango/math/black_scholes_analytics.hpp"
+#include "mango/math/latin_hypercube.hpp"
+#include "mango/option/table/price_table_grid_estimator.hpp"
 #include <algorithm>
 #include <cmath>
 
@@ -1435,7 +1435,7 @@ In `tests/adaptive_grid_builder_integration_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/table/adaptive_grid_builder.hpp"
+#include "mango/option/table/adaptive_grid_builder.hpp"
 #include <chrono>
 
 namespace mango {

--- a/docs/archive/2025-11-27-thread-workspace-buffer-design.md
+++ b/docs/archive/2025-11-27-thread-workspace-buffer-design.md
@@ -409,7 +409,7 @@ The existing `PDEWorkspace` takes `std::span<double>`, requiring callers to mana
 
 #pragma once
 
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <span>
 #include <expected>
 #include <string>

--- a/docs/archive/2025-11-27-thread-workspace-buffer-impl.md
+++ b/docs/archive/2025-11-27-thread-workspace-buffer-impl.md
@@ -19,7 +19,7 @@ This plan implements the ThreadWorkspaceBuffer design from `docs/plans/2025-11-2
 **Test (RED):**
 ```cpp
 // tests/parallel_critical_test.cc
-#include "src/support/parallel.hpp"
+#include "mango/support/parallel.hpp"
 #include <gtest/gtest.h>
 #include <atomic>
 #include <vector>
@@ -64,7 +64,7 @@ Add to `src/support/parallel.hpp` after line 43:
 **Test (RED):**
 ```cpp
 // tests/lifetime_test.cc
-#include "src/support/lifetime.hpp"
+#include "mango/support/lifetime.hpp"
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <type_traits>
@@ -160,7 +160,7 @@ constexpr size_t align_up(size_t offset, size_t alignment) noexcept {
 **Test (RED):**
 ```cpp
 // tests/thread_workspace_test.cc
-#include "src/support/thread_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cstdint>
 
@@ -276,7 +276,7 @@ cc_test(
 **Test (RED):**
 ```cpp
 // tests/interpolation_error_test.cc (add to existing or create)
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 #include <gtest/gtest.h>
 #include <sstream>
 
@@ -410,8 +410,8 @@ inline PriceTableError convert_to_price_table_error(const InterpolationError& er
 **Test (RED):**
 ```cpp
 // tests/bspline_collocation_workspace_test.cc
-#include "src/math/bspline_collocation_workspace.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/math/bspline_collocation_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cstdint>
 
@@ -514,9 +514,9 @@ Create `src/math/bspline_collocation_workspace.hpp` with the exact implementatio
 **Test (RED):**
 ```cpp
 // tests/bspline_fit_with_workspace_test.cc
-#include "src/math/bspline_collocation.hpp"
-#include "src/math/bspline_collocation_workspace.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/math/bspline_collocation.hpp"
+#include "mango/math/bspline_collocation_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -736,8 +736,8 @@ Add tests to `tests/BUILD.bazel`.
 **Test:**
 ```cpp
 // Verify 4D tensor fitting produces identical results with and without workspace
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 
 using namespace mango;
@@ -790,8 +790,8 @@ Follow the exact pattern from design document lines 563-676.
 **Test (RED):**
 ```cpp
 // tests/american_pde_workspace_test.cc
-#include "src/pde/core/american_pde_workspace.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/pde/core/american_pde_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 
 using namespace mango;
@@ -878,7 +878,7 @@ cc_library(
 **Test (RED):**
 ```cpp
 // tests/american_option_batch_workspace_test.cc
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option_batch.hpp"
 #include <gtest/gtest.h>
 
 using namespace mango;

--- a/docs/archive/2026-01-29-python-binding-gaps.md
+++ b/docs/archive/2026-01-29-python-binding-gaps.md
@@ -58,7 +58,7 @@ git commit -m "Add batch solver dep to Python bindings BUILD"
 At the top of `mango_bindings.cpp`, after the existing includes, add:
 
 ```cpp
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option_batch.hpp"
 ```
 
 **Step 2: Bind GridAccuracyParams struct**

--- a/docs/archive/IV_IMPLEMENTATION_SUMMARY.md
+++ b/docs/archive/IV_IMPLEMENTATION_SUMMARY.md
@@ -74,7 +74,7 @@ The IV solver for American options has been successfully implemented using C++20
 ### Basic Example
 
 ```cpp
-#include "src/cpp/iv_solver.hpp"
+#include "mango/cpp/iv_solver.hpp"
 
 // Setup parameters
 mango::IVParams params{

--- a/docs/archive/plans/2025-01-12-batch-option-implementation-plan.md
+++ b/docs/archive/plans/2025-01-12-batch-option-implementation-plan.md
@@ -32,9 +32,9 @@ The implementation is divided into 3 phases with bite-sized tasks. Each task inc
 #ifndef MANGO_NORMALIZED_CHAIN_SOLVER_HPP
 #define MANGO_NORMALIZED_CHAIN_SOLVER_HPP
 
-#include "src/option/american_option.hpp"
-#include "src/option/american_solver_workspace.hpp"
-#include "src/support/expected.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_solver_workspace.hpp"
+#include "mango/support/expected.hpp"
 #include <span>
 #include <memory>
 #include <vector>
@@ -251,7 +251,7 @@ to solve once and interpolate for all strikes.
  * @brief Implementation of normalized chain solver
  */
 
-#include "src/option/normalized_chain_solver.hpp"
+#include "mango/option/normalized_chain_solver.hpp"
 #include <cmath>
 #include <algorithm>
 
@@ -540,7 +540,7 @@ accuracy and Newton convergence for production use cases.
 **Add to existing file:**
 
 ```cpp
-#include "src/option/price_table_snapshot_collector.hpp"
+#include "mango/option/price_table_snapshot_collector.hpp"
 #include <cmath>
 
 expected<void, SolverError> NormalizedChainSolver::solve(
@@ -679,7 +679,7 @@ One solve yields prices for all (S,K) via V = K·u interpolation.
  * @brief Unit tests for normalized chain solver
  */
 
-#include "src/option/normalized_chain_solver.hpp"
+#include "mango/option/normalized_chain_solver.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -1364,7 +1364,7 @@ private:
 **Add to source:**
 
 ```cpp
-#include "src/option/normalized_chain_solver.hpp"
+#include "mango/option/normalized_chain_solver.hpp"
 
 bool PriceTable4DBuilder::should_use_normalized_solver(
     double x_min,
@@ -1776,7 +1776,7 @@ that normalized solver cannot handle.
  * @brief Integration tests for PriceTable4DBuilder with routing
  */
 
-#include "src/option/price_table_4d_builder.hpp"
+#include "mango/option/price_table_4d_builder.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -1961,8 +1961,8 @@ bazel run //benchmarks:price_table_benchmark
 Create `examples/example_normalized_solver.cc`:
 
 ```cpp
-#include "src/option/normalized_chain_solver.hpp"
-#include "src/option/price_table_4d_builder.hpp"
+#include "mango/option/normalized_chain_solver.hpp"
+#include "mango/option/price_table_4d_builder.hpp"
 #include <iostream>
 #include <vector>
 

--- a/docs/archive/plans/2025-01-12-normalized-solver-design.md
+++ b/docs/archive/plans/2025-01-12-normalized-solver-design.md
@@ -542,7 +542,7 @@ All existing code continues to work unchanged:
 ### Direct Normalized Solving
 
 ```cpp
-#include "src/option/normalized_chain_solver.hpp"
+#include "mango/option/normalized_chain_solver.hpp"
 
 std::vector<double> maturities = {0.25, 0.5, 1.0};
 

--- a/docs/archive/plans/2025-01-13-batch-iv-simd-corrected-design.md
+++ b/docs/archive/plans/2025-01-13-batch-iv-simd-corrected-design.md
@@ -330,7 +330,7 @@ SIMD Newton Loop (batches of W=8)
 ```cpp
 #pragma once
 
-#include "src/pde/memory/workspace_base.hpp"
+#include "mango/pde/memory/workspace_base.hpp"
 #include <span>
 #include <string>
 
@@ -639,7 +639,7 @@ TEST(BatchIVWorkspaceTest, ConcurrentDistinctWorkspaces) {
 
 3. **Reset Contract**: Document that callers **must** call `reset()` before each `solve_batch()` to clear stale convergence flags and failure reasons. Without this, previous batch state bleeds into new queries.
 
-4. **Include Style**: Follow existing codebase pattern with relative includes (e.g., `#include "workspace_base.hpp"` not `#include "src/pde/memory/workspace_base.hpp"`).
+4. **Include Style**: Follow existing codebase pattern with relative includes (e.g., `#include "workspace_base.hpp"` not `#include "mango/pde/memory/workspace_base.hpp"`).
 
 5. **Build Dependencies**: Ensure Bazel target links OpenMP before adding `#pragma omp` tests, otherwise tests will compile but not parallelize.
 

--- a/docs/archive/plans/2025-01-13-iv-interpolation-vertical-simd.md
+++ b/docs/archive/plans/2025-01-13-iv-interpolation-vertical-simd.md
@@ -38,8 +38,8 @@
 Create `tests/bspline_vega_triple_test.cc`:
 
 ```cpp
-#include "src/interpolation/bspline_4d.hpp"
-#include "src/interpolation/bspline_fitter_4d.hpp"
+#include "mango/interpolation/bspline_4d.hpp"
+#include "mango/interpolation/bspline_fitter_4d.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>

--- a/docs/archive/plans/2025-01-13-price-table-arrow-persistence.md
+++ b/docs/archive/plans/2025-01-13-price-table-arrow-persistence.md
@@ -24,7 +24,7 @@
 Create `tests/price_table_workspace_test.cc`:
 
 ```cpp
-#include "src/option/price_table_workspace.hpp"
+#include "mango/option/price_table_workspace.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -95,8 +95,8 @@ Create `src/option/price_table_workspace.hpp`:
 ```cpp
 #pragma once
 
-#include "src/support/expected.hpp"
-#include "src/interpolation/bspline_utils.hpp"
+#include "mango/support/expected.hpp"
+#include "mango/interpolation/bspline_utils.hpp"
 #include <vector>
 #include <span>
 #include <string>
@@ -222,7 +222,7 @@ private:
 Create `src/option/price_table_workspace.cpp`:
 
 ```cpp
-#include "src/option/price_table_workspace.hpp"
+#include "mango/option/price_table_workspace.hpp"
 #include <algorithm>
 #include <numeric>
 #include <cstring>
@@ -450,7 +450,7 @@ git commit -m "feat: add PriceTableWorkspace with aligned arena
 Add to `tests/bspline_4d_test.cc`:
 
 ```cpp
-#include "src/option/price_table_workspace.hpp"
+#include "mango/option/price_table_workspace.hpp"
 
 TEST(BSpline4D, ConstructsFromWorkspace) {
     std::vector<double> m = {0.8, 0.9, 1.0, 1.1};
@@ -587,7 +587,7 @@ public:
 Add include at top of file:
 
 ```cpp
-#include "src/option/price_table_workspace.hpp"
+#include "mango/option/price_table_workspace.hpp"
 ```
 
 **Step 4: Update BSpline4D dependencies in BUILD.bazel**

--- a/docs/archive/plans/2025-01-13-price-table-arrow-schema.md
+++ b/docs/archive/plans/2025-01-13-price-table-arrow-schema.md
@@ -349,8 +349,8 @@ Total: ~2.4 MB per table
 ### Save (Overnight Batch)
 
 ```cpp
-#include "src/option/price_table_4d_builder.hpp"
-#include "src/option/price_table_arrow.hpp"
+#include "mango/option/price_table_4d_builder.hpp"
+#include "mango/option/price_table_arrow.hpp"
 
 // Build price table (expensive: ~3 minutes)
 auto builder = PriceTable4DBuilder::create(grid);
@@ -366,8 +366,8 @@ if (!save_result) {
 ### Load (Pre-Market)
 
 ```cpp
-#include "src/option/price_table_arrow.hpp"
-#include "src/option/iv_solver_interpolated.hpp"
+#include "mango/option/price_table_arrow.hpp"
+#include "mango/option/iv_solver_interpolated.hpp"
 
 // Load table from disk (<1ms, zero-copy mmap)
 auto surface_result = load_price_table("SPY_put_20250113.arrow");

--- a/docs/archive/plans/2025-01-14-bspline-banded-solver-implementation.md
+++ b/docs/archive/plans/2025-01-14-bspline-banded-solver-implementation.md
@@ -87,7 +87,7 @@ git commit -m "docs: analyze current banded matrix implementation"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/interpolation/bspline_fitter_4d.hpp"
+#include "mango/interpolation/bspline_fitter_4d.hpp"
 #include <vector>
 #include <cmath>
 
@@ -666,7 +666,7 @@ git commit -m "feat: integrate banded solver into BSplineCollocation1D"
 
 ```cpp
 #include <benchmark/benchmark.h>
-#include "src/interpolation/bspline_fitter_4d.hpp"
+#include "mango/interpolation/bspline_fitter_4d.hpp"
 #include <vector>
 
 namespace mango {

--- a/docs/archive/plans/2025-01-16-pmr-workspace-optimization-plan.md
+++ b/docs/archive/plans/2025-01-16-pmr-workspace-optimization-plan.md
@@ -361,7 +361,7 @@ Create test file:
 
 ```bash
 cat > /tmp/test_workspace.cc << 'EOF'
-#include "src/interpolation/bspline_fitter_4d.hpp"
+#include "mango/interpolation/bspline_fitter_4d.hpp"
 #include <iostream>
 
 int main() {
@@ -763,7 +763,7 @@ Create new test file:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/interpolation/bspline_fitter_4d.hpp"
+#include "mango/interpolation/bspline_fitter_4d.hpp"
 #include <cmath>
 #include <vector>
 

--- a/docs/archive/plans/2025-01-17-gridspacing-variant-refactor.md
+++ b/docs/archive/plans/2025-01-17-gridspacing-variant-refactor.md
@@ -21,7 +21,7 @@
 Create `tests/grid_spacing_data_test.cc`:
 
 ```cpp
-#include "src/pde/core/grid_spacing_data.hpp"
+#include "mango/pde/core/grid_spacing_data.hpp"
 #include <gtest/gtest.h>
 
 TEST(UniformSpacingTest, ConstructionAndAccessors) {
@@ -545,7 +545,7 @@ private:
 Add to top of `src/pde/core/grid.hpp` after other includes:
 
 ```cpp
-#include "src/pde/core/grid_spacing_data.hpp"
+#include "mango/pde/core/grid_spacing_data.hpp"
 ```
 
 **Step 6: Update grid library BUILD dependency**

--- a/docs/archive/plans/2025-11-01-gamma-interpolation.md
+++ b/docs/archive/plans/2025-11-01-gamma-interpolation.md
@@ -899,8 +899,8 @@ File: `benchmarks/gamma_accuracy.cc`
 #include <string>
 
 extern "C" {
-#include "src/price_table.h"
-#include "src/american_option.h"
+#include "mango/price_table.h"
+#include "mango/american_option.h"
 }
 
 // Compute gamma using finite differences

--- a/docs/archive/plans/2025-11-01-p6-implementation-plan.md
+++ b/docs/archive/plans/2025-11-01-p6-implementation-plan.md
@@ -336,8 +336,8 @@ int american_option_solve_on_grid_with_greeks(
 ```python
 cc_library(
     name = "american_option_unified",
-    srcs = ["src/american_option_unified.c"],
-    hdrs = ["src/american_option_unified.h"],
+    srcs = ["mango/american_option_unified.c"],
+    hdrs = ["mango/american_option_unified.h"],
     deps = [
         ":pde_solver",
     ],

--- a/docs/archive/plans/2025-11-01-rust-phase1-bazel-types.md
+++ b/docs/archive/plans/2025-11-01-rust-phase1-bazel-types.md
@@ -124,7 +124,7 @@ license.workspace = true
 
 [lib]
 name = "mango_types"
-path = "src/lib.rs"
+path = "mango/lib.rs"
 
 [dependencies]
 # No dependencies yet - pure types
@@ -181,7 +181,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "types",
-    srcs = ["src/lib.rs"],
+    srcs = ["mango/lib.rs"],
     edition = "2021",
     visibility = ["//visibility:public"],
 )

--- a/docs/archive/plans/2025-11-03-phase1-weeks1-2-implementation.md
+++ b/docs/archive/plans/2025-11-03-phase1-weeks1-2-implementation.md
@@ -175,7 +175,7 @@ Part of Phase 1 Week 1: Grid system foundation"
 Create `tests/grid_test.cc`:
 
 ```cpp
-#include "src/cpp/grid.hpp"
+#include "mango/cpp/grid.hpp"
 #include <gtest/gtest.h>
 
 TEST(GridSpecTest, UniformGridGeneration) {
@@ -552,7 +552,7 @@ cc_library(
 Create `tests/boundary_conditions_test.cc`:
 
 ```cpp
-#include "src/cpp/boundary_conditions.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
 #include <gtest/gtest.h>
 
 TEST(BoundaryConditionTest, DirichletTagExists) {
@@ -1198,7 +1198,7 @@ cc_library(
 Create `tests/cache_config_test.cc`:
 
 ```cpp
-#include "src/cpp/cache_config.hpp"
+#include "mango/cpp/cache_config.hpp"
 #include <gtest/gtest.h>
 
 TEST(CacheBlockConfigTest, SmallGridSingleBlock) {

--- a/docs/archive/plans/2025-11-04-american-option-implementation-plan.md
+++ b/docs/archive/plans/2025-11-04-american-option-implementation-plan.md
@@ -35,7 +35,7 @@ Add to `tests/workspace_test.cc` (create if needed):
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/cpp/workspace.hpp"
+#include "mango/cpp/workspace.hpp"
 
 namespace mango {
 namespace {
@@ -145,9 +145,9 @@ Create `tests/temporal_event_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/cpp/pde_solver.hpp"
-#include "src/cpp/boundary_conditions.hpp"
-#include "src/cpp/spatial_operators.hpp"
+#include "mango/cpp/pde_solver.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
+#include "mango/cpp/spatial_operators.hpp"
 #include <cmath>
 
 namespace mango {
@@ -367,8 +367,8 @@ Create `tests/obstacle_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/cpp/pde_solver.hpp"
-#include "src/cpp/boundary_conditions.hpp"
+#include "mango/cpp/pde_solver.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
 #include <algorithm>
 
 namespace mango {
@@ -568,7 +568,7 @@ Create `tests/american_option_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/cpp/american_option.hpp"
+#include "mango/cpp/american_option.hpp"
 #include <cmath>
 
 namespace mango {

--- a/docs/archive/plans/2025-11-04-cache-blocking-implementation-plan.md
+++ b/docs/archive/plans/2025-11-04-cache-blocking-implementation-plan.md
@@ -1058,9 +1058,9 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 **File:** `tests/cache_blocking_benchmark.cc`
 
 ```cpp
-#include "src/cpp/pde_solver.hpp"
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/boundary_conditions.hpp"
+#include "mango/cpp/pde_solver.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
 #include <gtest/gtest.h>
 #include <chrono>
 #include <iostream>

--- a/docs/archive/plans/2025-11-04-iv-calculation-implementation-plan.md
+++ b/docs/archive/plans/2025-11-04-iv-calculation-implementation-plan.md
@@ -82,8 +82,8 @@ Create `tests/brent_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/cpp/brent.hpp"
-#include "src/cpp/root_finding.hpp"
+#include "mango/cpp/brent.hpp"
+#include "mango/cpp/root_finding.hpp"
 #include <cmath>
 #include <limits>
 
@@ -141,8 +141,8 @@ Create `src/cpp/brent.hpp`:
 ```cpp
 #pragma once
 
-#include "src/cpp/root_finding.hpp"
-#include "src/mango_trace.h"
+#include "mango/cpp/root_finding.hpp"
+#include "mango/mango_trace.h"
 #include <cmath>
 #include <algorithm>
 #include <limits>
@@ -497,8 +497,8 @@ Create `tests/iv_solver_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/cpp/iv_solver.hpp"
-#include "src/cpp/american_option.hpp"
+#include "mango/cpp/iv_solver.hpp"
+#include "mango/cpp/american_option.hpp"
 #include <vector>
 
 namespace mango {
@@ -585,10 +585,10 @@ Create `src/cpp/iv_solver.hpp`:
 ```cpp
 #pragma once
 
-#include "src/cpp/brent.hpp"
-#include "src/cpp/american_option.hpp"
-#include "src/cpp/root_finding.hpp"
-#include "src/mango_trace.h"
+#include "mango/cpp/brent.hpp"
+#include "mango/cpp/american_option.hpp"
+#include "mango/cpp/root_finding.hpp"
+#include "mango/mango_trace.h"
 #include <span>
 #include <vector>
 #include <optional>
@@ -1655,8 +1655,8 @@ git commit -m "docs(iv): add IV calculation workflow to CLAUDE.md"
 Create `examples/example_iv_calculation.cc`:
 
 ```cpp
-#include "src/cpp/iv_solver.hpp"
-#include "src/cpp/american_option.hpp"
+#include "mango/cpp/iv_solver.hpp"
+#include "mango/cpp/american_option.hpp"
 #include <iostream>
 #include <iomanip>
 

--- a/docs/archive/plans/2025-11-04-newton-raphson-implementation.md
+++ b/docs/archive/plans/2025-11-04-newton-raphson-implementation.md
@@ -25,7 +25,7 @@
 Create `tests/tridiagonal_solver_test.cc`:
 
 ```cpp
-#include "src/cpp/tridiagonal_solver.hpp"
+#include "mango/cpp/tridiagonal_solver.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>

--- a/docs/archive/plans/2025-11-04-phase1-week2-workspace-and-operators.md
+++ b/docs/archive/plans/2025-11-04-phase1-week2-workspace-and-operators.md
@@ -21,8 +21,8 @@
 Create `tests/workspace_test.cc`:
 
 ```cpp
-#include "src/cpp/workspace.hpp"
-#include "src/cpp/grid.hpp"
+#include "mango/cpp/workspace.hpp"
+#include "mango/cpp/grid.hpp"
 #include <gtest/gtest.h>
 
 TEST(WorkspaceStorageTest, SmallGridSingleBlock) {
@@ -374,8 +374,8 @@ Tests: 5 passing"
 Create `tests/spatial_operators_test.cc`:
 
 ```cpp
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/grid.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/grid.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/docs/archive/plans/2025-11-04-phase1-weeks3-4-multigrid.md
+++ b/docs/archive/plans/2025-11-04-phase1-weeks3-4-multigrid.md
@@ -23,8 +23,8 @@
 Create `tests/multigrid_test.cc`:
 
 ```cpp
-#include "src/cpp/multigrid.hpp"
-#include "src/cpp/grid.hpp"
+#include "mango/cpp/multigrid.hpp"
+#include "mango/cpp/grid.hpp"
 #include <gtest/gtest.h>
 
 TEST(MultiGridBufferTest, TwoAxisCreation) {
@@ -591,10 +591,10 @@ No functional changes - documentation only"
 Create `tests/integration_5d_price_table_test.cc`:
 
 ```cpp
-#include "src/cpp/multigrid.hpp"
-#include "src/cpp/workspace.hpp"
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/grid.hpp"
+#include "mango/cpp/multigrid.hpp"
+#include "mango/cpp/workspace.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/grid.hpp"
 #include <gtest/gtest.h>
 
 /// Integration test: 5D price table grid setup

--- a/docs/archive/plans/2025-11-04-phase1-weeks5-6-tr-bdf2-solver.md
+++ b/docs/archive/plans/2025-11-04-phase1-weeks5-6-tr-bdf2-solver.md
@@ -47,7 +47,7 @@ This plan implements TR-BDF2 with cache-blocking for performance on large grids 
 Create `tests/time_domain_test.cc`:
 
 ```cpp
-#include "src/cpp/time_domain.hpp"
+#include "mango/cpp/time_domain.hpp"
 #include <gtest/gtest.h>
 
 TEST(TimeDomainTest, BasicConfiguration) {
@@ -197,7 +197,7 @@ Tests: 2 passing"
 Create `tests/trbdf2_config_test.cc`:
 
 ```cpp
-#include "src/cpp/trbdf2_config.hpp"
+#include "mango/cpp/trbdf2_config.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -347,7 +347,7 @@ Tests: 2 passing"
 Create `tests/fixed_point_solver_test.cc`:
 
 ```cpp
-#include "src/cpp/fixed_point_solver.hpp"
+#include "mango/cpp/fixed_point_solver.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -595,9 +595,9 @@ Tests: 3 passing"
 Create `tests/pde_solver_test.cc`:
 
 ```cpp
-#include "src/cpp/pde_solver.hpp"
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/boundary_conditions.hpp"
+#include "mango/cpp/pde_solver.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <numbers>
@@ -1031,9 +1031,9 @@ Tests: 2 passing"
 Create `tests/integration_trbdf2_accuracy_test.cc`:
 
 ```cpp
-#include "src/cpp/pde_solver.hpp"
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/boundary_conditions.hpp"
+#include "mango/cpp/pde_solver.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <numbers>

--- a/docs/archive/plans/2025-11-04-snapshot-optimization-implementation-plan-v2.md
+++ b/docs/archive/plans/2025-11-04-snapshot-optimization-implementation-plan-v2.md
@@ -32,7 +32,7 @@
 Create `tests/snapshot_test.cc`:
 
 ```cpp
-#include "src/cpp/snapshot.hpp"
+#include "mango/cpp/snapshot.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -344,7 +344,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Add to `tests/pde_solver_test.cc`:
 
 ```cpp
-#include "src/cpp/snapshot.hpp"
+#include "mango/cpp/snapshot.hpp"
 
 // Mock collector for testing
 class MockCollector : public mango::SnapshotCollector {
@@ -619,7 +619,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/snapshot_interpolator_test.cc`:
 
 ```cpp
-#include "src/cpp/snapshot_interpolator.hpp"
+#include "mango/cpp/snapshot_interpolator.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -679,7 +679,7 @@ Create `src/cpp/snapshot_interpolator.hpp`:
 ```cpp
 #pragma once
 
-#include "src/cubic_spline.h"
+#include "mango/cubic_spline.h"
 #include <span>
 #include <memory>
 #include <vector>
@@ -811,8 +811,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/price_table_snapshot_collector_test.cc`:
 
 ```cpp
-#include "src/cpp/price_table_snapshot_collector.hpp"
-#include "src/cpp/snapshot.hpp"
+#include "mango/cpp/price_table_snapshot_collector.hpp"
+#include "mango/cpp/snapshot.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>

--- a/docs/archive/plans/2025-11-04-snapshot-optimization-implementation-plan.md
+++ b/docs/archive/plans/2025-11-04-snapshot-optimization-implementation-plan.md
@@ -25,7 +25,7 @@
 Create `tests/snapshot_test.cc`:
 
 ```cpp
-#include "src/cpp/snapshot.hpp"
+#include "mango/cpp/snapshot.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -369,7 +369,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Add to `tests/pde_solver_test.cc`:
 
 ```cpp
-#include "src/cpp/snapshot.hpp"
+#include "mango/cpp/snapshot.hpp"
 
 // Mock collector for testing
 class MockCollector : public mango::SnapshotCollector {
@@ -690,7 +690,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/snapshot_interpolator_test.cc`:
 
 ```cpp
-#include "src/cpp/snapshot_interpolator.hpp"
+#include "mango/cpp/snapshot_interpolator.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -759,7 +759,7 @@ Create `src/cpp/snapshot_interpolator.hpp`:
 ```cpp
 #pragma once
 
-#include "src/cubic_spline.h"  // Existing C cubic spline
+#include "mango/cubic_spline.h"  // Existing C cubic spline
 #include <span>
 #include <memory>
 #include <vector>
@@ -892,8 +892,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/price_table_snapshot_collector_test.cc`:
 
 ```cpp
-#include "src/cpp/price_table_snapshot_collector.hpp"
-#include "src/cpp/snapshot.hpp"
+#include "mango/cpp/price_table_snapshot_collector.hpp"
+#include "mango/cpp/snapshot.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -1228,10 +1228,10 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/snapshot_optimization_benchmark.cc`:
 
 ```cpp
-#include "src/cpp/pde_solver.hpp"
-#include "src/cpp/price_table_snapshot_collector.hpp"
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/boundary_conditions.hpp"
+#include "mango/cpp/pde_solver.hpp"
+#include "mango/cpp/price_table_snapshot_collector.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
 #include <gtest/gtest.h>
 #include <chrono>
 #include <iostream>

--- a/docs/archive/plans/2025-11-04-unified-root-finding-implementation.md
+++ b/docs/archive/plans/2025-11-04-unified-root-finding-implementation.md
@@ -22,7 +22,7 @@
 Create `tests/root_finding_test.cc`:
 
 ```cpp
-#include "src/cpp/root_finding.hpp"
+#include "mango/cpp/root_finding.hpp"
 #include <gtest/gtest.h>
 
 TEST(RootFindingConfigTest, DefaultValues) {
@@ -183,9 +183,9 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/newton_workspace_test.cc`:
 
 ```cpp
-#include "src/cpp/newton_workspace.hpp"
-#include "src/cpp/workspace.hpp"
-#include "src/cpp/grid.hpp"
+#include "mango/cpp/newton_workspace.hpp"
+#include "mango/cpp/workspace.hpp"
+#include "mango/cpp/grid.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -435,12 +435,12 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/newton_solver_test.cc`:
 
 ```cpp
-#include "src/cpp/newton_solver.hpp"
-#include "src/cpp/root_finding.hpp"
-#include "src/cpp/workspace.hpp"
-#include "src/cpp/boundary_conditions.hpp"
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/grid.hpp"
+#include "mango/cpp/newton_solver.hpp"
+#include "mango/cpp/root_finding.hpp"
+#include "mango/cpp/workspace.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/grid.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -1323,7 +1323,7 @@ The library provides a unified configuration and result interface for all root-f
 ### Configuration
 
 ```cpp
-#include "src/cpp/root_finding.hpp"
+#include "mango/cpp/root_finding.hpp"
 
 mango::RootFindingConfig config{
     .max_iter = 100,
@@ -1370,12 +1370,12 @@ Safe borrowing: u_stage and rhs are unused during Newton iteration.
 Create `examples/example_newton_solver.cc`:
 
 ```cpp
-#include "src/cpp/pde_solver.hpp"
-#include "src/cpp/boundary_conditions.hpp"
-#include "src/cpp/spatial_operators.hpp"
-#include "src/cpp/root_finding.hpp"
-#include "src/cpp/grid.hpp"
-#include "src/cpp/time_domain.hpp"
+#include "mango/cpp/pde_solver.hpp"
+#include "mango/cpp/boundary_conditions.hpp"
+#include "mango/cpp/spatial_operators.hpp"
+#include "mango/cpp/root_finding.hpp"
+#include "mango/cpp/grid.hpp"
+#include "mango/cpp/time_domain.hpp"
 #include <iostream>
 #include <vector>
 #include <cmath>

--- a/docs/archive/plans/2025-11-10-unified-memory-management-implementation-plan.md
+++ b/docs/archive/plans/2025-11-10-unified-memory-management-implementation-plan.md
@@ -27,7 +27,7 @@
 Create `tests/memory/unified_memory_resource_test.cc`:
 
 ```cpp
-#include "src/pde/memory/unified_memory_resource.hpp"
+#include "mango/pde/memory/unified_memory_resource.hpp"
 #include <gtest/gtest.h>
 
 TEST(UnifiedMemoryResourceTest, BasicAllocation) {
@@ -208,7 +208,7 @@ Part of unified memory management refactor (Phase 1/5)."
 Create `tests/memory/workspace_base_test.cc`:
 
 ```cpp
-#include "src/pde/memory/workspace_base.hpp"
+#include "mango/pde/memory/workspace_base.hpp"
 #include <gtest/gtest.h>
 
 TEST(WorkspaceBaseTest, TileMetadataGeneration) {
@@ -407,8 +407,8 @@ Part of unified memory management refactor (Phase 1/5)."
 Create `tests/memory/pde_workspace_test.cc`:
 
 ```cpp
-#include "src/pde/memory/pde_workspace.hpp"
-#include "src/grid.hpp"
+#include "mango/pde/memory/pde_workspace.hpp"
+#include "mango/grid.hpp"
 #include <gtest/gtest.h>
 #include <algorithm>
 
@@ -744,7 +744,7 @@ Part of unified memory management refactor (Phase 2/5)."
 Create `tests/cpu/feature_detection_test.cc`:
 
 ```cpp
-#include "src/support/cpu/feature_detection.hpp"
+#include "mango/support/cpu/feature_detection.hpp"
 #include <gtest/gtest.h>
 #include <iostream>
 
@@ -1004,9 +1004,9 @@ Part of unified memory management refactor (Phase 3/5)."
 Create `tests/operators/centered_difference_simd_test.cc`:
 
 ```cpp
-#include "src/pde/operators/centered_difference_simd.hpp"
-#include "src/pde/operators/grid_spacing.hpp"
-#include "src/grid.hpp"
+#include "mango/pde/operators/centered_difference_simd.hpp"
+#include "mango/pde/operators/grid_spacing.hpp"
+#include "mango/grid.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <vector>
@@ -1475,8 +1475,8 @@ PDESolver(/* existing params */)
 Create `tests/pde_solver_simd_benchmark.cc`:
 
 ```cpp
-#include "src/pde_solver.hpp"
-#include "src/support/cpu/feature_detection.hpp"
+#include "mango/pde_solver.hpp"
+#include "mango/support/cpu/feature_detection.hpp"
 #include <gtest/gtest.h>
 #include <chrono>
 #include <iostream>
@@ -1583,14 +1583,14 @@ Old workspace classes are deprecated in favor of new PMR-based implementations.
 
 **Before:**
 \`\`\`cpp
-#include "src/workspace.hpp"
+#include "mango/workspace.hpp"
 WorkspaceStorage workspace(n, grid);
 auto u = workspace.u_current();
 \`\`\`
 
 **After:**
 \`\`\`cpp
-#include "src/pde/memory/pde_workspace.hpp"
+#include "mango/pde/memory/pde_workspace.hpp"
 PDEWorkspace workspace(n, grid);
 auto u = workspace.u_current();  // Same API!
 \`\`\`

--- a/docs/archive/plans/2025-11-11-unified-centered-difference-implementation-plan.md
+++ b/docs/archive/plans/2025-11-11-unified-centered-difference-implementation-plan.md
@@ -552,9 +552,9 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `tests/centered_difference_facade_test.cc`:
 
 ```cpp
-#include "src/pde/operators/centered_difference_facade.hpp"
-#include "src/pde/operators/grid_spacing.hpp"
-#include "src/grid.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/operators/grid_spacing.hpp"
+#include "mango/grid.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>
@@ -754,10 +754,10 @@ Modify `tests/centered_difference_simd_test.cc`:
 Change includes:
 ```cpp
 // Old:
-#include "src/pde/operators/centered_difference_simd.hpp"
+#include "mango/pde/operators/centered_difference_simd.hpp"
 
 // New:
-#include "src/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
 ```
 
 Change test instantiations:

--- a/docs/archive/plans/2025-11-12-option-chain-batch-solver.md
+++ b/docs/archive/plans/2025-11-12-option-chain-batch-solver.md
@@ -62,9 +62,9 @@ Create `src/option/option_chain_solver.hpp`:
 
 #pragma once
 
-#include "src/option/american_option.hpp"
-#include "src/option/slice_solver_workspace.hpp"
-#include "src/support/expected.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/slice_solver_workspace.hpp"
+#include "mango/support/expected.hpp"
 #include <vector>
 #include <span>
 
@@ -182,7 +182,7 @@ git commit -m "feat(option): add option chain configuration struct"
 Create `tests/option_chain_solver_test.cc`:
 
 ```cpp
-#include "src/option/option_chain_solver.hpp"
+#include "mango/option/option_chain_solver.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {
@@ -327,9 +327,9 @@ public:
 Create `src/option/option_chain_solver.cpp`:
 
 ```cpp
-#include "src/option/option_chain_solver.hpp"
-#include "src/option/american_option.hpp"
-#include "src/option/slice_solver_workspace.hpp"
+#include "mango/option/option_chain_solver.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/slice_solver_workspace.hpp"
 
 namespace mango {
 
@@ -757,8 +757,8 @@ git commit -m "test(option): add parallel chain solver tests"
 Create `benchmarks/option_chain_benchmark.cc`:
 
 ```cpp
-#include "src/option/option_chain_solver.hpp"
-#include "src/option/american_option.hpp"
+#include "mango/option/option_chain_solver.hpp"
+#include "mango/option/american_option.hpp"
 #include <benchmark/benchmark.h>
 #include <vector>
 
@@ -956,7 +956,7 @@ Example: SPY Dec-19-2025 Puts with strikes [400, 420, 440, 460, ...]
 ### Basic Usage
 
 ```cpp
-#include "src/option/option_chain_solver.hpp"
+#include "mango/option/option_chain_solver.hpp"
 
 // Define chain: 5 put strikes, shared parameters
 mango::AmericanOptionChain chain{

--- a/docs/archive/plans/2025-11-18-pmr-memory-refactoring.md
+++ b/docs/archive/plans/2025-11-18-pmr-memory-refactoring.md
@@ -24,7 +24,7 @@ Create `tests/pde_workspace_pmr_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/pde/core/pde_workspace_pmr.hpp"
+#include "mango/pde/core/pde_workspace_pmr.hpp"
 #include <memory_resource>
 
 namespace mango {
@@ -85,7 +85,7 @@ Create `src/pde/core/pde_workspace_pmr.hpp`:
 ```cpp
 #pragma once
 
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <memory_resource>
 #include <span>
 #include <expected>
@@ -360,7 +360,7 @@ Create `tests/grid_spacing_view_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/pde/core/grid_spacing.hpp"
+#include "mango/pde/core/grid_spacing.hpp"
 #include <vector>
 
 namespace mango {
@@ -824,9 +824,9 @@ In `src/option/american_solver_workspace.hpp`:
 ```cpp
 #pragma once
 
-#include "src/pde/core/pde_workspace_pmr.hpp"
-#include "src/pde/core/grid_spacing.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/pde_workspace_pmr.hpp"
+#include "mango/pde/core/grid_spacing.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <memory>
 #include <expected>
 #include <string>
@@ -870,7 +870,7 @@ private:
 In `src/option/american_solver_workspace.cpp`:
 
 ```cpp
-#include "src/option/american_solver_workspace.hpp"
+#include "mango/option/american_solver_workspace.hpp"
 
 namespace mango {
 
@@ -1150,13 +1150,13 @@ git commit -m "Update American option test fixture for PMR
 **Step 1: Update example to use PMR workspace**
 
 ```cpp
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/core/pde_workspace_pmr.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
-#include "src/pde/operators/laplacian_pde.hpp"
-#include "src/pde/operators/operator_factory.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/core/pde_workspace_pmr.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
+#include "mango/pde/operators/laplacian_pde.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <iostream>
 #include <memory_resource>
 #include <cmath>

--- a/docs/archive/plans/2025-11-20-greeks-use-pde-operators.md
+++ b/docs/archive/plans/2025-11-20-greeks-use-pde-operators.md
@@ -126,9 +126,9 @@ This will be used by delta/gamma calculations in next commits."
 Open `src/option/american_option.hpp` and add after line 9 (after black_scholes_pde include):
 
 ```cpp
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/operators/black_scholes_pde.hpp"
-#include "src/pde/operators/centered_difference_facade.hpp"  // NEW
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/operators/black_scholes_pde.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"  // NEW
 #include <expected>
 ```
 
@@ -422,7 +422,7 @@ Create `tests/greeks_performance_test.cc`:
  * have acceptable performance overhead vs manual calculation.
  */
 
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 #include <gtest/gtest.h>
 #include <chrono>
 

--- a/docs/archive/plans/2025-11-20-grid-based-american-option-result-design.md
+++ b/docs/archive/plans/2025-11-20-grid-based-american-option-result-design.md
@@ -498,8 +498,8 @@ This design:
 ### Example 1: Basic Usage (No Snapshots)
 
 ```cpp
-#include "src/option/american_option.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 
 // Define params
 AmericanOptionParams params{

--- a/docs/archive/plans/2025-11-20-pde-workspace-implementation.md
+++ b/docs/archive/plans/2025-11-20-pde-workspace-implementation.md
@@ -45,9 +45,9 @@ Create `src/pde/core/grid_with_solution.hpp`:
 #ifndef MANGO_GRID_WITH_SOLUTION_HPP
 #define MANGO_GRID_WITH_SOLUTION_HPP
 
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
-#include "src/bspline/bspline_utils.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
+#include "mango/bspline/bspline_utils.hpp"
 #include <expected>
 #include <memory>
 #include <vector>
@@ -166,9 +166,9 @@ Related: #209"
 Create `tests/grid_with_solution_test.cc`:
 
 ```cpp
-#include "src/pde/core/grid_with_solution.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/grid_with_solution.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {
@@ -491,7 +491,7 @@ Related: #209"
 Create `tests/pde_workspace_spans_test.cc`:
 
 ```cpp
-#include "src/pde/core/pde_workspace_spans.hpp"
+#include "mango/pde/core/pde_workspace_spans.hpp"
 #include <gtest/gtest.h>
 #include <memory_resource>
 #include <vector>
@@ -632,8 +632,8 @@ This completes Commit 1. The new infrastructure is added with zero impact on exi
 At top of `src/pde/core/pde_solver.hpp`, add:
 
 ```cpp
-#include "src/pde/core/grid_with_solution.hpp"
-#include "src/pde/core/pde_workspace_spans.hpp"
+#include "mango/pde/core/grid_with_solution.hpp"
+#include "mango/pde/core/pde_workspace_spans.hpp"
 ```
 
 **Step 2: Replace member variables (lines ~245-266)**

--- a/docs/archive/plans/2025-11-20-pde-workspace-refactoring.md
+++ b/docs/archive/plans/2025-11-20-pde-workspace-refactoring.md
@@ -27,9 +27,9 @@
 Create `tests/grid_with_solution_test.cc`:
 
 ```cpp
-#include "src/pde/core/grid_with_solution.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/grid_with_solution.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {
@@ -148,8 +148,8 @@ Create `src/pde/core/grid_with_solution.hpp`:
 #ifndef MANGO_GRID_WITH_SOLUTION_HPP
 #define MANGO_GRID_WITH_SOLUTION_HPP
 
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <expected>
 #include <memory>
 #include <vector>
@@ -343,7 +343,7 @@ Expected: FAIL with "clamped_knots_cubic was not declared in this scope"
 Modify `src/pde/core/grid_with_solution.hpp`:
 
 ```cpp
-#include "src/bspline/bspline_utils.hpp"  // Add this line
+#include "mango/bspline/bspline_utils.hpp"  // Add this line
 ```
 
 Update `src/pde/core/BUILD.bazel`:
@@ -395,7 +395,7 @@ Related: #209"
 Create `tests/pde_workspace_spans_test.cc`:
 
 ```cpp
-#include "src/pde/core/pde_workspace_spans.hpp"
+#include "mango/pde/core/pde_workspace_spans.hpp"
 #include <gtest/gtest.h>
 #include <memory_resource>
 #include <vector>
@@ -1219,7 +1219,7 @@ Related: #209"
 Create `tests/obstacle_policies_test.cc`:
 
 ```cpp
-#include "src/pde/core/obstacle_policies.hpp"
+#include "mango/pde/core/obstacle_policies.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/docs/archive/plans/2025-11-21-grid-snapshot-refactoring-implementation.md
+++ b/docs/archive/plans/2025-11-21-grid-snapshot-refactoring-implementation.md
@@ -24,9 +24,9 @@
 Create `tests/grid_snapshot_test.cc`:
 
 ```cpp
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/grid_spec.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/grid_spec.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -425,10 +425,10 @@ git commit -m "feat(grid): add snapshot recording API
 Create `tests/pde_solver_snapshot_test.cc`:
 
 ```cpp
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/operators/laplacian_pde.hpp"
-#include "src/pde/operators/operator_factory.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/operators/laplacian_pde.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
 #include <gtest/gtest.h>
 
 // Simple diffusion solver for testing
@@ -633,8 +633,8 @@ git commit -m "test(pde): verify snapshot recording during time steps
 Create `tests/american_option_result_test.cc`:
 
 ```cpp
-#include "src/option/american_option_result.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/option/american_option_result.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 TEST(AmericanOptionResultTest, ValueAtSpot) {
@@ -686,9 +686,9 @@ Create `src/option/american_option_result.hpp`:
 ```cpp
 #pragma once
 
-#include "src/pde/core/grid.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
 #include <memory>
 #include <optional>
 
@@ -758,7 +758,7 @@ private:
 Create `src/option/american_option_result.cpp`:
 
 ```cpp
-#include "src/option/american_option_result.hpp"
+#include "mango/option/american_option_result.hpp"
 
 namespace mango {
 
@@ -1051,8 +1051,8 @@ git commit -m "feat(option): add PDEWorkspace-based constructor
 Create `tests/american_option_new_api_test.cc`:
 
 ```cpp
-#include "src/option/american_option.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <gtest/gtest.h>
 
 TEST(AmericanOptionNewAPITest, SolveWithPDEWorkspace) {

--- a/docs/archive/plans/2025-11-21-simplify-to-openmp-simd-only.md
+++ b/docs/archive/plans/2025-11-21-simplify-to-openmp-simd-only.md
@@ -22,8 +22,8 @@ Create: `tests/pde_operators/target_clones_test.cc`
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/pde/operators/centered_difference_scalar.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/operators/centered_difference_scalar.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <vector>
 #include <cmath>
 #include <dlfcn.h>
@@ -368,7 +368,7 @@ Remove all SimdBackend-related code:
 
 ```cpp
 // DELETE THIS INCLUDE:
-// #include "src/pde/operators/centered_difference_simd_backend.hpp"
+// #include "mango/pde/operators/centered_difference_simd_backend.hpp"
 
 // DELETE ALL BM_Simd_* functions (lines 133-187)
 // DELETE ALL BENCHMARK(BM_Simd_*) registrations (lines 200-203)
@@ -469,8 +469,8 @@ Create: `tests/pde_operators/centered_difference_facade_test.cc`
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/pde/operators/centered_difference_facade.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <vector>
 #include <cmath>
 
@@ -544,7 +544,7 @@ Replace entire file with simplified version:
 ```cpp
 #pragma once
 
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include "centered_difference_scalar.hpp"
 #include <span>
 #include <concepts>
@@ -780,7 +780,7 @@ inline std::string describe_cpu_features() {
 Create: `tests/cpu/cpu_diagnostics_test.cc`
 
 ```cpp
-#include "src/support/cpu/cpu_diagnostics.hpp"
+#include "mango/support/cpu/cpu_diagnostics.hpp"
 #include <gtest/gtest.h>
 #include <iostream>
 
@@ -884,10 +884,10 @@ For each file, replace:
 
 ```cpp
 // OLD:
-#include "src/support/cpu/feature_detection.hpp"
+#include "mango/support/cpu/feature_detection.hpp"
 
 // NEW:
-#include "src/support/cpu/cpu_diagnostics.hpp"
+#include "mango/support/cpu/cpu_diagnostics.hpp"
 ```
 
 **Step 7: Run all tests**
@@ -949,7 +949,7 @@ Benchmark results (see `docs/experiments/openmp-simd-alternative.md`) showed:
 ### Single-ISA Code (Portable)
 
 ```cpp
-#include "src/support/parallel.hpp"
+#include "mango/support/parallel.hpp"
 
 [[gnu::target_clones("default", "avx2", "avx512f")]]
 void compute_stencil(const double* u, double* result, size_t n) {
@@ -1018,7 +1018,7 @@ For typical workloads (1000+ iterations):
 For logging/debugging, use `src/support/cpu/cpu_diagnostics.hpp`:
 
 ```cpp
-#include "src/support/cpu/cpu_diagnostics.hpp"
+#include "mango/support/cpu/cpu_diagnostics.hpp"
 
 void log_cpu_info() {
     auto features = mango::cpu::detect_cpu_features();

--- a/docs/archive/plans/2025-11-22-iv-solver-expected-refactoring.md
+++ b/docs/archive/plans/2025-11-22-iv-solver-expected-refactoring.md
@@ -24,7 +24,7 @@ Create test file `tests/iv_error_types_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 
 using namespace mango;
 
@@ -141,7 +141,7 @@ Create test file `tests/iv_result_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/iv_result.hpp"
+#include "mango/option/iv_result.hpp"
 
 using namespace mango;
 
@@ -331,8 +331,8 @@ std::expected<IVSuccess, IVError> solve_impl(const IVQuery& query);
 Add includes at top:
 
 ```cpp
-#include "src/option/iv_result.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/iv_result.hpp"
+#include "mango/support/error_types.hpp"
 #include <expected>
 ```
 
@@ -604,7 +604,7 @@ In `src/option/iv_result.hpp`, add after IVSuccess:
 ```cpp
 #include <vector>
 #include <expected>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 
 /// Batch IV solver result
 struct BatchIVResult {
@@ -960,7 +960,7 @@ In `CLAUDE.md`, find the "Implied Volatility Solver" section and update:
 ### Basic Usage
 
 ```cpp
-#include "src/option/iv_solver_fdm.hpp"
+#include "mango/option/iv_solver_fdm.hpp"
 
 // Setup option parameters
 OptionSpec spec{
@@ -1085,8 +1085,8 @@ Create `tests/iv_solver_integration_test.cc`:
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/iv_solver_fdm.hpp"
-#include "src/option/american_option.hpp"
+#include "mango/option/iv_solver_fdm.hpp"
+#include "mango/option/american_option.hpp"
 
 using namespace mango;
 
@@ -1249,7 +1249,7 @@ bazel build //... 2>&1 | grep -i deprecated
 
 # 4. Example usage compiles
 cat > /tmp/test_iv_api.cc <<'EOF'
-#include "src/option/iv_solver_fdm.hpp"
+#include "mango/option/iv_solver_fdm.hpp"
 int main() {
     mango::OptionSpec spec{100, 100, 1, 0.05, 0.02, mango::OptionType::PUT};
     mango::IVQuery q{spec, 10.0};

--- a/docs/archive/plans/2025-11-22-mdspan-adoption-implementation.md
+++ b/docs/archive/plans/2025-11-22-mdspan-adoption-implementation.md
@@ -162,7 +162,7 @@ Added basic integration tests to verify functionality."
 
 Create `tests/lapack_banded_layout_test.cc`:
 ```cpp
-#include "src/math/lapack_banded_layout.hpp"
+#include "mango/math/lapack_banded_layout.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -376,7 +376,7 @@ Includes comprehensive tests verifying:
 
 Create `tests/banded_matrix_mdspan_test.cc`:
 ```cpp
-#include "src/math/banded_matrix_solver.hpp"
+#include "mango/math/banded_matrix_solver.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {
@@ -448,7 +448,7 @@ Expected: FAIL (BandedMatrix doesn't have mdspan interface yet)
 Modify `src/math/banded_matrix_solver.hpp` (replace old BandedMatrix class):
 ```cpp
 // Add includes at top of file
-#include "src/math/lapack_banded_layout.hpp"
+#include "mango/math/lapack_banded_layout.hpp"
 #include <experimental/mdspan>
 
 // Replace BandedMatrix class (around line 30-100)
@@ -766,7 +766,7 @@ Performance improvement measured via benchmark test."
 
 Create `tests/bspline_nd_mdspan_test.cc`:
 ```cpp
-#include "src/math/bspline_nd.hpp"
+#include "mango/math/bspline_nd.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {
@@ -1100,7 +1100,7 @@ All existing B-spline tests pass with identical results."
 
 Create `tests/grid_spacing_mdspan_test.cc`:
 ```cpp
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {
@@ -1291,9 +1291,9 @@ Benefits:
 
 Create `tests/mdspan_integration_e2e_test.cc`:
 ```cpp
-#include "src/math/banded_matrix_solver.hpp"
-#include "src/math/bspline_nd.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/math/banded_matrix_solver.hpp"
+#include "mango/math/bspline_nd.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {

--- a/docs/archive/plans/2025-11-23-multi-sinh-grid.md
+++ b/docs/archive/plans/2025-11-23-multi-sinh-grid.md
@@ -749,7 +749,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Create `examples/example_multi_sinh_grid.cc`:
 
 ```cpp
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <iostream>
 #include <format>
 
@@ -874,7 +874,7 @@ For batch solvers that mix instruments with different normalized strikes, multi-
 **Usage:**
 
 ```cpp
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 
 // Define concentration regions
 std::vector<mango::MultiSinhCluster<double>> clusters = {

--- a/docs/archive/plans/2025-11-23-price-table-refactor.md
+++ b/docs/archive/plans/2025-11-23-price-table-refactor.md
@@ -21,7 +21,7 @@
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/support/memory/aligned_arena.hpp"
+#include "mango/support/memory/aligned_arena.hpp"
 
 namespace mango {
 namespace memory {
@@ -127,7 +127,7 @@ private:
 - Create: `src/support/memory/aligned_arena.cpp`
 
 ```cpp
-#include "src/support/memory/aligned_arena.hpp"
+#include "mango/support/memory/aligned_arena.hpp"
 #include <cstring>
 
 namespace mango {
@@ -235,7 +235,7 @@ Part of price table refactor (#XXX)"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/price_table_axes.hpp"
+#include "mango/option/price_table_axes.hpp"
 
 namespace mango {
 namespace {
@@ -424,8 +424,8 @@ Part of price table refactor (#XXX)"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/price_tensor.hpp"
-#include "src/support/memory/aligned_arena.hpp"
+#include "mango/option/price_tensor.hpp"
+#include "mango/support/memory/aligned_arena.hpp"
 
 namespace mango {
 namespace {
@@ -502,7 +502,7 @@ Expected: FAIL with "No such file: src/option/price_tensor.hpp"
 ```cpp
 #pragma once
 
-#include "src/support/memory/aligned_arena.hpp"
+#include "mango/support/memory/aligned_arena.hpp"
 #include <experimental/mdspan>
 #include <memory>
 #include <expected>
@@ -631,7 +631,7 @@ Part of price table refactor (#XXX)"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/price_table_metadata.hpp"
+#include "mango/option/price_table_metadata.hpp"
 
 namespace mango {
 namespace {
@@ -726,8 +726,8 @@ Part of price table refactor (#XXX)"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/price_table_surface.hpp"
-#include "src/support/memory/aligned_arena.hpp"
+#include "mango/option/price_table_surface.hpp"
+#include "mango/support/memory/aligned_arena.hpp"
 
 namespace mango {
 namespace {
@@ -806,10 +806,10 @@ Expected: FAIL
 ```cpp
 #pragma once
 
-#include "src/option/price_table_axes.hpp"
-#include "src/option/price_table_tensor.hpp"
-#include "src/option/price_table_metadata.hpp"
-#include "src/math/bspline_nd.hpp"
+#include "mango/option/price_table_axes.hpp"
+#include "mango/option/price_table_tensor.hpp"
+#include "mango/option/price_table_metadata.hpp"
+#include "mango/math/bspline_nd.hpp"
 #include <memory>
 #include <expected>
 #include <string>
@@ -871,8 +871,8 @@ private:
 - Create: `src/option/price_table_surface.cpp`
 
 ```cpp
-#include "src/option/price_table_surface.hpp"
-#include "src/math/bspline_nd.hpp"
+#include "mango/option/price_table_surface.hpp"
+#include "mango/math/bspline_nd.hpp"
 
 namespace mango {
 
@@ -1023,7 +1023,7 @@ Part of price table refactor (#XXX)"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/price_table_config.hpp"
+#include "mango/option/price_table_config.hpp"
 
 namespace mango {
 namespace {
@@ -1060,8 +1060,8 @@ TEST(PriceTableConfigTest, WithDiscreteDividends) {
 ```cpp
 #pragma once
 
-#include "src/option/american_option.hpp"  // For OptionType
-#include "src/pde/core/grid_spec.hpp"
+#include "mango/option/american_option.hpp"  // For OptionType
+#include "mango/pde/core/grid_spec.hpp"
 #include <vector>
 #include <utility>
 #include <optional>
@@ -1103,7 +1103,7 @@ Part of price table refactor (#XXX)"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/price_table_builder.hpp"
+#include "mango/option/price_table_builder.hpp"
 
 namespace mango {
 namespace {
@@ -1144,10 +1144,10 @@ TEST(PriceTableBuilderTest, BuildEmpty4DSurface) {
 ```cpp
 #pragma once
 
-#include "src/option/price_table_config.hpp"
-#include "src/option/price_table_axes.hpp"
-#include "src/option/price_table_surface.hpp"
-#include "src/option/american_option.hpp"
+#include "mango/option/price_table_config.hpp"
+#include "mango/option/price_table_axes.hpp"
+#include "mango/option/price_table_surface.hpp"
+#include "mango/option/american_option.hpp"
 #include <expected>
 #include <string>
 
@@ -1185,7 +1185,7 @@ private:
 - Create: `src/option/price_table_builder.cpp`
 
 ```cpp
-#include "src/option/price_table_builder.hpp"
+#include "mango/option/price_table_builder.hpp"
 
 namespace mango {
 
@@ -1237,7 +1237,7 @@ Part of price table refactor (#XXX)"
 
 ```cpp
 #include <gtest/gtest.h>
-#include "src/option/recursion_helpers.hpp"
+#include "mango/option/recursion_helpers.hpp"
 #include <vector>
 
 namespace mango {
@@ -1288,7 +1288,7 @@ TEST(RecursionHelpersTest, ForEachAxisIndex4D) {
 ```cpp
 #pragma once
 
-#include "src/option/price_table_axes.hpp"
+#include "mango/option/price_table_axes.hpp"
 #include <array>
 #include <functional>
 

--- a/docs/archive/plans/2025-11-24-price-table-phases-8-10-corrected.md
+++ b/docs/archive/plans/2025-11-24-price-table-phases-8-10-corrected.md
@@ -330,7 +330,7 @@ Expected: FAIL (extract_tensor doesn't exist yet)
 Add to `src/option/price_table_builder.hpp`:
 
 ```cpp
-#include "src/math/cubic_spline_solver.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
 
 private:
     std::expected<PriceTensor<N>, std::string> extract_tensor(

--- a/docs/archive/vectorization-strategy.md
+++ b/docs/archive/vectorization-strategy.md
@@ -323,7 +323,7 @@ Measured on centered difference stencil (second derivative, 100-point grid):
 
 **Step 1: Include the header**
 ```cpp
-#include "src/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
 ```
 
 **Step 2: Create operator from grid spacing**
@@ -493,7 +493,7 @@ objdump -d ./bazel-bin/examples/example_newton_solver | grep -A 30 "avx512"
 Use the CPU diagnostics API to check which ISA is available:
 
 ```cpp
-#include "src/support/cpu/cpu_diagnostics.hpp"
+#include "mango/support/cpu/cpu_diagnostics.hpp"
 
 int main() {
     auto features = mango::cpu::detect_cpu_features();

--- a/docs/plans/2026-01-31-discrete-dividend-interpolated-iv-impl.md
+++ b/docs/plans/2026-01-31-discrete-dividend-interpolated-iv-impl.md
@@ -27,8 +27,8 @@ Modify `AmericanPriceSurface` to handle `SurfaceContent::RawPrice` and expose bo
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/table/price_table_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_surface.hpp"
 
 using namespace mango;
 
@@ -166,8 +166,8 @@ Define the concept that `AmericanPriceSurface` satisfies. This is a header-only 
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_surface_concept.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_surface_concept.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 using namespace mango;
 
@@ -253,7 +253,7 @@ Add optional IC override so the solver can accept a custom initial condition ins
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 
 using namespace mango;
 
@@ -366,8 +366,8 @@ Three additive changes to the existing builder.
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 using namespace mango;
 
@@ -505,7 +505,7 @@ Test segment selection, spot adjustment, and the worked example from the design 
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_price_surface.hpp"
+#include "mango/option/table/segmented_price_surface.hpp"
 
 using namespace mango;
 
@@ -569,7 +569,7 @@ Create `src/option/table/segmented_price_surface.hpp`:
 
 #include <vector>
 #include <utility>
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 namespace mango {
 
@@ -654,7 +654,7 @@ Orchestrates backward-chained construction for a single K_ref.
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_price_table_builder.hpp"
+#include "mango/option/table/segmented_price_table_builder.hpp"
 
 using namespace mango;
 
@@ -761,8 +761,8 @@ Wraps multiple `SegmentedPriceSurface` instances with strike interpolation. Sati
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_multi_kref_surface.hpp"
-#include "src/option/table/price_surface_concept.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/price_surface_concept.hpp"
 
 using namespace mango;
 
@@ -837,7 +837,7 @@ Top-level builder that chooses K_ref values and assembles the multi-K_ref surfac
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
 
 using namespace mango;
 
@@ -913,9 +913,9 @@ Template the solver and replace concrete `AmericanPriceSurface` references with 
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/iv_solver_interpolated.hpp"
-#include "src/option/table/segmented_multi_kref_surface.hpp"
-#include "src/option/table/price_surface_concept.hpp"
+#include "mango/option/iv_solver_interpolated.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/price_surface_concept.hpp"
 
 using namespace mango;
 
@@ -998,7 +998,7 @@ Single factory function that hides the two paths.
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/iv_solver_factory.hpp"
+#include "mango/option/iv_solver_factory.hpp"
 
 using namespace mango;
 
@@ -1085,8 +1085,8 @@ Full integration test exercising the complete pipeline: factory → segmented bu
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/iv_solver_factory.hpp"
-#include "src/option/iv_solver_fdm.hpp"
+#include "mango/option/iv_solver_factory.hpp"
+#include "mango/option/iv_solver_fdm.hpp"
 
 using namespace mango;
 

--- a/docs/plans/2026-01-31-eep-decomposition-impl.md
+++ b/docs/plans/2026-01-31-eep-decomposition-impl.md
@@ -30,7 +30,7 @@ Create `src/option/option_concepts.hpp`:
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/option_spec.hpp"
+#include "mango/option/option_spec.hpp"
 #include <concepts>
 
 namespace mango {
@@ -87,8 +87,8 @@ Create `tests/option_concepts_test.cc`:
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/option_concepts.hpp"
-#include "src/option/american_option_result.hpp"
+#include "mango/option/option_concepts.hpp"
+#include "mango/option/american_option_result.hpp"
 
 namespace mango {
 namespace {
@@ -159,8 +159,8 @@ Create `tests/european_option_test.cc`:
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/european_option.hpp"
-#include "src/option/option_concepts.hpp"
+#include "mango/option/european_option.hpp"
+#include "mango/option/option_concepts.hpp"
 #include <cmath>
 
 namespace mango {
@@ -532,7 +532,7 @@ meta.content = config_.store_eep
 
 **Step 3: Add include and BUILD dep**
 
-Add `#include "src/option/european_option.hpp"` to `price_table_builder.cpp`.
+Add `#include "mango/option/european_option.hpp"` to `price_table_builder.cpp`.
 
 Add `"//src/option:european_option"` to deps in `src/option/table/BUILD.bazel:73-89`.
 
@@ -571,11 +571,11 @@ Create `tests/american_price_surface_test.cc`:
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/option/european_option.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/option/european_option.hpp"
 #include <cmath>
 
 namespace mango {
@@ -974,10 +974,10 @@ Create `tests/eep_integration_test.cc`. This test builds a price table in both r
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/iv_solver_interpolated.hpp"
-#include "src/option/european_option.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/iv_solver_interpolated.hpp"
+#include "mango/option/european_option.hpp"
 
 namespace mango {
 namespace {

--- a/docs/plans/2026-02-01-api-cleanup-design.md
+++ b/docs/plans/2026-02-01-api-cleanup-design.md
@@ -18,7 +18,7 @@ Move `GridAccuracyParams` and `GridAccuracyProfile` from `american_option.hpp`, 
 
 **Files:**
 - Create: `src/option/grid_spec_types.hpp`
-- Modify: `src/option/american_option.hpp` — remove `GridAccuracyParams` and `GridAccuracyProfile` definitions, add `#include "src/option/grid_spec_types.hpp"`
+- Modify: `src/option/american_option.hpp` — remove `GridAccuracyParams` and `GridAccuracyProfile` definitions, add `#include "mango/option/grid_spec_types.hpp"`
 - Modify: `src/option/table/price_table_config.hpp` — remove `ExplicitPDEGrid` and `PDEGridSpec`, add include, replace heavy `american_option.hpp` include with `option_spec.hpp`
 - Modify: `BUILD.bazel` — add new header to appropriate `cc_library` target
 - Modify: any file that includes `american_option.hpp` solely for `GridAccuracyParams` — switch to lighter include
@@ -28,8 +28,8 @@ Move `GridAccuracyParams` and `GridAccuracyProfile` from `american_option.hpp`, 
 ```cpp
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <variant>
 
 namespace mango {
@@ -65,8 +65,8 @@ GridAccuracyParams grid_accuracy_profile(GridAccuracyProfile profile);
 
 **`price_table_config.hpp` after:**
 ```cpp
-#include "src/option/grid_spec_types.hpp"  // PDEGridSpec, ExplicitPDEGrid, GridAccuracyParams
-#include "src/option/option_spec.hpp"      // OptionType (was: american_option.hpp — too heavy)
+#include "mango/option/grid_spec_types.hpp"  // PDEGridSpec, ExplicitPDEGrid, GridAccuracyParams
+#include "mango/option/option_spec.hpp"      // OptionType (was: american_option.hpp — too heavy)
 ```
 
 This fixes the heavy transitive include: `price_table_config.hpp` no longer pulls in the PDE solver chain.
@@ -269,7 +269,7 @@ private:
 ```cpp
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 
 namespace mango::testing {
 

--- a/docs/plans/2026-02-01-api-cleanup-plan.md
+++ b/docs/plans/2026-02-01-api-cleanup-plan.md
@@ -19,8 +19,8 @@ Move `GridAccuracyParams`, `GridAccuracyProfile`, `grid_accuracy_profile()` from
 **Files:**
 - Create: `src/option/grid_spec_types.hpp`
 - Create: `src/option/grid_spec_types.cpp` (for `grid_accuracy_profile()` definition)
-- Modify: `src/option/american_option.hpp:39-101` — remove `GridAccuracyParams`, `GridAccuracyProfile`, `grid_accuracy_profile()`; add `#include "src/option/grid_spec_types.hpp"`
-- Modify: `src/option/table/price_table_config.hpp:4-22` — remove `ExplicitPDEGrid` and `PDEGridSpec`; replace `#include "src/option/american_option.hpp"` with `#include "src/option/grid_spec_types.hpp"` and `#include "src/option/option_spec.hpp"`
+- Modify: `src/option/american_option.hpp:39-101` — remove `GridAccuracyParams`, `GridAccuracyProfile`, `grid_accuracy_profile()`; add `#include "mango/option/grid_spec_types.hpp"`
+- Modify: `src/option/table/price_table_config.hpp:4-22` — remove `ExplicitPDEGrid` and `PDEGridSpec`; replace `#include "mango/option/american_option.hpp"` with `#include "mango/option/grid_spec_types.hpp"` and `#include "mango/option/option_spec.hpp"`
 - Modify: `src/option/BUILD.bazel` — add `grid_spec_types` cc_library target; update deps for `american_option` and others
 - Modify: `src/option/table/BUILD.bazel:58-66` — update `price_table_config` deps: replace `/src/option:american_option` with `/src/option:grid_spec_types` and `/src/option:option_spec`
 
@@ -31,7 +31,7 @@ Write `src/option/grid_spec_types.hpp`:
 ```cpp
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <variant>
 #include <vector>
 
@@ -87,7 +87,7 @@ Update `src/option/table/BUILD.bazel` `price_table_config` target:
 
 **Step 3: Update `american_option.hpp`**
 
-- Add `#include "src/option/grid_spec_types.hpp"` to includes
+- Add `#include "mango/option/grid_spec_types.hpp"` to includes
 - Remove lines 39-101 (`GridAccuracyParams` struct, `GridAccuracyProfile` enum, `grid_accuracy_profile()` function) — they now live in the new header
 - Keep `estimate_grid_for_option()` and `compute_global_grid_for_batch()` here (they depend on `PricingParams` which is in `option_spec.hpp`)
 
@@ -95,12 +95,12 @@ Update `src/option/table/BUILD.bazel` `price_table_config` target:
 
 Replace:
 ```cpp
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 ```
 With:
 ```cpp
-#include "src/option/grid_spec_types.hpp"
-#include "src/option/option_spec.hpp"
+#include "mango/option/grid_spec_types.hpp"
+#include "mango/option/option_spec.hpp"
 ```
 
 Remove the `ExplicitPDEGrid` struct (lines 15-19) and `PDEGridSpec` alias (line 22) — now in `grid_spec_types.hpp`.
@@ -151,7 +151,7 @@ struct IVSolverFDMConfig {
 };
 ```
 
-Add `#include "src/option/grid_spec_types.hpp"` if not already included transitively.
+Add `#include "mango/option/grid_spec_types.hpp"` if not already included transitively.
 
 **Step 2: Update `iv_solver_fdm.cpp`**
 
@@ -458,7 +458,7 @@ Write `tests/price_table_builder_test_access.hpp`:
 ```cpp
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 
 namespace mango::testing {
 
@@ -575,7 +575,7 @@ Update all deps referencing `:option_chain` → `:option_grid`.
 **Step 3: Update includes and references**
 
 In `src/option/table/price_table_builder.hpp:11`:
-- `#include "src/option/option_chain.hpp"` → `#include "src/option/option_grid.hpp"`
+- `#include "mango/option/option_chain.hpp"` → `#include "mango/option/option_grid.hpp"`
 - Rename factory methods: `from_chain` → `from_grid`, `from_chain_auto` → `from_grid_auto`, `from_chain_auto_profile` → `from_grid_auto_profile`
 - Rename parameter types: `const OptionChain&` → `const OptionGrid&`
 

--- a/docs/plans/2026-02-01-api-safety-impl.md
+++ b/docs/plans/2026-02-01-api-safety-impl.md
@@ -275,7 +275,7 @@ concept PriceSurface = requires(const S& s, double spot, double strike,
 };
 ```
 
-This requires adding `#include "src/option/option_spec.hpp"` to the concept header (for `OptionType`).
+This requires adding `#include "mango/option/option_spec.hpp"` to the concept header (for `OptionType`).
 
 **Step 3: Add accessors to AmericanPriceSurface**
 

--- a/docs/plans/2026-02-01-fdm-discrete-dividends-impl.md
+++ b/docs/plans/2026-02-01-fdm-discrete-dividends-impl.md
@@ -401,7 +401,7 @@ Create `tests/discrete_dividend_event_test.cc`:
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/discrete_dividend_event.hpp"
+#include "mango/option/discrete_dividend_event.hpp"
 #include <vector>
 #include <cmath>
 
@@ -520,8 +520,8 @@ Create `src/option/discrete_dividend_event.hpp`:
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/pde/core/pde_solver.hpp"
-#include "src/math/cubic_spline_solver.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
 #include <cmath>
 #include <span>
 #include <vector>
@@ -749,7 +749,7 @@ In `src/option/american_option.cpp`, add dividend event registration after creat
 
 Add include at top:
 ```cpp
-#include "src/option/discrete_dividend_event.hpp"
+#include "mango/option/discrete_dividend_event.hpp"
 ```
 
 In `solve()`, replace the solver creation block (lines 109-119) with:
@@ -886,8 +886,8 @@ lower bound). Also compare put-call parity bounds.
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
 
 using namespace mango;
 

--- a/docs/plans/2026-02-01-test-quality-improvements.md
+++ b/docs/plans/2026-02-01-test-quality-improvements.md
@@ -571,7 +571,7 @@ ThomasWorkspace construction and resize.
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 
 using namespace mango;
 
@@ -749,7 +749,7 @@ are used at every API boundary but had zero test coverage.
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/option_spec.hpp"
+#include "mango/option/option_spec.hpp"
 #include <cmath>
 
 using namespace mango;

--- a/docs/plans/2026-02-02-boundary-smoothing-design.md
+++ b/docs/plans/2026-02-02-boundary-smoothing-design.md
@@ -1,0 +1,56 @@
+# K_ref Boundary Smoothing Design
+
+## Problem
+
+`SegmentedMultiKRefSurface` interpolates across independently-fit B-spline
+surfaces using Catmull-Rom in log(K_ref) space. Three edge cases produce
+artificial kinks:
+
+1. **< 4 K_ref points:** falls back to piecewise linear (C0 only)
+2. **Edge clamping:** duplicating edge indices degrades Catmull-Rom to quadratic
+3. **Outside K_ref range:** hard switch to nearest surface (discontinuous derivative)
+
+## Fixes
+
+### 1. Monotone Hermite for < 4 points
+
+Replace the piecewise linear fallback in `interp_across_krefs()` with
+Fritsch-Carlson monotone Hermite interpolation. For 3 points this gives C1
+continuity while preserving monotonicity. For 2 points, keep linear.
+
+Inline implementation (~20 lines), no new utility file.
+
+### 2. Virtual edge points for Catmull-Rom
+
+Replace index clamping (`i0=i1` or `i3=i2`) with linearly extrapolated
+virtual points:
+
+- Left edge: `x_v = 2*x[1] - x[2]`, `y_v = 2*y[1] - y[2]`
+- Right edge: `x_v = 2*x[2] - x[1]`, `y_v = 2*y[2] - y[1]`
+
+Preserves cubic character at boundary intervals.
+
+### 3. Smooth extrapolation outside K_ref range
+
+Let Catmull-Rom naturally extrapolate (up to ~1 K_ref spacing) instead of
+hard-switching to nearest surface. Beyond the extrapolation limit, clamp
+to nearest.
+
+### 4. Boundary disagreement metric (test-only)
+
+Free function in the test file that evaluates adjacent surfaces at shared
+K_ref boundaries across a grid of (tau, sigma, rate) and reports max/mean
+normalized price difference. Diagnostic for deciding if overlap blending
+(future Option B) is needed.
+
+## Files
+
+- `src/option/table/segmented_multi_kref_surface.cpp` -- fixes 1, 2, 3
+- `tests/segmented_multi_kref_surface_test.cc` -- fix 4, smoothness tests
+
+## Testing
+
+- Numerical derivative checks: verify C1 continuity across K_ref boundaries
+- Boundary disagreement metric: quantify cross-surface mismatch
+- Regression: existing tests pass
+- IV solver integration: Newton convergence unchanged or improved

--- a/docs/plans/2026-02-02-boundary-smoothing-impl.md
+++ b/docs/plans/2026-02-02-boundary-smoothing-impl.md
@@ -1,0 +1,673 @@
+# K_ref Boundary Smoothing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove artificial kinks at K_ref boundaries in SegmentedMultiKRefSurface by fixing interpolation edge cases.
+
+**Architecture:** All changes are in `interp_across_krefs()` and the `price()`/`vega()` entry logic in `segmented_multi_kref_surface.cpp`. Three interpolation fixes (C1 Hermite, virtual edge points, smooth extrapolation) plus test-only diagnostics. No new files, no header changes.
+
+**Tech Stack:** C++23, GoogleTest, Bazel
+
+---
+
+### Task 1: Add C1 smoothness tests (failing)
+
+Write tests that detect the current C0 kinks. These fail now and pass after fixes.
+
+**Files:**
+- Modify: `tests/segmented_multi_kref_surface_test.cc`
+
+**Step 1: Write the failing smoothness test**
+
+Add a test that checks numerical derivative continuity across K_ref boundaries.
+The test builds a 3-point surface ({80, 100, 120}), then evaluates price at
+strikes near K_ref=100 using **off-boundary points only** (avoids the
+exact-match branch that bypasses interpolation).
+
+```cpp
+// Numerical derivative smoothness test at K_ref boundaries
+TEST(SegmentedMultiKRefSurfaceTest, C1SmoothnessAtKRefBoundary) {
+    auto s80 = build_surface(80.0);
+    auto s100 = build_surface(100.0);
+    auto s120 = build_surface(120.0);
+
+    std::vector<SegmentedMultiKRefSurface::Entry> entries;
+    entries.push_back({80.0, std::move(s80)});
+    entries.push_back({100.0, std::move(s100)});
+    entries.push_back({120.0, std::move(s120)});
+
+    auto surface = SegmentedMultiKRefSurface::create(std::move(entries));
+    ASSERT_TRUE(surface.has_value());
+
+    // Use off-boundary points to avoid the exact-match branch in price()
+    // which bypasses interpolation and could mask discontinuities
+    constexpr double spot = 100.0, tau = 0.5, sigma = 0.20, rate = 0.05;
+    constexpr double h = 0.5;  // step size for finite differences
+
+    // Compute left and right derivatives near K_ref=100 using 4-point stencil
+    // Left derivative:  (p(K-h) - p(K-2h)) / h
+    // Right derivative: (p(K+2h) - p(K+h)) / h
+    double K = 100.0;
+    double p_minus2h = surface->price(spot, K - 2*h, tau, sigma, rate);
+    double p_minus_h = surface->price(spot, K - h, tau, sigma, rate);
+    double p_plus_h  = surface->price(spot, K + h, tau, sigma, rate);
+    double p_plus2h  = surface->price(spot, K + 2*h, tau, sigma, rate);
+
+    double deriv_left  = (p_minus_h - p_minus2h) / h;
+    double deriv_right = (p_plus2h - p_plus_h) / h;
+
+    // For C1 continuity, these should be close
+    // Tolerance: relative difference < 10% of the average absolute derivative
+    double avg_deriv = 0.5 * (std::abs(deriv_left) + std::abs(deriv_right));
+    if (avg_deriv > 1e-10) {  // skip if derivative is near zero
+        double rel_diff = std::abs(deriv_left - deriv_right) / avg_deriv;
+        EXPECT_LT(rel_diff, 0.10)
+            << "Derivative discontinuity at K_ref=100: "
+            << "left=" << deriv_left << " right=" << deriv_right;
+    }
+}
+
+// Also test vega smoothness at K_ref boundaries
+TEST(SegmentedMultiKRefSurfaceTest, VegaSmoothnessAtKRefBoundary) {
+    auto s80 = build_surface(80.0);
+    auto s100 = build_surface(100.0);
+    auto s120 = build_surface(120.0);
+
+    std::vector<SegmentedMultiKRefSurface::Entry> entries;
+    entries.push_back({80.0, std::move(s80)});
+    entries.push_back({100.0, std::move(s100)});
+    entries.push_back({120.0, std::move(s120)});
+
+    auto surface = SegmentedMultiKRefSurface::create(std::move(entries));
+    ASSERT_TRUE(surface.has_value());
+
+    constexpr double spot = 100.0, tau = 0.5, sigma = 0.20, rate = 0.05;
+    constexpr double h = 0.5;
+
+    double K = 100.0;
+    double v_minus2h = surface->vega(spot, K - 2*h, tau, sigma, rate);
+    double v_minus_h = surface->vega(spot, K - h, tau, sigma, rate);
+    double v_plus_h  = surface->vega(spot, K + h, tau, sigma, rate);
+    double v_plus2h  = surface->vega(spot, K + 2*h, tau, sigma, rate);
+
+    double deriv_left  = (v_minus_h - v_minus2h) / h;
+    double deriv_right = (v_plus2h - v_plus_h) / h;
+
+    double avg_deriv = 0.5 * (std::abs(deriv_left) + std::abs(deriv_right));
+    if (avg_deriv > 1e-10) {
+        double rel_diff = std::abs(deriv_left - deriv_right) / avg_deriv;
+        EXPECT_LT(rel_diff, 0.10)
+            << "Vega derivative discontinuity at K_ref=100: "
+            << "left=" << deriv_left << " right=" << deriv_right;
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bazel test //tests:segmented_multi_kref_surface_test --test_filter=C1Smoothness --test_output=all`
+
+Expected: FAIL (current piecewise linear interpolation with 3 points produces C0 kink)
+
+**Step 3: Commit**
+
+```bash
+git add tests/segmented_multi_kref_surface_test.cc
+git commit -m "Add failing C1 smoothness tests for K_ref boundaries"
+```
+
+---
+
+### Task 2: Implement C1 Hermite for < 4 K_ref points
+
+Replace the piecewise linear fallback with Fritsch-Carlson C1 Hermite.
+
+**Files:**
+- Modify: `src/option/table/segmented_multi_kref_surface.cpp:102-180`
+
+**Context:** The current `interp_across_krefs()` uses piecewise linear when
+`entries.size() < 4`. This gives C0 only. We need a proper C1 Hermite that:
+- Handles non-uniform spacing in log(K_ref) correctly
+- Uses weighted slopes for endpoints (not simple one-sided differences)
+- Applies monotonicity limiter only when data is monotone
+- Falls back to C1 central difference when data is non-monotone
+- Supports extrapolation (t outside [x[0], x[n-1]])
+
+**Step 1: Add C1 Hermite helper**
+
+Add a static helper function above `interp_across_krefs()`:
+
+```cpp
+// C1 Hermite interpolation (Fritsch-Carlson) for n=2 or n=3 points.
+// x[] are strictly increasing positions in log(K_ref) space.
+// y[] are normalized values (value/K_ref).
+// t can be inside or outside [x[0], x[n-1]] (extrapolation supported).
+static double hermite_interp(const double* x, const double* y, size_t n,
+                             double t) {
+    if (n == 2) {
+        double u = (t - x[0]) / (x[1] - x[0]);
+        return (1.0 - u) * y[0] + u * y[1];
+    }
+
+    // n == 3: Full Fritsch-Carlson for non-uniform spacing
+    const double h0 = x[1] - x[0];
+    const double h1 = x[2] - x[1];
+    const double d0 = (y[1] - y[0]) / h0;
+    const double d1 = (y[2] - y[1]) / h1;
+
+    // Weighted endpoint slopes (correct for non-uniform spacing)
+    double m0 = ((2.0 * h0 + h1) * d0 - h0 * d1) / (h0 + h1);
+    double m2 = ((2.0 * h1 + h0) * d1 - h1 * d0) / (h0 + h1);
+
+    // Interior slope
+    double m1;
+    if (d0 * d1 > 0.0) {
+        // Data is monotone over both intervals: weighted harmonic mean
+        const double w1 = 2.0 * h1 + h0;
+        const double w2 = 2.0 * h0 + h1;
+        m1 = (w1 + w2) / (w1 / d0 + w2 / d1);
+    } else {
+        // Non-monotone data: C1 central difference (no monotone forcing)
+        m1 = (h0 * d1 + h1 * d0) / (h0 + h1);
+    }
+
+    // Monotonicity limiter on ALL slopes (only when data is monotone)
+    if (d0 * d1 > 0.0) {
+        auto limit = [](double& m, double d_near) {
+            if (m * d_near <= 0.0) { m = 0.0; return; }
+            double lim = 3.0 * std::abs(d_near);
+            if (std::abs(m) > lim) m = std::copysign(lim, m);
+        };
+        limit(m0, d0);
+        limit(m1, d0);
+        limit(m1, d1);
+        limit(m2, d1);
+    }
+
+    // Choose interval (supports extrapolation: t can be outside [x[0], x[2]])
+    size_t i = (t <= x[1]) ? 0 : 1;
+
+    const double hi = x[i + 1] - x[i];
+    const double u = (t - x[i]) / hi;
+    const double u2 = u * u;
+    const double u3 = u2 * u;
+
+    const double mi  = (i == 0) ? m0 : m1;
+    const double mi1 = (i == 0) ? m1 : m2;
+
+    // Hermite basis (slopes scaled by interval width)
+    return (2.0 * u3 - 3.0 * u2 + 1.0) * y[i]
+         + (u3 - 2.0 * u2 + u)          * (mi * hi)
+         + (-2.0 * u3 + 3.0 * u2)       * y[i + 1]
+         + (u3 - u2)                     * (mi1 * hi);
+}
+```
+
+**Step 2: Replace the linear fallback in `interp_across_krefs()`**
+
+Replace lines 149-156 (the `if (n < 4)` block) with:
+
+```cpp
+    if (n < 4) {
+        // C1 Hermite for 2-3 points (Fritsch-Carlson for n=3, linear for n=2)
+        std::array<double, 3> xs, ys;
+        for (size_t i = 0; i < n; ++i) {
+            xs[i] = std::log(entries[i].K_ref);
+            ys[i] = eval_fn(i) / entries[i].K_ref;
+        }
+        double result = hermite_interp(xs.data(), ys.data(), n, log_strike);
+        return std::max(result, 0.0) * strike;  // clamp non-negative
+    }
+```
+
+**Step 3: Run tests to verify the smoothness tests pass**
+
+Run: `bazel test //tests:segmented_multi_kref_surface_test --test_output=all`
+
+Expected: All tests pass including the new C1 smoothness tests.
+
+**Step 4: Commit**
+
+```bash
+git add src/option/table/segmented_multi_kref_surface.cpp
+git commit -m "Replace linear fallback with C1 Hermite for < 4 K_refs"
+```
+
+---
+
+### Task 3: Virtual edge points for Catmull-Rom
+
+Replace index clamping with linearly extrapolated virtual points at edges.
+
+**Files:**
+- Modify: `src/option/table/segmented_multi_kref_surface.cpp:158-177`
+- Modify: `tests/segmented_multi_kref_surface_test.cc`
+
+**Step 1: Write a smoothness test for 5+ K_ref points with asymmetric spacing**
+
+Use asymmetric K_ref spacing to make the edge clamping issue visible.
+
+```cpp
+TEST(SegmentedMultiKRefSurfaceTest, C1SmoothnessAtEdgeIntervals) {
+    // Asymmetric spacing makes edge clamping visible
+    // (uniform spacing can hide the issue because duplicate gives same slope)
+    std::vector<SegmentedMultiKRefSurface::Entry> entries;
+    for (double K : {70.0, 80.0, 100.0, 115.0, 140.0}) {
+        entries.push_back({K, build_surface(K)});
+    }
+
+    auto surface = SegmentedMultiKRefSurface::create(std::move(entries));
+    ASSERT_TRUE(surface.has_value());
+
+    constexpr double spot = 100.0, tau = 0.5, sigma = 0.20, rate = 0.05;
+    constexpr double h = 0.5;
+
+    // Check smoothness near edge K_refs (K=80 is first interior, K=115 is last interior)
+    for (double K : {80.0, 115.0}) {
+        double p_m2 = surface->price(spot, K - 2*h, tau, sigma, rate);
+        double p_m1 = surface->price(spot, K - h, tau, sigma, rate);
+        double p_p1 = surface->price(spot, K + h, tau, sigma, rate);
+        double p_p2 = surface->price(spot, K + 2*h, tau, sigma, rate);
+
+        double deriv_left  = (p_m1 - p_m2) / h;
+        double deriv_right = (p_p2 - p_p1) / h;
+
+        double avg_deriv = 0.5 * (std::abs(deriv_left) + std::abs(deriv_right));
+        if (avg_deriv > 1e-10) {
+            double rel_diff = std::abs(deriv_left - deriv_right) / avg_deriv;
+            EXPECT_LT(rel_diff, 0.15)
+                << "Edge derivative discontinuity at K=" << K
+                << ": left=" << deriv_left << " right=" << deriv_right;
+        }
+    }
+
+    // Same for vega
+    for (double K : {80.0, 115.0}) {
+        double v_m2 = surface->vega(spot, K - 2*h, tau, sigma, rate);
+        double v_m1 = surface->vega(spot, K - h, tau, sigma, rate);
+        double v_p1 = surface->vega(spot, K + h, tau, sigma, rate);
+        double v_p2 = surface->vega(spot, K + 2*h, tau, sigma, rate);
+
+        double deriv_left  = (v_m1 - v_m2) / h;
+        double deriv_right = (v_p2 - v_p1) / h;
+
+        double avg_deriv = 0.5 * (std::abs(deriv_left) + std::abs(deriv_right));
+        if (avg_deriv > 1e-10) {
+            double rel_diff = std::abs(deriv_left - deriv_right) / avg_deriv;
+            EXPECT_LT(rel_diff, 0.15)
+                << "Vega edge discontinuity at K=" << K
+                << ": left=" << deriv_left << " right=" << deriv_right;
+        }
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bazel test //tests:segmented_multi_kref_surface_test --test_filter=C1SmoothnessAtEdge --test_output=all`
+
+**Step 3: Replace clamping with virtual points**
+
+In `interp_across_krefs()`, replace the index selection and x/y array construction
+(lines ~158-177):
+
+```cpp
+    // Select 4 entries centered on the bracket [lo_idx, lo_idx+1]
+    size_t i1 = lo_idx;
+    size_t i2 = lo_idx + 1;
+
+    // Use virtual points at edges (linear extrapolation) instead of clamping
+    std::array<double, 4> x, y;
+    x[1] = std::log(entries[i1].K_ref);
+    x[2] = std::log(entries[i2].K_ref);
+    y[1] = eval_fn(i1) / entries[i1].K_ref;
+    y[2] = eval_fn(i2) / entries[i2].K_ref;
+
+    if (i1 > 0) {
+        size_t i0 = i1 - 1;
+        x[0] = std::log(entries[i0].K_ref);
+        y[0] = eval_fn(i0) / entries[i0].K_ref;
+    } else {
+        // Virtual left point: linear extrapolation from [i1, i2]
+        x[0] = 2.0 * x[1] - x[2];
+        y[0] = 2.0 * y[1] - y[2];
+    }
+
+    if (i2 + 1 < n) {
+        size_t i3 = i2 + 1;
+        x[3] = std::log(entries[i3].K_ref);
+        y[3] = eval_fn(i3) / entries[i3].K_ref;
+    } else {
+        // Virtual right point: linear extrapolation from [i1, i2]
+        x[3] = 2.0 * x[2] - x[1];
+        y[3] = 2.0 * y[2] - y[1];
+    }
+
+    // Clamp result to non-negative (Catmull-Rom can overshoot at edges)
+    double result = catmull_rom(x, y, log_strike);
+    return std::max(result, 0.0) * strike;
+```
+
+**Step 4: Run tests**
+
+Run: `bazel test //tests:segmented_multi_kref_surface_test --test_output=all`
+
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/option/table/segmented_multi_kref_surface.cpp tests/segmented_multi_kref_surface_test.cc
+git commit -m "Use virtual edge points for Catmull-Rom instead of clamping"
+```
+
+---
+
+### Task 4: Smooth extrapolation outside K_ref range
+
+Let Catmull-Rom naturally extrapolate for modest distances beyond the K_ref range.
+Bound extrapolation in **log(K_ref) space** (not linear space) to avoid
+overshooting with irregular grids. Clamp output to non-negative.
+
+**Files:**
+- Modify: `src/option/table/segmented_multi_kref_surface.cpp:182-228` (price and vega)
+- Modify: `tests/segmented_multi_kref_surface_test.cc`
+
+**Step 1: Write tests for smooth transition at K_ref boundaries**
+
+```cpp
+TEST(SegmentedMultiKRefSurfaceTest, SmoothExtrapolationOutsideRange) {
+    std::vector<SegmentedMultiKRefSurface::Entry> entries;
+    for (double K : {80.0, 100.0, 120.0}) {
+        entries.push_back({K, build_surface(K)});
+    }
+
+    auto surface = SegmentedMultiKRefSurface::create(std::move(entries));
+    ASSERT_TRUE(surface.has_value());
+
+    constexpr double spot = 100.0, tau = 0.5, sigma = 0.20, rate = 0.05;
+    constexpr double h = 0.5;
+
+    // Check price smoothness at the left boundary (K_ref=80)
+    {
+        double K = 80.0;
+        double p_m2 = surface->price(spot, K - 2*h, tau, sigma, rate);
+        double p_m1 = surface->price(spot, K - h, tau, sigma, rate);
+        double p_p1 = surface->price(spot, K + h, tau, sigma, rate);
+        double p_p2 = surface->price(spot, K + 2*h, tau, sigma, rate);
+
+        double deriv_left  = (p_m1 - p_m2) / h;
+        double deriv_right = (p_p2 - p_p1) / h;
+
+        double avg_deriv = 0.5 * (std::abs(deriv_left) + std::abs(deriv_right));
+        if (avg_deriv > 1e-10) {
+            double rel_diff = std::abs(deriv_left - deriv_right) / avg_deriv;
+            EXPECT_LT(rel_diff, 0.25)
+                << "Extrapolation kink at left boundary K=" << K
+                << ": left_deriv=" << deriv_left << " right_deriv=" << deriv_right;
+        }
+    }
+
+    // Check vega smoothness at the right boundary (K_ref=120)
+    {
+        double K = 120.0;
+        double v_m2 = surface->vega(spot, K - 2*h, tau, sigma, rate);
+        double v_m1 = surface->vega(spot, K - h, tau, sigma, rate);
+        double v_p1 = surface->vega(spot, K + h, tau, sigma, rate);
+        double v_p2 = surface->vega(spot, K + 2*h, tau, sigma, rate);
+
+        double deriv_left  = (v_m1 - v_m2) / h;
+        double deriv_right = (v_p2 - v_p1) / h;
+
+        double avg_deriv = 0.5 * (std::abs(deriv_left) + std::abs(deriv_right));
+        if (avg_deriv > 1e-10) {
+            double rel_diff = std::abs(deriv_left - deriv_right) / avg_deriv;
+            EXPECT_LT(rel_diff, 0.25)
+                << "Vega extrapolation kink at right boundary K=" << K
+                << ": left_deriv=" << deriv_left << " right_deriv=" << deriv_right;
+        }
+    }
+
+    // Extrapolated prices must be finite and non-negative
+    for (double K_out : {75.0, 70.0, 125.0, 130.0}) {
+        double p = surface->price(spot, K_out, tau, sigma, rate);
+        EXPECT_TRUE(std::isfinite(p)) << "K=" << K_out;
+        EXPECT_GE(p, 0.0) << "K=" << K_out;  // non-negative guard
+
+        double v = surface->vega(spot, K_out, tau, sigma, rate);
+        EXPECT_TRUE(std::isfinite(v)) << "vega K=" << K_out;
+    }
+}
+```
+
+**Step 2: Implement smooth extrapolation in `price()`**
+
+Replace the `price()` method. Key changes:
+- Extrapolation bounds in **log space** (one log-interval beyond range)
+- Clamp to nearest surface beyond the extrapolation limit
+- Non-negative guard on output
+
+```cpp
+double SegmentedMultiKRefSurface::price(double spot, double strike,
+                                         double tau, double sigma,
+                                         double rate) const {
+    const size_t n = entries_.size();
+
+    // Single entry: use it directly
+    if (n == 1) {
+        return entries_.front().surface.price(spot, strike, tau, sigma, rate);
+    }
+
+    // Extrapolation bounds in log space (one log-interval beyond range)
+    double log_K_min = std::log(entries_.front().K_ref);
+    double log_K_max = std::log(entries_.back().K_ref);
+    double log_left_spacing = (n > 1)
+        ? std::log(entries_[1].K_ref) - log_K_min : 0.0;
+    double log_right_spacing = (n > 1)
+        ? log_K_max - std::log(entries_[n - 2].K_ref) : 0.0;
+    double log_strike = std::log(strike);
+
+    if (log_strike < log_K_min - log_left_spacing) {
+        return entries_.front().surface.price(spot, strike, tau, sigma, rate);
+    }
+    if (log_strike > log_K_max + log_right_spacing) {
+        return entries_.back().surface.price(spot, strike, tau, sigma, rate);
+    }
+
+    // Exact match at boundary K_refs (must check before extrapolation path)
+    if (strike == entries_.front().K_ref) {
+        return entries_.front().surface.price(spot, strike, tau, sigma, rate);
+    }
+    if (strike == entries_.back().K_ref) {
+        return entries_.back().surface.price(spot, strike, tau, sigma, rate);
+    }
+
+    // For strikes in the extrapolation zone or interior, use interpolation
+    size_t lo_idx;
+    if (strike < entries_.front().K_ref) {
+        lo_idx = 0;
+    } else if (strike > entries_.back().K_ref) {
+        lo_idx = n - 2;
+    } else {
+        lo_idx = find_bracket(strike);
+        // Exact match at interior K_ref
+        if (strike == entries_[lo_idx].K_ref) {
+            return entries_[lo_idx].surface.price(spot, strike, tau, sigma, rate);
+        }
+    }
+
+    return interp_across_krefs(entries_, strike, lo_idx, [&](size_t i) {
+        return entries_[i].surface.price(spot, strike, tau, sigma, rate);
+    });
+}
+```
+
+**Step 3: Apply the same pattern to `vega()`**
+
+Same log-space extrapolation logic as price().
+
+```cpp
+double SegmentedMultiKRefSurface::vega(double spot, double strike,
+                                        double tau, double sigma,
+                                        double rate) const {
+    const size_t n = entries_.size();
+
+    if (n == 1) {
+        return entries_.front().surface.vega(spot, strike, tau, sigma, rate);
+    }
+
+    double log_K_min = std::log(entries_.front().K_ref);
+    double log_K_max = std::log(entries_.back().K_ref);
+    double log_left_spacing = (n > 1)
+        ? std::log(entries_[1].K_ref) - log_K_min : 0.0;
+    double log_right_spacing = (n > 1)
+        ? log_K_max - std::log(entries_[n - 2].K_ref) : 0.0;
+    double log_strike = std::log(strike);
+
+    if (log_strike < log_K_min - log_left_spacing) {
+        return entries_.front().surface.vega(spot, strike, tau, sigma, rate);
+    }
+    if (log_strike > log_K_max + log_right_spacing) {
+        return entries_.back().surface.vega(spot, strike, tau, sigma, rate);
+    }
+
+    // Exact match at boundary K_refs
+    if (strike == entries_.front().K_ref) {
+        return entries_.front().surface.vega(spot, strike, tau, sigma, rate);
+    }
+    if (strike == entries_.back().K_ref) {
+        return entries_.back().surface.vega(spot, strike, tau, sigma, rate);
+    }
+
+    size_t lo_idx;
+    if (strike < entries_.front().K_ref) {
+        lo_idx = 0;
+    } else if (strike > entries_.back().K_ref) {
+        lo_idx = n - 2;
+    } else {
+        lo_idx = find_bracket(strike);
+        if (strike == entries_[lo_idx].K_ref) {
+            return entries_[lo_idx].surface.vega(spot, strike, tau, sigma, rate);
+        }
+    }
+
+    return interp_across_krefs(entries_, strike, lo_idx, [&](size_t i) {
+        return entries_[i].surface.vega(spot, strike, tau, sigma, rate);
+    });
+}
+```
+
+**Step 4: Run tests**
+
+Run: `bazel test //tests:segmented_multi_kref_surface_test --test_output=all`
+
+Expected: All tests pass including extrapolation smoothness and non-negative guard.
+
+**Step 5: Commit**
+
+```bash
+git add src/option/table/segmented_multi_kref_surface.cpp tests/segmented_multi_kref_surface_test.cc
+git commit -m "Smooth extrapolation outside K_ref range in log space"
+```
+
+---
+
+### Task 5: Boundary disagreement metric and full regression
+
+Add a diagnostic metric and run the full test suite.
+
+**Files:**
+- Modify: `tests/segmented_multi_kref_surface_test.cc`
+
+**Step 1: Add boundary disagreement metric**
+
+```cpp
+// Diagnostic: measure cross-surface disagreement at K_ref boundaries
+struct BoundaryDiagnostics {
+    double max_price_diff = 0.0;   // max |P_left(K) - P_right(K)| / K
+    double mean_price_diff = 0.0;
+    size_t sample_count = 0;
+};
+
+static BoundaryDiagnostics measure_boundary_disagreement(
+    const std::vector<SegmentedMultiKRefSurface::Entry>& entries,
+    double spot) {
+    BoundaryDiagnostics result;
+    if (entries.size() < 2) return result;
+
+    std::vector<double> taus = {0.25, 0.5, 0.75};
+    std::vector<double> sigmas = {0.15, 0.20, 0.30};
+    std::vector<double> rates = {0.03, 0.05, 0.07};
+
+    double sum_diff = 0.0;
+    size_t count = 0;
+
+    for (size_t i = 0; i + 1 < entries.size(); ++i) {
+        double K = entries[i + 1].K_ref;
+        for (double tau : taus) {
+            for (double sigma : sigmas) {
+                for (double rate : rates) {
+                    double p_left = entries[i].surface.price(spot, K, tau, sigma, rate);
+                    double p_right = entries[i + 1].surface.price(spot, K, tau, sigma, rate);
+                    double diff = std::abs(p_left - p_right) / K;
+                    result.max_price_diff = std::max(result.max_price_diff, diff);
+                    sum_diff += diff;
+                    count++;
+                }
+            }
+        }
+    }
+
+    result.mean_price_diff = count > 0 ? sum_diff / count : 0.0;
+    result.sample_count = count;
+    return result;
+}
+```
+
+**Step 2: Add a test using the metric**
+
+```cpp
+TEST(SegmentedMultiKRefSurfaceTest, BoundaryDisagreementMetric) {
+    std::vector<SegmentedMultiKRefSurface::Entry> entries;
+    entries.push_back({80.0, build_surface(80.0)});
+    entries.push_back({100.0, build_surface(100.0)});
+    entries.push_back({120.0, build_surface(120.0)});
+
+    auto diag = measure_boundary_disagreement(entries, 100.0);
+
+    EXPECT_TRUE(std::isfinite(diag.max_price_diff));
+    EXPECT_GE(diag.sample_count, 1u);
+
+    // RecordProperty makes the values visible in test XML output
+    // without polluting stdout in CI
+    ::testing::Test::RecordProperty("max_price_diff",
+        std::to_string(diag.max_price_diff));
+    ::testing::Test::RecordProperty("mean_price_diff",
+        std::to_string(diag.mean_price_diff));
+}
+```
+
+**Step 3: Run all tests**
+
+Run: `bazel test //tests:segmented_multi_kref_surface_test --test_output=all`
+
+Expected: All tests pass.
+
+**Step 4: Run the full test suite for regressions**
+
+Run: `bazel test //...`
+
+Expected: All tests pass (no regressions).
+
+**Step 5: Run the IV factory test to verify Newton convergence**
+
+Run: `bazel test //tests:iv_solver_factory_test --test_output=all`
+
+Expected: All tests pass, including the segmented path test.
+
+**Step 6: Commit**
+
+```bash
+git add tests/segmented_multi_kref_surface_test.cc
+git commit -m "Add boundary disagreement metric and full regression check"
+```

--- a/docs/plans/2026-02-03-adaptive-segmented-grid-impl.md
+++ b/docs/plans/2026-02-03-adaptive-segmented-grid-impl.md
@@ -420,8 +420,8 @@ Expected: FAIL — `build_segmented` and `SegmentedAdaptiveConfig` don't exist.
 In `src/option/table/adaptive_grid_builder.hpp`, add includes and types:
 
 ```cpp
-#include "src/option/table/segmented_multi_kref_builder.hpp"
-#include "src/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
 
 // Before AdaptiveGridBuilder class:
 struct AdaptiveGrid;  // forward-declared; defined in iv_solver_factory.hpp

--- a/docs/plans/2026-02-03-probe-based-grid-estimation-impl.md
+++ b/docs/plans/2026-02-03-probe-based-grid-estimation-impl.md
@@ -82,7 +82,7 @@ git commit -m "Add target_price_error field to IVSolverFDMConfig"
 ```cpp
 // tests/grid_probe_test.cc
 #include <gtest/gtest.h>
-#include "src/option/grid_probe.hpp"
+#include "mango/option/grid_probe.hpp"
 
 TEST(GridProbeTest, ConvergesForTypicalOption) {
     mango::PricingParams params(
@@ -115,10 +115,10 @@ Expected: FAIL with "No such file or directory" or "probe_grid_adequacy not foun
 #pragma once
 
 #include <expected>
-#include "src/pde/core/grid_spec.hpp"
-#include "src/pde/core/time_domain.hpp"
-#include "src/option/american_option.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/pde/core/grid_spec.hpp"
+#include "mango/pde/core/time_domain.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/support/error_types.hpp"
 
 namespace mango {
 
@@ -148,8 +148,8 @@ std::expected<ProbeResult, ValidationError> probe_grid_adequacy(
 ```cpp
 // src/option/grid_probe.cpp
 // SPDX-License-Identifier: MIT
-#include "src/option/grid_probe.hpp"
-#include "src/option/american_option.hpp"
+#include "mango/option/grid_probe.hpp"
+#include "mango/option/american_option.hpp"
 #include <cmath>
 #include <algorithm>
 
@@ -558,7 +558,7 @@ if (probe_grid.has_value()) {
 **Step 5: Add include for grid_probe.hpp**
 
 ```cpp
-#include "src/option/grid_probe.hpp"
+#include "mango/option/grid_probe.hpp"
 ```
 
 **Step 6: Update BUILD.bazel to add grid_probe dependency**
@@ -635,7 +635,7 @@ git commit -m "Add test for IVSolver fallback when probe doesn't converge"
 
 ```cpp
 // At top of file
-#include "src/support/usdt_probes.hpp"
+#include "mango/support/usdt_probes.hpp"
 
 // In probe_grid_adequacy():
 
@@ -678,7 +678,7 @@ git commit -m "Add USDT probes for grid calibration tracing"
 ```cpp
 // SPDX-License-Identifier: MIT
 #include <benchmark/benchmark.h>
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 
 static void BM_IVSolver_Heuristic(benchmark::State& state) {
     mango::OptionSpec spec{
@@ -809,7 +809,7 @@ Add Pattern 5 to "Common Development Patterns" section:
 ```markdown
 **Pattern 5: Probe-Based IV Solver**
 ```cpp
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 
 // Simple: just specify target accuracy
 mango::IVSolverFDMConfig config{.target_price_error = 0.01};

--- a/src/math/BUILD.bazel
+++ b/src/math/BUILD.bazel
@@ -12,6 +12,8 @@ cc_library(
     name = "black_scholes_analytics",
     hdrs = ["black_scholes_analytics.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -19,12 +21,16 @@ cc_library(
     hdrs = ["safe_math.hpp"],
     deps = ["//src/support:error_types"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
     name = "yield_curve",
     hdrs = ["yield_curve.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -32,6 +38,8 @@ cc_library(
     hdrs = ["lapack_banded_layout.hpp"],
     deps = ["@mdspan//:mdspan"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -47,6 +55,8 @@ cc_library(
         "-DHAVE_SYSTEMTAP_SDT",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -58,6 +68,8 @@ cc_library(
         "-O3",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -65,6 +77,8 @@ cc_library(
     hdrs = ["thomas_solver.hpp"],
     deps = [":tridiagonal_matrix_view"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -75,12 +89,16 @@ cc_library(
         "//src/support:parallel",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
     name = "bspline_basis",
     hdrs = ["bspline_basis.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -93,6 +111,8 @@ cc_library(
     ],
     linkopts = ["-llapacke"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -105,6 +125,8 @@ cc_library(
         "@mdspan//:mdspan",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -119,6 +141,8 @@ cc_library(
     ],
     linkopts = ["-llapacke"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -131,6 +155,8 @@ cc_library(
         "@mdspan//:mdspan",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
@@ -153,10 +179,14 @@ cc_library(
     ],
     linkopts = ["-fopenmp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )
 
 cc_library(
     name = "latin_hypercube",
     hdrs = ["latin_hypercube.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/math",
+    include_prefix = "mango/math",
 )

--- a/src/math/banded_matrix_solver.hpp
+++ b/src/math/banded_matrix_solver.hpp
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include "src/math/lapack_banded_layout.hpp"
-#include "src/support/parallel.hpp"
+#include "mango/math/lapack_banded_layout.hpp"
+#include "mango/support/parallel.hpp"
 #include <experimental/mdspan>
 #include <span>
 #include <vector>

--- a/src/math/bspline_collocation.hpp
+++ b/src/math/bspline_collocation.hpp
@@ -23,11 +23,11 @@
 
 #pragma once
 
-#include "src/math/banded_matrix_solver.hpp"
-#include "src/math/bspline_basis.hpp"
-#include "src/math/bspline_collocation_workspace.hpp"
-#include "src/support/error_types.hpp"
-#include "src/support/parallel.hpp"
+#include "mango/math/banded_matrix_solver.hpp"
+#include "mango/math/bspline_basis.hpp"
+#include "mango/math/bspline_collocation_workspace.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/support/parallel.hpp"
 #include <experimental/mdspan>
 #include <expected>
 #include <span>

--- a/src/math/bspline_collocation_workspace.hpp
+++ b/src/math/bspline_collocation_workspace.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "src/math/lapack_banded_layout.hpp"
-#include "src/support/lifetime.hpp"
+#include "mango/math/lapack_banded_layout.hpp"
+#include "mango/support/lifetime.hpp"
 #include <experimental/mdspan>
 #include <span>
 #include <expected>

--- a/src/math/bspline_nd.hpp
+++ b/src/math/bspline_nd.hpp
@@ -27,9 +27,9 @@
 
 #pragma once
 
-#include "src/math/bspline_basis.hpp"
-#include "src/support/error_types.hpp"
-#include "src/math/safe_math.hpp"
+#include "mango/math/bspline_basis.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/math/safe_math.hpp"
 #include <experimental/mdspan>
 #include <array>
 #include <vector>

--- a/src/math/bspline_nd_separable.hpp
+++ b/src/math/bspline_nd_separable.hpp
@@ -27,11 +27,11 @@
 
 #pragma once
 
-#include "src/math/bspline_collocation.hpp"
-#include "src/math/bspline_collocation_workspace.hpp"
-#include "src/support/parallel.hpp"
-#include "src/support/thread_workspace.hpp"
-#include "src/math/safe_math.hpp"
+#include "mango/math/bspline_collocation.hpp"
+#include "mango/math/bspline_collocation_workspace.hpp"
+#include "mango/support/parallel.hpp"
+#include "mango/support/thread_workspace.hpp"
+#include "mango/math/safe_math.hpp"
 #include <experimental/mdspan>
 #include <expected>
 #include <span>

--- a/src/math/cubic_spline_solver.hpp
+++ b/src/math/cubic_spline_solver.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "src/math/thomas_solver.hpp"
-#include "src/support/parallel.hpp"
+#include "mango/math/thomas_solver.hpp"
+#include "mango/support/parallel.hpp"
 #include <span>
 #include <vector>
 #include <optional>

--- a/src/math/root_finding.hpp
+++ b/src/math/root_finding.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/support/ivcalc_trace.h"
+#include "mango/support/ivcalc_trace.h"
 #include <cstddef>
 #include <optional>
 #include <string>

--- a/src/math/safe_math.hpp
+++ b/src/math/safe_math.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <expected>

--- a/src/math/thomas_solver.hpp
+++ b/src/math/thomas_solver.hpp
@@ -15,7 +15,7 @@
 #include <optional>
 #include <string_view>
 #include <limits>
-#include "src/math/tridiagonal_matrix_view.hpp"
+#include "mango/math/tridiagonal_matrix_view.hpp"
 
 namespace mango {
 

--- a/src/option/BUILD.bazel
+++ b/src/option/BUILD.bazel
@@ -16,12 +16,16 @@ cc_library(
         "//src/pde/core:grid",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
     name = "option_grid",
     hdrs = ["option_grid.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -39,6 +43,8 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -68,6 +74,8 @@ cc_library(
         "-ftree-vectorize",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -85,6 +93,8 @@ cc_library(
         "-Wextra",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -112,6 +122,8 @@ cc_library(
     ],
     linkopts = ["-fopenmp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -130,6 +142,8 @@ cc_library(
         "-O3",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -139,6 +153,8 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -165,6 +181,8 @@ cc_library(
     ],
     linkopts = ["-fopenmp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -176,6 +194,8 @@ cc_library(
         "//src/math:yield_curve",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -188,6 +208,8 @@ cc_library(
         "//src/math:black_scholes_analytics",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -197,6 +219,8 @@ cc_library(
         ":option_spec",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -223,6 +247,8 @@ cc_library(
     ],
     linkopts = ["-fopenmp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -248,6 +274,8 @@ cc_library(
     ],
     linkopts = ["-fopenmp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 
 cc_library(
@@ -258,5 +286,7 @@ cc_library(
         "//src/pde/core:pde_solver",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option",
+    include_prefix = "mango/option",
 )
 

--- a/src/option/american_option.cpp
+++ b/src/option/american_option.cpp
@@ -4,12 +4,12 @@
  * @brief American option pricing solver implementation
  */
 
-#include "src/option/american_option.hpp"
-#include "src/option/american_pde_solver.hpp"
-#include "src/option/discrete_dividend_event.hpp"
-#include "src/math/cubic_spline_solver.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_pde_solver.hpp"
+#include "mango/option/discrete_dividend_event.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <algorithm>
 #include <cmath>
 #include <vector>

--- a/src/option/american_option.hpp
+++ b/src/option/american_option.hpp
@@ -7,17 +7,17 @@
 #ifndef MANGO_AMERICAN_OPTION_HPP
 #define MANGO_AMERICAN_OPTION_HPP
 
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/operators/black_scholes_pde.hpp"
-#include "src/pde/operators/centered_difference_facade.hpp"
-#include "src/option/option_concepts.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/operators/black_scholes_pde.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
+#include "mango/option/option_concepts.hpp"
 #include <expected>
-#include "src/support/error_types.hpp"
-#include "src/support/parallel.hpp"
-#include "src/option/american_option_result.hpp"
-#include "src/option/option_spec.hpp"  // For OptionType enum
-#include "src/option/grid_spec_types.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/support/parallel.hpp"
+#include "mango/option/american_option_result.hpp"
+#include "mango/option/option_spec.hpp"  // For OptionType enum
+#include "mango/option/grid_spec_types.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <vector>
 #include <memory>
 #include <memory_resource>

--- a/src/option/american_option_batch.cpp
+++ b/src/option/american_option_batch.cpp
@@ -4,10 +4,10 @@
  * @brief Implementation of batch and normalized chain solvers
  */
 
-#include "src/option/american_option_batch.hpp"
-#include "src/support/ivcalc_trace.h"
-#include "src/support/thread_workspace.hpp"
-#include "src/pde/core/american_pde_workspace.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/support/ivcalc_trace.h"
+#include "mango/support/thread_workspace.hpp"
+#include "mango/pde/core/american_pde_workspace.hpp"
 #include <cmath>
 #include <algorithm>
 #include <ranges>

--- a/src/option/american_option_batch.hpp
+++ b/src/option/american_option_batch.hpp
@@ -9,11 +9,11 @@
 #ifndef MANGO_AMERICAN_OPTION_BATCH_HPP
 #define MANGO_AMERICAN_OPTION_BATCH_HPP
 
-#include "src/option/american_option.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/support/error_types.hpp"
-#include "src/support/parallel.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/support/parallel.hpp"
 #include <vector>
 #include <expected>
 #include <span>

--- a/src/option/american_option_result.cpp
+++ b/src/option/american_option_result.cpp
@@ -4,7 +4,7 @@
  * @brief Implementation of AmericanOptionResult wrapper class
  */
 
-#include "american_option_result.hpp"
+#include "mango/option/american_option_result.hpp"
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/src/option/american_option_result.hpp
+++ b/src/option/american_option_result.hpp
@@ -11,10 +11,10 @@
 
 #pragma once
 
-#include "src/pde/core/grid.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/option/option_concepts.hpp"
-#include "src/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/option/option_concepts.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
 #include <memory>
 #include <optional>
 #include <span>

--- a/src/option/american_pde_solver.hpp
+++ b/src/option/american_pde_solver.hpp
@@ -12,15 +12,15 @@
 
 #pragma once
 
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
-#include "src/pde/core/time_domain.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/operators/operator_factory.hpp"
-#include "src/pde/operators/black_scholes_pde.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
+#include "mango/pde/core/time_domain.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
+#include "mango/pde/operators/black_scholes_pde.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/support/error_types.hpp"
 #include <cassert>
 #include <expected>
 #include <variant>

--- a/src/option/batch_bracketing.cpp
+++ b/src/option/batch_bracketing.cpp
@@ -10,7 +10,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 
-#include "src/option/batch_bracketing.hpp"
+#include "mango/option/batch_bracketing.hpp"
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/src/option/batch_bracketing.hpp
+++ b/src/option/batch_bracketing.hpp
@@ -11,10 +11,10 @@
 #ifndef MANGO_BATCH_BRACKETING_HPP
 #define MANGO_BATCH_BRACKETING_HPP
 
-#include "src/option/option_spec.hpp"
-#include "src/option/american_option.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <vector>
 #include <span>
 #include <expected>

--- a/src/option/discrete_dividend_event.hpp
+++ b/src/option/discrete_dividend_event.hpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/pde/core/pde_solver.hpp"
-#include "src/math/cubic_spline_solver.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
 #include <cmath>
 #include <span>
 

--- a/src/option/european_option.cpp
+++ b/src/option/european_option.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/european_option.hpp"
-#include "src/math/black_scholes_analytics.hpp"
+#include "mango/option/european_option.hpp"
+#include "mango/math/black_scholes_analytics.hpp"
 #include <algorithm>
 #include <cmath>
 

--- a/src/option/european_option.hpp
+++ b/src/option/european_option.hpp
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include "src/option/option_spec.hpp"
-#include "src/option/option_concepts.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/option/option_concepts.hpp"
 #include <expected>
 
 namespace mango {

--- a/src/option/grid_spec_types.cpp
+++ b/src/option/grid_spec_types.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/grid_spec_types.hpp"
+#include "mango/option/grid_spec_types.hpp"
 
 namespace mango {
 

--- a/src/option/grid_spec_types.hpp
+++ b/src/option/grid_spec_types.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <variant>
 #include <vector>
 

--- a/src/option/interpolated_iv_solver.cpp
+++ b/src/option/interpolated_iv_solver.cpp
@@ -8,8 +8,8 @@
  * instantiations for common surface types to improve compile times.
  */
 
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 namespace mango {
 

--- a/src/option/interpolated_iv_solver.hpp
+++ b/src/option/interpolated_iv_solver.hpp
@@ -49,13 +49,13 @@
 
 #pragma once
 
-#include "src/option/option_spec.hpp"
-#include "src/option/iv_result.hpp"
-#include "src/option/table/price_surface_concept.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/support/error_types.hpp"
-#include "src/support/parallel.hpp"
-#include "src/math/root_finding.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/option/iv_result.hpp"
+#include "mango/option/table/price_surface_concept.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/support/parallel.hpp"
+#include "mango/math/root_finding.hpp"
 #include <expected>
 #include <cmath>
 #include <algorithm>

--- a/src/option/iv_result.hpp
+++ b/src/option/iv_result.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 #include <expected>
 #include <cmath>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 
 namespace mango {
 

--- a/src/option/iv_solver.cpp
+++ b/src/option/iv_solver.cpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/iv_solver.hpp"
-#include "src/math/root_finding.hpp"
-#include "src/option/american_option.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/support/parallel.hpp"
-#include "src/support/ivcalc_trace.h"
+#include "mango/option/iv_solver.hpp"
+#include "mango/math/root_finding.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/support/parallel.hpp"
+#include "mango/support/ivcalc_trace.h"
 #include <cmath>
 #include <algorithm>
 #include <memory>

--- a/src/option/iv_solver.hpp
+++ b/src/option/iv_solver.hpp
@@ -31,13 +31,13 @@
 
 #pragma once
 
-#include "src/option/option_spec.hpp"
-#include "src/option/iv_result.hpp"
-#include "src/option/american_option.hpp"
-#include "src/option/grid_spec_types.hpp"
-#include "src/math/root_finding.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/option/iv_result.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/grid_spec_types.hpp"
+#include "mango/math/root_finding.hpp"
 #include <expected>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 #include <span>
 #include <optional>
 #include <unordered_map>

--- a/src/option/iv_solver_factory.cpp
+++ b/src/option/iv_solver_factory.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/iv_solver_factory.hpp"
-#include "src/option/table/adaptive_grid_builder.hpp"
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/iv_solver_factory.hpp"
+#include "mango/option/table/adaptive_grid_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 #include <type_traits>
 
 namespace mango {

--- a/src/option/iv_solver_factory.hpp
+++ b/src/option/iv_solver_factory.hpp
@@ -16,13 +16,13 @@
 #include <vector>
 #include <variant>
 #include <expected>
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/table/segmented_multi_kref_surface.hpp"
-#include "src/option/table/segmented_multi_kref_builder.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/option/table/adaptive_grid_types.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/option/table/adaptive_grid_types.hpp"
+#include "mango/support/error_types.hpp"
 
 namespace mango {
 

--- a/src/option/option_concepts.hpp
+++ b/src/option/option_concepts.hpp
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "src/option/option_spec.hpp"
+#include "mango/option/option_spec.hpp"
 #include <concepts>
 #include <expected>
 

--- a/src/option/option_spec.cpp
+++ b/src/option/option_spec.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/option_spec.hpp"
+#include "mango/option/option_spec.hpp"
 #include <cmath>
 #include <algorithm>
 

--- a/src/option/option_spec.hpp
+++ b/src/option/option_spec.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <expected>
-#include "src/support/error_types.hpp"
-#include "src/math/yield_curve.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/math/yield_curve.hpp"
 #include <string>
 #include <vector>
 #include <utility>

--- a/src/option/table/BUILD.bazel
+++ b/src/option/table/BUILD.bazel
@@ -15,6 +15,8 @@ cc_library(
         "//src/option:option_spec",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -25,6 +27,8 @@ cc_library(
         "//src/math:safe_math",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -36,6 +40,8 @@ cc_library(
         "@mdspan//:mdspan",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -45,6 +51,8 @@ cc_library(
         "//src/option:option_spec",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -58,6 +66,8 @@ cc_library(
         "//src/math:bspline_basis",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -69,6 +79,8 @@ cc_library(
         "//src/option:option_spec",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -102,6 +114,8 @@ cc_library(
         "//src/support:parallel",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -111,6 +125,8 @@ cc_library(
         ":price_table_axes",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -125,18 +141,24 @@ cc_library(
         "@mdspan//:mdspan",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
     name = "price_table_grid",
     hdrs = ["price_table_grid.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
     name = "price_table_grid_estimator",
     hdrs = ["price_table_grid_estimator.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -151,12 +173,16 @@ cc_library(
         "@mdspan//:mdspan",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
     name = "error_attribution",
     hdrs = ["error_attribution.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -166,6 +192,8 @@ cc_library(
         "//src/option:american_option_result",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -180,6 +208,8 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -193,6 +223,8 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -207,6 +239,8 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -219,6 +253,8 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -232,6 +268,8 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -242,6 +280,8 @@ cc_library(
         ":price_table_surface",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )
 
 cc_library(
@@ -271,4 +311,6 @@ cc_library(
         "//src/support:error_types",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
 )

--- a/src/option/table/adaptive_grid_builder.cpp
+++ b/src/option/table/adaptive_grid_builder.cpp
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/adaptive_grid_builder.hpp"
-#include "src/math/black_scholes_analytics.hpp"
-#include "src/math/latin_hypercube.hpp"
-#include "src/option/american_option_batch.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/segmented_price_table_builder.hpp"
-#include "src/option/table/segmented_multi_kref_builder.hpp"
-#include "src/option/table/segmented_multi_kref_surface.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/option/table/adaptive_grid_builder.hpp"
+#include "mango/math/black_scholes_analytics.hpp"
+#include "mango/math/latin_hypercube.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/segmented_price_table_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <algorithm>
 #include <cmath>
 #include <chrono>

--- a/src/option/table/adaptive_grid_builder.hpp
+++ b/src/option/table/adaptive_grid_builder.hpp
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/table/adaptive_grid_types.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/slice_cache.hpp"
-#include "src/option/table/error_attribution.hpp"
-#include "src/option/table/segmented_multi_kref_builder.hpp"
-#include "src/option/table/segmented_multi_kref_surface.hpp"
-#include "src/option/option_grid.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/adaptive_grid_types.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/slice_cache.hpp"
+#include "mango/option/table/error_attribution.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/option_grid.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/support/error_types.hpp"
 #include <expected>
 #include <optional>
 

--- a/src/option/table/adaptive_grid_types.hpp
+++ b/src/option/table/adaptive_grid_types.hpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_surface.hpp"
 #include <array>
 #include <memory>
 #include <vector>

--- a/src/option/table/american_price_surface.cpp
+++ b/src/option/table/american_price_surface.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/european_option.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/european_option.hpp"
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/src/option/table/american_price_surface.hpp
+++ b/src/option/table/american_price_surface.hpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/support/error_types.hpp"
 #include <memory>
 #include <expected>
 

--- a/src/option/table/price_surface_concept.hpp
+++ b/src/option/table/price_surface_concept.hpp
@@ -2,7 +2,7 @@
 #pragma once
 
 #include <concepts>
-#include "src/option/option_spec.hpp"
+#include "mango/option/option_spec.hpp"
 
 namespace mango {
 

--- a/src/option/table/price_table_axes.hpp
+++ b/src/option/table/price_table_axes.hpp
@@ -6,8 +6,8 @@
 #include <string>
 #include <expected>
 #include <algorithm>
-#include "src/support/error_types.hpp"
-#include "src/math/safe_math.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/math/safe_math.hpp"
 
 namespace mango {
 

--- a/src/option/table/price_table_builder.cpp
+++ b/src/option/table/price_table_builder.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/european_option.hpp"
-#include "src/option/table/recursion_helpers.hpp"
-#include "src/math/cubic_spline_solver.hpp"
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/support/ivcalc_trace.h"
-#include "src/pde/core/time_domain.hpp"
-#include "src/support/parallel.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/european_option.hpp"
+#include "mango/option/table/recursion_helpers.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/support/ivcalc_trace.h"
+#include "mango/pde/core/time_domain.hpp"
+#include "mango/support/parallel.hpp"
 #include <cmath>
 #include <limits>
 #include <algorithm>

--- a/src/option/table/price_table_builder.hpp
+++ b/src/option/table/price_table_builder.hpp
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/option/table/price_table_config.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/price_tensor.hpp"
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
-#include "src/option/option_grid.hpp"
-#include "src/option/table/price_table_grid_estimator.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/option/table/price_table_config.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_tensor.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/option/option_grid.hpp"
+#include "mango/option/table/price_table_grid_estimator.hpp"
+#include "mango/support/error_types.hpp"
 #include <expected>
 #include <functional>
 #include <memory>

--- a/src/option/table/price_table_config.hpp
+++ b/src/option/table/price_table_config.hpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/grid_spec_types.hpp"  // PDEGridSpec, PDEGridConfig, GridAccuracyParams
-#include "src/option/option_spec.hpp"      // OptionType
-#include "src/option/table/price_table_metadata.hpp"  // For SurfaceContent
+#include "mango/option/grid_spec_types.hpp"  // PDEGridSpec, PDEGridConfig, GridAccuracyParams
+#include "mango/option/option_spec.hpp"      // OptionType
+#include "mango/option/table/price_table_metadata.hpp"  // For SurfaceContent
 #include <utility>
 #include <optional>
 #include <string>

--- a/src/option/table/price_table_extraction.cpp
+++ b/src/option/table/price_table_extraction.cpp
@@ -4,9 +4,9 @@
  * @brief Implementation of price table extraction utility
  */
 
-#include "src/option/table/price_table_extraction.hpp"
-#include "src/math/cubic_spline_solver.hpp"
-#include "src/support/parallel.hpp"
+#include "mango/option/table/price_table_extraction.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
+#include "mango/support/parallel.hpp"
 #include <experimental/mdspan>
 #include <cassert>
 #include <cmath>

--- a/src/option/table/price_table_extraction.hpp
+++ b/src/option/table/price_table_extraction.hpp
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "src/option/american_option_batch.hpp"
-#include "src/option/table/price_table_grid.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/option/table/price_table_grid.hpp"
 
 namespace mango {
 

--- a/src/option/table/price_table_metadata.hpp
+++ b/src/option/table/price_table_metadata.hpp
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "src/option/option_spec.hpp"
+#include "mango/option/option_spec.hpp"
 
 namespace mango {
 

--- a/src/option/table/price_table_surface.cpp
+++ b/src/option/table/price_table_surface.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/price_table_surface.hpp"
-#include "src/math/bspline_nd.hpp"
-#include "src/math/bspline_basis.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/math/bspline_nd.hpp"
+#include "mango/math/bspline_basis.hpp"
 #include <algorithm>
 #include <cmath>
 

--- a/src/option/table/price_table_surface.hpp
+++ b/src/option/table/price_table_surface.hpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/math/bspline_nd.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/math/bspline_nd.hpp"
+#include "mango/support/error_types.hpp"
 #include <memory>
 #include <expected>
 

--- a/src/option/table/price_table_workspace.cpp
+++ b/src/option/table/price_table_workspace.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/price_table_workspace.hpp"
-#include "src/support/crc64.hpp"
+#include "mango/option/table/price_table_workspace.hpp"
+#include "mango/support/crc64.hpp"
 #include <algorithm>
 #include <numeric>
 #include <cstring>

--- a/src/option/table/price_table_workspace.hpp
+++ b/src/option/table/price_table_workspace.hpp
@@ -2,8 +2,8 @@
 #pragma once
 
 #include <expected>
-#include "src/support/error_types.hpp"
-#include "src/math/bspline_basis.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/math/bspline_basis.hpp"
 #include <experimental/mdspan>
 #include <vector>
 #include <span>

--- a/src/option/table/price_tensor.hpp
+++ b/src/option/table/price_tensor.hpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/support/aligned_allocator.hpp"
-#include "src/math/safe_math.hpp"
+#include "mango/support/aligned_allocator.hpp"
+#include "mango/math/safe_math.hpp"
 #include <experimental/mdspan>
 #include <memory>
 #include <expected>

--- a/src/option/table/recursion_helpers.hpp
+++ b/src/option/table/recursion_helpers.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_axes.hpp"
 #include <array>
 #include <functional>
 

--- a/src/option/table/segmented_multi_kref_builder.cpp
+++ b/src/option/table/segmented_multi_kref_builder.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/src/option/table/segmented_multi_kref_builder.hpp
+++ b/src/option/table/segmented_multi_kref_builder.hpp
@@ -3,10 +3,10 @@
 
 #include <vector>
 #include <expected>
-#include "src/option/table/segmented_multi_kref_surface.hpp"
-#include "src/option/table/segmented_price_table_builder.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/segmented_price_table_builder.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/support/error_types.hpp"
 
 namespace mango {
 

--- a/src/option/table/segmented_multi_kref_surface.cpp
+++ b/src/option/table/segmented_multi_kref_surface.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
 
 #include <algorithm>
 #include <array>

--- a/src/option/table/segmented_multi_kref_surface.hpp
+++ b/src/option/table/segmented_multi_kref_surface.hpp
@@ -3,9 +3,9 @@
 
 #include <vector>
 #include <expected>
-#include "src/option/table/segmented_price_surface.hpp"
-#include "src/option/table/price_surface_concept.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/segmented_price_surface.hpp"
+#include "mango/option/table/price_surface_concept.hpp"
+#include "mango/support/error_types.hpp"
 
 namespace mango {
 

--- a/src/option/table/segmented_price_surface.cpp
+++ b/src/option/table/segmented_price_surface.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/segmented_price_surface.hpp"
+#include "mango/option/table/segmented_price_surface.hpp"
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/src/option/table/segmented_price_surface.hpp
+++ b/src/option/table/segmented_price_surface.hpp
@@ -3,9 +3,9 @@
 
 #include <vector>
 #include <expected>
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/support/error_types.hpp"
 
 namespace mango {
 

--- a/src/option/table/segmented_price_table_builder.cpp
+++ b/src/option/table/segmented_price_table_builder.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/segmented_price_table_builder.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/american_option.hpp"
+#include "mango/option/table/segmented_price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/american_option.hpp"
 #include <algorithm>
 #include <cmath>
 #include <numeric>

--- a/src/option/table/segmented_price_table_builder.hpp
+++ b/src/option/table/segmented_price_table_builder.hpp
@@ -3,9 +3,9 @@
 
 #include <vector>
 #include <expected>
-#include "src/option/table/segmented_price_surface.hpp"
-#include "src/option/option_spec.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/table/segmented_price_surface.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/support/error_types.hpp"
 
 namespace mango {
 

--- a/src/option/table/slice_cache.hpp
+++ b/src/option/table/slice_cache.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/option/american_option_result.hpp"
+#include "mango/option/american_option_result.hpp"
 #include <map>
 #include <optional>
 #include <vector>

--- a/src/pde/core/BUILD.bazel
+++ b/src/pde/core/BUILD.bazel
@@ -23,6 +23,8 @@ cc_library(
         "-O3",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/core",
+    include_prefix = "mango/pde/core",
 )
 
 cc_library(
@@ -34,6 +36,8 @@ cc_library(
         "-O3",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/core",
+    include_prefix = "mango/pde/core",
 )
 
 cc_library(
@@ -44,6 +48,8 @@ cc_library(
         "-Wextra",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/core",
+    include_prefix = "mango/pde/core",
 )
 
 cc_library(
@@ -54,6 +60,8 @@ cc_library(
         "-Wextra",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/core",
+    include_prefix = "mango/pde/core",
 )
 
 cc_library(
@@ -65,6 +73,8 @@ cc_library(
         "-Wextra",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/core",
+    include_prefix = "mango/pde/core",
 )
 
 cc_library(
@@ -79,6 +89,8 @@ cc_library(
         "-Wextra",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/core",
+    include_prefix = "mango/pde/core",
 )
 
 cc_library(
@@ -101,4 +113,6 @@ cc_library(
         "-Wextra",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/core",
+    include_prefix = "mango/pde/core",
 )

--- a/src/pde/core/american_pde_workspace.hpp
+++ b/src/pde/core/american_pde_workspace.hpp
@@ -2,8 +2,8 @@
 // src/pde/core/american_pde_workspace.hpp
 #pragma once
 
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/support/lifetime.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/support/lifetime.hpp"
 #include <span>
 #include <expected>
 #include <string>

--- a/src/pde/core/grid.hpp
+++ b/src/pde/core/grid.hpp
@@ -14,9 +14,9 @@
 #include <format>
 #include <limits>
 #include <experimental/mdspan>
-#include "src/support/aligned_allocator.hpp"
-#include "src/support/error_types.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/support/aligned_allocator.hpp"
+#include "mango/support/error_types.hpp"
+#include "mango/pde/core/time_domain.hpp"
 
 namespace mango {
 

--- a/src/pde/core/pde_solver.hpp
+++ b/src/pde/core/pde_solver.hpp
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/operators/centered_difference_facade.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
-#include "src/pde/core/time_domain.hpp"
-#include "src/pde/core/trbdf2_config.hpp"
-#include "src/math/thomas_solver.hpp"
-#include "src/math/tridiagonal_matrix_view.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
+#include "mango/pde/core/time_domain.hpp"
+#include "mango/pde/core/trbdf2_config.hpp"
+#include "mango/math/thomas_solver.hpp"
+#include "mango/math/tridiagonal_matrix_view.hpp"
 #include <expected>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 #include <memory>
 #include <span>
 #include <vector>

--- a/src/pde/core/pde_workspace.hpp
+++ b/src/pde/core/pde_workspace.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <format>
 #include <algorithm>
-#include "src/math/tridiagonal_matrix_view.hpp"
+#include "mango/math/tridiagonal_matrix_view.hpp"
 
 namespace mango {
 

--- a/src/pde/operators/BUILD.bazel
+++ b/src/pde/operators/BUILD.bazel
@@ -12,12 +12,16 @@ cc_library(
     name = "laplacian_pde",
     hdrs = ["laplacian_pde.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/operators",
+    include_prefix = "mango/pde/operators",
 )
 
 cc_library(
     name = "black_scholes_pde",
     hdrs = ["black_scholes_pde.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/operators",
+    include_prefix = "mango/pde/operators",
 )
 
 cc_library(
@@ -29,6 +33,8 @@ cc_library(
         "//src/math:tridiagonal_matrix_view",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/operators",
+    include_prefix = "mango/pde/operators",
 )
 
 cc_library(
@@ -39,6 +45,8 @@ cc_library(
         "//src/pde/core:grid",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/operators",
+    include_prefix = "mango/pde/operators",
 )
 
 cc_library(
@@ -53,6 +61,8 @@ cc_library(
         "-fopenmp-simd",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/operators",
+    include_prefix = "mango/pde/operators",
 )
 
 cc_library(
@@ -63,4 +73,6 @@ cc_library(
         "//src/pde/core:grid",
     ],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/pde/operators",
+    include_prefix = "mango/pde/operators",
 )

--- a/src/pde/operators/centered_difference_facade.hpp
+++ b/src/pde/operators/centered_difference_facade.hpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/pde/core/grid.hpp"
-#include "centered_difference_scalar.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/operators/centered_difference_scalar.hpp"
 #include <span>
 #include <concepts>
 

--- a/src/pde/operators/centered_difference_scalar.hpp
+++ b/src/pde/operators/centered_difference_scalar.hpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/pde/core/grid.hpp"
-#include "src/support/parallel.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/support/parallel.hpp"
 #include <span>
 #include <cmath>
 #include <cassert>

--- a/src/pde/operators/operator_factory.hpp
+++ b/src/pde/operators/operator_factory.hpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "spatial_operator.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/pde/operators/spatial_operator.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <memory>
 
 namespace mango::operators {

--- a/src/pde/operators/spatial_operator.hpp
+++ b/src/pde/operators/spatial_operator.hpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "src/pde/core/grid.hpp"
-#include "centered_difference_facade.hpp"
-#include "src/math/tridiagonal_matrix_view.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
+#include "mango/math/tridiagonal_matrix_view.hpp"
 #include <span>
 #include <memory>
 #include <concepts>

--- a/src/python/mango_bindings.cpp
+++ b/src/python/mango_bindings.cpp
@@ -8,20 +8,20 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 #include <sstream>
-#include "src/option/option_spec.hpp"
-#include "src/option/iv_solver.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/american_option.hpp"
-#include "src/option/option_grid.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_workspace.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/math/yield_curve.hpp"
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/option/iv_solver.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/option_grid.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_workspace.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/math/yield_curve.hpp"
+#include "mango/option/american_option_batch.hpp"
 
 namespace py = pybind11;
 

--- a/src/simple/BUILD.bazel
+++ b/src/simple/BUILD.bazel
@@ -13,6 +13,8 @@ cc_library(
     name = "price",
     hdrs = ["price.hpp"],
     deps = [],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )
 
 cc_library(
@@ -20,6 +22,8 @@ cc_library(
     srcs = ["timestamp.cpp"],
     hdrs = ["timestamp.hpp"],
     deps = [],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )
 
 cc_library(
@@ -30,6 +34,8 @@ cc_library(
         ":timestamp",
         "//src/option:option_spec",
     ],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )
 
 cc_library(
@@ -40,6 +46,8 @@ cc_library(
         "//src/math:yield_curve",
         "//src/option:option_spec",
     ],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )
 
 cc_library(
@@ -56,6 +64,8 @@ cc_library(
         ":option_types",
         "//src/option:option_spec",
     ],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )
 
 cc_library(
@@ -65,6 +75,8 @@ cc_library(
         ":option_chain",
         ":converter",
     ],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )
 
 cc_library(
@@ -76,6 +88,8 @@ cc_library(
         "//src/option:interpolated_iv_solver",
         "//src/option:iv_solver",
     ],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )
 
 # Convenience target for all simple headers
@@ -91,4 +105,6 @@ cc_library(
         ":chain_builder",
         ":vol_surface",
     ],
+    strip_include_prefix = "/src/simple",
+    include_prefix = "mango/simple",
 )

--- a/src/simple/chain_builder.hpp
+++ b/src/simple/chain_builder.hpp
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "src/simple/option_chain.hpp"
-#include "src/simple/converter.hpp"
+#include "mango/simple/option_chain.hpp"
+#include "mango/simple/converter.hpp"
 #include <map>
 
 namespace mango::simple {

--- a/src/simple/converter.hpp
+++ b/src/simple/converter.hpp
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include "src/simple/price.hpp"
-#include "src/simple/timestamp.hpp"
-#include "src/simple/option_types.hpp"
-#include "src/option/option_spec.hpp"
+#include "mango/simple/price.hpp"
+#include "mango/simple/timestamp.hpp"
+#include "mango/simple/option_types.hpp"
+#include "mango/option/option_spec.hpp"
 #include <concepts>
 #include <stdexcept>
 

--- a/src/simple/option_chain.hpp
+++ b/src/simple/option_chain.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "src/simple/option_types.hpp"
-#include "src/math/yield_curve.hpp"
-#include "src/option/option_spec.hpp"  // For RateSpec
+#include "mango/simple/option_types.hpp"
+#include "mango/math/yield_curve.hpp"
+#include "mango/option/option_spec.hpp"  // For RateSpec
 #include <optional>
 #include <string>
 #include <vector>

--- a/src/simple/option_types.hpp
+++ b/src/simple/option_types.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "src/option/option_spec.hpp"  // For mango::OptionType
-#include "src/simple/price.hpp"
-#include "src/simple/timestamp.hpp"
+#include "mango/option/option_spec.hpp"  // For mango::OptionType
+#include "mango/simple/price.hpp"
+#include "mango/simple/timestamp.hpp"
 #include <cstdint>
 #include <optional>
 #include <ranges>

--- a/src/simple/simple.hpp
+++ b/src/simple/simple.hpp
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include "src/simple/price.hpp"
-#include "src/simple/timestamp.hpp"
-#include "src/simple/option_types.hpp"
-#include "src/simple/option_chain.hpp"
-#include "src/simple/converter.hpp"
-#include "src/simple/chain_builder.hpp"
-#include "src/simple/vol_surface.hpp"
-#include "src/simple/sources/yfinance.hpp"
-#include "src/simple/sources/databento.hpp"
-#include "src/simple/sources/ibkr.hpp"
+#include "mango/simple/price.hpp"
+#include "mango/simple/timestamp.hpp"
+#include "mango/simple/option_types.hpp"
+#include "mango/simple/option_chain.hpp"
+#include "mango/simple/converter.hpp"
+#include "mango/simple/chain_builder.hpp"
+#include "mango/simple/vol_surface.hpp"
+#include "mango/simple/sources/yfinance.hpp"
+#include "mango/simple/sources/databento.hpp"
+#include "mango/simple/sources/ibkr.hpp"

--- a/src/simple/sources/databento.hpp
+++ b/src/simple/sources/databento.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "src/simple/converter.hpp"
+#include "mango/simple/converter.hpp"
 
 namespace mango::simple {
 

--- a/src/simple/sources/ibkr.hpp
+++ b/src/simple/sources/ibkr.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "src/simple/converter.hpp"
+#include "mango/simple/converter.hpp"
 
 namespace mango::simple {
 

--- a/src/simple/sources/yfinance.hpp
+++ b/src/simple/sources/yfinance.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "src/simple/converter.hpp"
+#include "mango/simple/converter.hpp"
 
 namespace mango::simple {
 

--- a/src/simple/timestamp.cpp
+++ b/src/simple/timestamp.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/simple/timestamp.hpp"
+#include "mango/simple/timestamp.hpp"
 #include <charconv>
 #include <ctime>
 #include <iomanip>

--- a/src/simple/vol_surface.cpp
+++ b/src/simple/vol_surface.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/simple/vol_surface.hpp"
+#include "mango/simple/vol_surface.hpp"
 #include <cmath>
 
 namespace mango::simple {

--- a/src/simple/vol_surface.hpp
+++ b/src/simple/vol_surface.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "src/simple/option_chain.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/iv_solver.hpp"
+#include "mango/simple/option_chain.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 #include <expected>
 #include <memory>
 #include <ranges>

--- a/src/support/BUILD.bazel
+++ b/src/support/BUILD.bazel
@@ -12,18 +12,24 @@ cc_library(
     name = "aligned_allocator",
     hdrs = ["aligned_allocator.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/support",
+    include_prefix = "mango/support",
 )
 
 cc_library(
     name = "parallel",
     hdrs = ["parallel.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/support",
+    include_prefix = "mango/support",
 )
 
 cc_library(
     name = "lifetime",
     hdrs = ["lifetime.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/support",
+    include_prefix = "mango/support",
 )
 
 cc_library(
@@ -31,12 +37,16 @@ cc_library(
     hdrs = ["thread_workspace.hpp"],
     deps = [":parallel"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/support",
+    include_prefix = "mango/support",
 )
 
 cc_library(
     name = "error_types",
     hdrs = ["error_types.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/support",
+    include_prefix = "mango/support",
 )
 
 
@@ -45,10 +55,14 @@ cc_library(
     srcs = ["crc64.cpp"],
     hdrs = ["crc64.hpp"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/support",
+    include_prefix = "mango/support",
 )
 
 cc_library(
     name = "ivcalc_trace_hdr",
     hdrs = ["ivcalc_trace.h"],
     visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/support",
+    include_prefix = "mango/support",
 )

--- a/src/support/crc64.cpp
+++ b/src/support/crc64.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/support/crc64.hpp"
+#include "mango/support/crc64.hpp"
 #include <cstring>
 #include <mutex>
 

--- a/tests/adaptive_grid_builder_integration_test.cc
+++ b/tests/adaptive_grid_builder_integration_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/adaptive_grid_builder.hpp"
+#include "mango/option/table/adaptive_grid_builder.hpp"
 #include <chrono>
 
 namespace mango {

--- a/tests/adaptive_grid_builder_test.cc
+++ b/tests/adaptive_grid_builder_test.cc
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/adaptive_grid_builder.hpp"
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/table/adaptive_grid_builder.hpp"
+#include "mango/option/american_option_batch.hpp"
 #include <algorithm>
-#include "src/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
 #include <iostream>
 
 namespace mango {

--- a/tests/adaptive_grid_types_test.cc
+++ b/tests/adaptive_grid_types_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/adaptive_grid_types.hpp"
+#include "mango/option/table/adaptive_grid_types.hpp"
 
 namespace mango {
 namespace {

--- a/tests/aligned_allocator_test.cc
+++ b/tests/aligned_allocator_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/support/aligned_allocator.hpp"
+#include "mango/support/aligned_allocator.hpp"
 #include <numeric>
 
 namespace mango {

--- a/tests/american_option_batch_test.cc
+++ b/tests/american_option_batch_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option_batch.hpp"
 
 using namespace mango;
 

--- a/tests/american_option_batch_workspace_test.cc
+++ b/tests/american_option_batch_workspace_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option_batch.hpp"
 
 using namespace mango;
 

--- a/tests/american_option_custom_ic_test.cc
+++ b/tests/american_option_custom_ic_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/american_option.hpp"
+#include "mango/option/american_option.hpp"
 
 #include <cmath>
 #include <memory_resource>

--- a/tests/american_option_gamma_oscillation_test.cc
+++ b/tests/american_option_gamma_oscillation_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/american_option.hpp"
-#include "src/pde/operators/centered_difference_facade.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <array>

--- a/tests/american_option_new_api_test.cc
+++ b/tests/american_option_new_api_test.cc
@@ -4,10 +4,10 @@
  * @brief Tests for new AmericanOptionSolver API with PDEWorkspace
  */
 
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_result.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_result.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 #include <memory_resource>
 

--- a/tests/american_option_result_test.cc
+++ b/tests/american_option_result_test.cc
@@ -4,7 +4,7 @@
  * @brief Tests for AmericanOptionResult wrapper class
  */
 
-#include "src/option/american_option_result.hpp"
+#include "mango/option/american_option_result.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/tests/american_option_solver_test.cc
+++ b/tests/american_option_solver_test.cc
@@ -4,9 +4,9 @@
  * @brief Tests for AmericanOptionSolver structure and API
  */
 
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <mutex>

--- a/tests/american_option_test.cc
+++ b/tests/american_option_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
 
 #include <gtest/gtest.h>
 #include <cmath>

--- a/tests/american_pde_workspace_test.cc
+++ b/tests/american_pde_workspace_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // tests/american_pde_workspace_test.cc
 
-#include "src/pde/core/american_pde_workspace.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/pde/core/american_pde_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/american_price_surface_test.cc
+++ b/tests/american_price_surface_test.cc
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/option/european_option.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/option/european_option.hpp"
 #include <cmath>
 
 namespace mango {

--- a/tests/batch_bracketing_test.cc
+++ b/tests/batch_bracketing_test.cc
@@ -5,7 +5,7 @@
  */
 
 #include <gtest/gtest.h>
-#include "src/option/batch_bracketing.hpp"
+#include "mango/option/batch_bracketing.hpp"
 #include <limits>
 
 namespace mango {

--- a/tests/batch_solver_custom_grid_test.cc
+++ b/tests/batch_solver_custom_grid_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/american_option_batch.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 
 TEST(BatchSolverCustomGridTest, AcceptsCustomGrid) {
     // Test without custom grid first (baseline)

--- a/tests/batch_solver_fuzz_test.cc
+++ b/tests/batch_solver_fuzz_test.cc
@@ -18,8 +18,8 @@
 
 #include "fuzztest/fuzztest.h"
 #include "gtest/gtest.h"
-#include "src/option/american_option_batch.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <cmath>
 
 using namespace mango;

--- a/tests/black_scholes_analytics_test.cc
+++ b/tests/black_scholes_analytics_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/math/black_scholes_analytics.hpp"
+#include "mango/math/black_scholes_analytics.hpp"
 #include <cmath>
 
 namespace mango {

--- a/tests/black_scholes_pde_rate_fn_test.cc
+++ b/tests/black_scholes_pde_rate_fn_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/operators/black_scholes_pde.hpp"
-#include "src/math/yield_curve.hpp"
+#include "mango/pde/operators/black_scholes_pde.hpp"
+#include "mango/math/yield_curve.hpp"
 #include <gtest/gtest.h>
 
 TEST(BlackScholesPDERateFnTest, ConstantRateFnViaLambda) {

--- a/tests/boundary_conditions_test.cc
+++ b/tests/boundary_conditions_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/boundary_conditions.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
 #include <gtest/gtest.h>
 
 TEST(BoundaryConditionTest, BoundarySideEnum) {

--- a/tests/brent_cpp_test.cc
+++ b/tests/brent_cpp_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/math/root_finding.hpp"
+#include "mango/math/root_finding.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/tests/bspline_banded_solver_test.cc
+++ b/tests/bspline_banded_solver_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <vector>
 #include <cmath>
 

--- a/tests/bspline_collocation_1d_test.cc
+++ b/tests/bspline_collocation_1d_test.cc
@@ -4,7 +4,7 @@
  * @brief Unit tests for 1D B-spline collocation solver
  */
 
-#include "src/math/bspline_collocation.hpp"
+#include "mango/math/bspline_collocation.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <vector>

--- a/tests/bspline_collocation_workspace_test.cc
+++ b/tests/bspline_collocation_workspace_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // tests/bspline_collocation_workspace_test.cc
-#include "src/math/bspline_collocation_workspace.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/math/bspline_collocation_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cstdint>
 

--- a/tests/bspline_condition_number_stress_test.cc
+++ b/tests/bspline_condition_number_stress_test.cc
@@ -8,7 +8,7 @@
  * on challenging matrices designed to stress the numerical algorithms.
  */
 
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <vector>

--- a/tests/bspline_fit_with_workspace_test.cc
+++ b/tests/bspline_fit_with_workspace_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // tests/bspline_fit_with_workspace_test.cc
-#include "src/math/bspline_collocation.hpp"
-#include "src/math/bspline_collocation_workspace.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/math/bspline_collocation.hpp"
+#include "mango/math/bspline_collocation_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/tests/bspline_fitter_4d_separable_test.cc
+++ b/tests/bspline_fitter_4d_separable_test.cc
@@ -13,7 +13,7 @@
  *       the old hardcoded BSplineNDSeparable<double, 4> class.
  */
 
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <array>

--- a/tests/bspline_fitting_stats_test.cc
+++ b/tests/bspline_fitting_stats_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // tests/bspline_fitting_stats_test.cc
 #include <gtest/gtest.h>
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 
 TEST(BSplineFittingStatsTest, DefaultConstruction) {
     mango::BSplineFittingStats<double, 4> stats;

--- a/tests/bspline_nd_mdspan_test.cc
+++ b/tests/bspline_nd_mdspan_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/math/bspline_nd.hpp"
-#include "src/math/bspline_basis.hpp"
+#include "mango/math/bspline_nd.hpp"
+#include "mango/math/bspline_basis.hpp"
 #include <gtest/gtest.h>
 #include <numeric>
 

--- a/tests/bspline_nd_test.cc
+++ b/tests/bspline_nd_test.cc
@@ -4,9 +4,9 @@
  * @brief Tests for N-dimensional B-spline interpolation
  */
 
-#include "src/math/bspline_nd.hpp"
-#include "src/math/bspline_basis.hpp"
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd.hpp"
+#include "mango/math/bspline_basis.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <array>

--- a/tests/bspline_nd_workspace_integration_test.cc
+++ b/tests/bspline_nd_workspace_integration_test.cc
@@ -6,8 +6,8 @@
 // Verifies that N-dimensional tensor fitting produces identical results
 // with workspace-based zero-allocation fitting.
 
-#include "src/math/bspline_nd_separable.hpp"
-#include "src/support/thread_workspace.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/tests/bspline_workspace_test.cc
+++ b/tests/bspline_workspace_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/math/bspline_nd_separable.hpp"
+#include "mango/math/bspline_nd_separable.hpp"
 #include <cmath>
 #include <vector>
 

--- a/tests/centered_difference_facade_test.cc
+++ b/tests/centered_difference_facade_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/operators/centered_difference_facade.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/operators/centered_difference_facade.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>

--- a/tests/crc64_test.cc
+++ b/tests/crc64_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/support/crc64.hpp"
+#include "mango/support/crc64.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/cubic_spline_2d_test.cc
+++ b/tests/cubic_spline_2d_test.cc
@@ -4,7 +4,7 @@
  * @brief Comprehensive tests for CubicSpline2D template class
  */
 
-#include "src/math/cubic_spline_solver.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>

--- a/tests/custom_grid_example_test.cc
+++ b/tests/custom_grid_example_test.cc
@@ -11,8 +11,8 @@
  * - Grid accuracy tradeoffs
  */
 
-#include "src/option/american_option.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 #include <memory_resource>
 #include <optional>

--- a/tests/discrete_dividend_accuracy_test.cc
+++ b/tests/discrete_dividend_accuracy_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
 #include <cmath>
 #include <memory_resource>
 #include <ql/quantlib.hpp>

--- a/tests/discrete_dividend_event_test.cc
+++ b/tests/discrete_dividend_event_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/discrete_dividend_event.hpp"
-#include "src/math/cubic_spline_solver.hpp"
+#include "mango/option/discrete_dividend_event.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
 #include <vector>
 #include <cmath>
 

--- a/tests/discrete_dividend_iv_integration_test.cc
+++ b/tests/discrete_dividend_iv_integration_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/iv_solver_factory.hpp"
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/iv_solver_factory.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
 
 using namespace mango;
 

--- a/tests/eep_integration_test.cc
+++ b/tests/eep_integration_test.cc
@@ -2,11 +2,11 @@
 /// @file eep_integration_test.cc
 /// @brief End-to-end integration tests for EEP decomposition feature
 
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/option/american_option.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <gtest/gtest.h>
 #include <memory_resource>
 #include <cmath>

--- a/tests/error_attribution_test.cc
+++ b/tests/error_attribution_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/error_attribution.hpp"
+#include "mango/option/table/error_attribution.hpp"
 
 namespace mango {
 namespace {

--- a/tests/error_types_test.cc
+++ b/tests/error_types_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 
 using namespace mango;
 

--- a/tests/european_option_test.cc
+++ b/tests/european_option_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/european_option.hpp"
-#include "src/option/option_concepts.hpp"
+#include "mango/option/european_option.hpp"
+#include "mango/option/option_concepts.hpp"
 #include <cmath>
 
 namespace {

--- a/tests/grid_expected_test.cc
+++ b/tests/grid_expected_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <expected>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 #include <gtest/gtest.h>
 
 using namespace mango;

--- a/tests/grid_snapshot_test.cc
+++ b/tests/grid_snapshot_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
+#include "mango/support/error_types.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/grid_spacing_data_test.cc
+++ b/tests/grid_spacing_data_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 TEST(UniformSpacingTest, ConstructionAndAccessors) {

--- a/tests/grid_spacing_mdspan_test.cc
+++ b/tests/grid_spacing_mdspan_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {

--- a/tests/grid_spacing_test.cc
+++ b/tests/grid_spacing_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/grid_test.cc
+++ b/tests/grid_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 TEST(GridSpecTest, UniformGridGeneration) {

--- a/tests/grid_with_solution_test.cc
+++ b/tests/grid_with_solution_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {

--- a/tests/interpolated_iv_solver_test.cc
+++ b/tests/interpolated_iv_solver_test.cc
@@ -5,14 +5,14 @@
  */
 
 #include <gtest/gtest.h>
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/option/table/american_price_surface.hpp"
-#include "src/option/table/segmented_multi_kref_builder.hpp"
-#include "src/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/option/table/american_price_surface.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
 
 namespace mango {
 namespace {

--- a/tests/interpolation_error_test.cc
+++ b/tests/interpolation_error_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 #include <gtest/gtest.h>
 #include <sstream>
 

--- a/tests/iv_error_types_test.cc
+++ b/tests/iv_error_types_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/support/error_types.hpp"
+#include "mango/support/error_types.hpp"
 
 using namespace mango;
 

--- a/tests/iv_result_test.cc
+++ b/tests/iv_result_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/iv_result.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/iv_result.hpp"
+#include "mango/support/error_types.hpp"
 #include <expected>
 #include <vector>
 

--- a/tests/iv_solver_expected_test.cc
+++ b/tests/iv_solver_expected_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/iv_solver.hpp"
-#include "src/option/iv_result.hpp"
-#include "src/support/error_types.hpp"
+#include "mango/option/iv_solver.hpp"
+#include "mango/option/iv_result.hpp"
+#include "mango/support/error_types.hpp"
 
 using namespace mango;
 

--- a/tests/iv_solver_factory_test.cc
+++ b/tests/iv_solver_factory_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/iv_solver_factory.hpp"
-#include "src/option/american_option.hpp"
+#include "mango/option/iv_solver_factory.hpp"
+#include "mango/option/american_option.hpp"
 #include <chrono>
 #include <cmath>
 #include <iostream>

--- a/tests/iv_solver_integration_test.cc
+++ b/tests/iv_solver_integration_test.cc
@@ -5,7 +5,7 @@
  */
 
 #include <gtest/gtest.h>
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 #include <string>
 
 using namespace mango;

--- a/tests/iv_solver_property_test.cc
+++ b/tests/iv_solver_property_test.cc
@@ -5,7 +5,7 @@
  */
 
 #include <gtest/gtest.h>
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 #include <cmath>
 #include <vector>
 

--- a/tests/iv_solver_test.cc
+++ b/tests/iv_solver_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include "src/option/iv_solver.hpp"
+#include "mango/option/iv_solver.hpp"
 #include <cmath>
 
 using namespace mango;

--- a/tests/lapack_banded_layout_test.cc
+++ b/tests/lapack_banded_layout_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/math/lapack_banded_layout.hpp"
+#include "mango/math/lapack_banded_layout.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/latin_hypercube_test.cc
+++ b/tests/latin_hypercube_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/math/latin_hypercube.hpp"
+#include "mango/math/latin_hypercube.hpp"
 #include <algorithm>
 #include <set>
 

--- a/tests/lifetime_test.cc
+++ b/tests/lifetime_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // tests/lifetime_test.cc
-#include "src/support/lifetime.hpp"
+#include "mango/support/lifetime.hpp"
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <type_traits>

--- a/tests/mdspan_integration_e2e_test.cc
+++ b/tests/mdspan_integration_e2e_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
-#include "src/math/banded_matrix_solver.hpp"
-#include "src/math/bspline_nd.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/math/banded_matrix_solver.hpp"
+#include "mango/math/bspline_nd.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 
 namespace mango {

--- a/tests/multi_sinh_grid_example_test.cc
+++ b/tests/multi_sinh_grid_example_test.cc
@@ -10,7 +10,7 @@
  * - Grid spacing properties (concentration near cluster centers)
  */
 
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 #include <limits>
 

--- a/tests/normalized_chain_accuracy_test.cc
+++ b/tests/normalized_chain_accuracy_test.cc
@@ -16,7 +16,7 @@
  */
 
 #include <gtest/gtest.h>
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option_batch.hpp"
 #include "tests/quantlib_validation_framework.hpp"
 
 using namespace mango;

--- a/tests/normalized_solver_regression_test.cc
+++ b/tests/normalized_solver_regression_test.cc
@@ -8,7 +8,7 @@
  * - Issue #2: SetupCallback disables normalized path
  */
 
-#include "src/option/american_option_batch.hpp"
+#include "mango/option/american_option_batch.hpp"
 #include <gtest/gtest.h>
 #include <mutex>
 #include <vector>

--- a/tests/obstacle_test.cc
+++ b/tests/obstacle_test.cc
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
-#include "src/pde/operators/laplacian_pde.hpp"
-#include "src/pde/operators/operator_factory.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
+#include "mango/pde/operators/laplacian_pde.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <cmath>
 #include <algorithm>
 #include <memory_resource>

--- a/tests/operators/target_clones_test.cc
+++ b/tests/operators/target_clones_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/pde/operators/centered_difference_scalar.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/operators/centered_difference_scalar.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <vector>
 #include <cmath>
 #include <dlfcn.h>

--- a/tests/option_concepts_test.cc
+++ b/tests/option_concepts_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/option_concepts.hpp"
-#include "src/option/american_option_result.hpp"
+#include "mango/option/option_concepts.hpp"
+#include "mango/option/american_option_result.hpp"
 
 namespace mango {
 namespace {

--- a/tests/option_grid_test.cc
+++ b/tests/option_grid_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/option_grid.hpp"
+#include "mango/option/option_grid.hpp"
 
 TEST(OptionGridTest, DefaultConstruction) {
     mango::OptionGrid chain;

--- a/tests/option_spec_test.cc
+++ b/tests/option_spec_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/option_spec.hpp"
+#include "mango/option/option_spec.hpp"
 #include <cmath>
 
 using namespace mango;

--- a/tests/parallel_critical_test.cc
+++ b/tests/parallel_critical_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/support/parallel.hpp"
+#include "mango/support/parallel.hpp"
 #include <gtest/gtest.h>
 #include <atomic>
 #include <vector>

--- a/tests/pde_solver_snapshot_test.cc
+++ b/tests/pde_solver_snapshot_test.cc
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/operators/laplacian_pde.hpp"
-#include "src/pde/operators/operator_factory.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/operators/laplacian_pde.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <numbers>

--- a/tests/pde_solver_test.cc
+++ b/tests/pde_solver_test.cc
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
-#include "src/pde/operators/operator_factory.hpp"
-#include "src/pde/operators/laplacian_pde.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/core/grid.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
+#include "mango/pde/operators/laplacian_pde.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/grid.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <numbers>

--- a/tests/pde_workspace_test.cc
+++ b/tests/pde_workspace_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/price_surface_concept_test.cc
+++ b/tests/price_surface_concept_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_surface_concept.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_surface_concept.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 using namespace mango;
 

--- a/tests/price_table_4d_integration_test.cc
+++ b/tests/price_table_4d_integration_test.cc
@@ -4,8 +4,8 @@
  * @brief Integration tests for PriceTableBuilder<4> with routing
  */
 
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <iostream>

--- a/tests/price_table_axes_test.cc
+++ b/tests/price_table_axes_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_axes.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_builder_custom_grid_advanced_test.cc
+++ b/tests/price_table_builder_custom_grid_advanced_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 #include "tests/price_table_builder_test_access.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/time_domain.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_builder_custom_grid_diagnosis_test.cc
+++ b/tests/price_table_builder_custom_grid_diagnosis_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 #include "tests/price_table_builder_test_access.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/time_domain.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_builder_custom_grid_test.cc
+++ b/tests/price_table_builder_custom_grid_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 #include "tests/price_table_builder_test_access.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/time_domain.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_builder_factories_test.cc
+++ b/tests/price_table_builder_factories_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/option_grid.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/option_grid.hpp"
 
 TEST(PriceTableFactoriesTest, FromVectorsCreatesBuilderAndAxes) {
     std::vector<double> moneyness = {0.8, 0.9, 1.0, 1.1};

--- a/tests/price_table_builder_grid_test.cc
+++ b/tests/price_table_builder_grid_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_config.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_config.hpp"
 
 TEST(PriceTableBuilderGridTest, RespectsUserGridBounds) {
     // Create axes with specific moneyness range

--- a/tests/price_table_builder_raw_price_test.cc
+++ b/tests/price_table_builder_raw_price_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 using namespace mango;
 

--- a/tests/price_table_builder_result_test.cc
+++ b/tests/price_table_builder_result_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_axes.hpp"
-#include "src/option/table/price_table_config.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_axes.hpp"
+#include "mango/option/table/price_table_config.hpp"
 
 TEST(PriceTableBuilderResultTest, BuildReturnsDiagnostics) {
     // Create minimal valid axes (4 points per axis for B-spline)

--- a/tests/price_table_builder_root_cause_test.cc
+++ b/tests/price_table_builder_root_cause_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 #include "tests/price_table_builder_test_access.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/time_domain.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_builder_test.cc
+++ b/tests/price_table_builder_test.cc
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 #include "tests/price_table_builder_test_access.hpp"
-#include "src/option/table/price_table_metadata.hpp"
-#include "src/option/table/price_tensor.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
+#include "mango/option/table/price_tensor.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_builder_test_access.hpp
+++ b/tests/price_table_builder_test_access.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 
 namespace mango::testing {
 

--- a/tests/price_table_config_test.cc
+++ b/tests/price_table_config_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_config.hpp"
+#include "mango/option/table/price_table_config.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_end_to_end_performance_test.cc
+++ b/tests/price_table_end_to_end_performance_test.cc
@@ -14,7 +14,7 @@
  * - Expected speedup: ≥1.47× (banded solver is ~40% of total runtime)
  */
 
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 #include <gtest/gtest.h>
 #include <chrono>
 #include <iostream>

--- a/tests/price_table_grid_estimator_test.cc
+++ b/tests/price_table_grid_estimator_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_grid_estimator.hpp"
-#include "src/option/american_option.hpp"
+#include "mango/option/table/price_table_grid_estimator.hpp"
+#include "mango/option/american_option.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_metadata_test.cc
+++ b/tests/price_table_metadata_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_metadata.hpp"
+#include "mango/option/table/price_table_metadata.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_result_test.cc
+++ b/tests/price_table_result_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_builder.hpp"
 
 TEST(PriceTableResultTest, DefaultConstruction) {
     mango::PriceTableResult<4> result;

--- a/tests/price_table_surface_test.cc
+++ b/tests/price_table_surface_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_table_surface.hpp"
 
 namespace mango {
 namespace {

--- a/tests/price_table_workspace_test.cc
+++ b/tests/price_table_workspace_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/table/price_table_workspace.hpp"
+#include "mango/option/table/price_table_workspace.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <fstream>

--- a/tests/price_tensor_test.cc
+++ b/tests/price_tensor_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/price_tensor.hpp"
+#include "mango/option/table/price_tensor.hpp"
 
 namespace mango {
 namespace {

--- a/tests/production_config_integration_test.cc
+++ b/tests/production_config_integration_test.cc
@@ -15,11 +15,11 @@
  */
 
 #include <gtest/gtest.h>
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/american_option_batch.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 
 using namespace mango;
 

--- a/tests/quantlib_accuracy_batch_test.cc
+++ b/tests/quantlib_accuracy_batch_test.cc
@@ -12,9 +12,9 @@
  */
 
 #include "tests/quantlib_validation_framework.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/price_table_surface.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 #include <gtest/gtest.h>
 
 using namespace mango;

--- a/tests/quantlib_accuracy_test.cc
+++ b/tests/quantlib_accuracy_test.cc
@@ -15,8 +15,8 @@
  * Tolerance: 1% relative error (protects against 14.5% regression like #204)
  */
 
-#include "src/option/american_option.hpp"
-#include "src/option/iv_solver.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/iv_solver.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 #include <memory_resource>

--- a/tests/quantlib_validation_framework.hpp
+++ b/tests/quantlib_validation_framework.hpp
@@ -17,9 +17,9 @@
 
 #pragma once
 
-#include "src/option/american_option.hpp"
-#include "src/option/iv_solver.hpp"
-#include "src/option/interpolated_iv_solver.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/iv_solver.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
 #include <gtest/gtest.h>
 #include <ql/quantlib.hpp>
 #include <vector>

--- a/tests/rate_spec_test.cc
+++ b/tests/rate_spec_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-#include "src/option/option_spec.hpp"
-#include "src/math/yield_curve.hpp"
+#include "mango/option/option_spec.hpp"
+#include "mango/math/yield_curve.hpp"
 #include <gtest/gtest.h>
 
 TEST(RateSpecTest, DefaultIsDouble) {

--- a/tests/real_market_data_test.cc
+++ b/tests/real_market_data_test.cc
@@ -9,9 +9,9 @@
 
 #include <gtest/gtest.h>
 #include "benchmarks/real_market_data.hpp"
-#include "src/option/american_option.hpp"
-#include "src/option/american_option_batch.hpp"
-#include "src/option/iv_solver.hpp"
+#include "mango/option/american_option.hpp"
+#include "mango/option/american_option_batch.hpp"
+#include "mango/option/iv_solver.hpp"
 
 using namespace mango;
 namespace bdata = mango::benchmark_data;

--- a/tests/recursion_helpers_test.cc
+++ b/tests/recursion_helpers_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/recursion_helpers.hpp"
+#include "mango/option/table/recursion_helpers.hpp"
 #include <vector>
 
 namespace mango {

--- a/tests/root_finding_test.cc
+++ b/tests/root_finding_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/math/root_finding.hpp"
+#include "mango/math/root_finding.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/tests/safe_math_test.cc
+++ b/tests/safe_math_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/math/safe_math.hpp"
+#include "mango/math/safe_math.hpp"
 #include <limits>
 #include <array>
 #include <vector>

--- a/tests/segmented_multi_kref_builder_test.cc
+++ b/tests/segmented_multi_kref_builder_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_multi_kref_builder.hpp"
-#include "src/option/table/segmented_price_table_builder.hpp"
+#include "mango/option/table/segmented_multi_kref_builder.hpp"
+#include "mango/option/table/segmented_price_table_builder.hpp"
 
 using namespace mango;
 

--- a/tests/segmented_multi_kref_surface_test.cc
+++ b/tests/segmented_multi_kref_surface_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_multi_kref_surface.hpp"
-#include "src/option/table/segmented_price_table_builder.hpp"
-#include "src/option/table/price_surface_concept.hpp"
+#include "mango/option/table/segmented_multi_kref_surface.hpp"
+#include "mango/option/table/segmented_price_table_builder.hpp"
+#include "mango/option/table/price_surface_concept.hpp"
 
 using namespace mango;
 

--- a/tests/segmented_price_surface_test.cc
+++ b/tests/segmented_price_surface_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_price_surface.hpp"
-#include "src/option/table/price_table_builder.hpp"
-#include "src/option/table/american_price_surface.hpp"
+#include "mango/option/table/segmented_price_surface.hpp"
+#include "mango/option/table/price_table_builder.hpp"
+#include "mango/option/table/american_price_surface.hpp"
 #include <cmath>
 
 using namespace mango;

--- a/tests/segmented_price_table_builder_test.cc
+++ b/tests/segmented_price_table_builder_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/segmented_price_table_builder.hpp"
+#include "mango/option/table/segmented_price_table_builder.hpp"
 #include <cmath>
 
 using namespace mango;

--- a/tests/simple_chain_builder_test.cc
+++ b/tests/simple_chain_builder_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/simple/chain_builder.hpp"
-#include "src/simple/sources/yfinance.hpp"
-#include "src/simple/sources/databento.hpp"
+#include "mango/simple/chain_builder.hpp"
+#include "mango/simple/sources/yfinance.hpp"
+#include "mango/simple/sources/databento.hpp"
 
 using namespace mango::simple;
 

--- a/tests/simple_converter_test.cc
+++ b/tests/simple_converter_test.cc
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/simple/converter.hpp"
-#include "src/simple/sources/yfinance.hpp"
-#include "src/simple/sources/databento.hpp"
-#include "src/simple/sources/ibkr.hpp"
+#include "mango/simple/converter.hpp"
+#include "mango/simple/sources/yfinance.hpp"
+#include "mango/simple/sources/databento.hpp"
+#include "mango/simple/sources/ibkr.hpp"
 
 using namespace mango::simple;
 

--- a/tests/simple_databento_test.cc
+++ b/tests/simple_databento_test.cc
@@ -9,7 +9,7 @@
  * - Correct conversion of nanosecond timestamps
  */
 
-#include "src/simple/simple.hpp"
+#include "mango/simple/simple.hpp"
 #include <gtest/gtest.h>
 
 using namespace mango::simple;

--- a/tests/simple_option_types_test.cc
+++ b/tests/simple_option_types_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/simple/option_types.hpp"
+#include "mango/simple/option_types.hpp"
 
 using namespace mango::simple;
 

--- a/tests/simple_price_test.cc
+++ b/tests/simple_price_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/simple/price.hpp"
+#include "mango/simple/price.hpp"
 
 TEST(SimplePriceTest, ConstructFromDouble) {
     mango::simple::Price p{100.50};

--- a/tests/simple_timestamp_test.cc
+++ b/tests/simple_timestamp_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/simple/timestamp.hpp"
+#include "mango/simple/timestamp.hpp"
 #include <chrono>
 
 using namespace mango::simple;

--- a/tests/simple_vol_surface_test.cc
+++ b/tests/simple_vol_surface_test.cc
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/simple/vol_surface.hpp"
-#include "src/simple/chain_builder.hpp"
-#include "src/simple/sources/yfinance.hpp"
+#include "mango/simple/vol_surface.hpp"
+#include "mango/simple/chain_builder.hpp"
+#include "mango/simple/sources/yfinance.hpp"
 
 using namespace mango::simple;
 

--- a/tests/simple_yfinance_test.cc
+++ b/tests/simple_yfinance_test.cc
@@ -10,7 +10,7 @@
  * - Data preservation through pipeline
  */
 
-#include "src/simple/simple.hpp"
+#include "mango/simple/simple.hpp"
 #include <gtest/gtest.h>
 #include <ranges>
 

--- a/tests/slice_cache_test.cc
+++ b/tests/slice_cache_test.cc
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/option/table/slice_cache.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
-#include "src/option/option_spec.hpp"
+#include "mango/option/table/slice_cache.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
+#include "mango/option/option_spec.hpp"
 
 namespace mango {
 namespace {

--- a/tests/temporal_event_test.cc
+++ b/tests/temporal_event_test.cc
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 #include <gtest/gtest.h>
-#include "src/pde/core/pde_solver.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/core/pde_workspace.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/boundary_conditions.hpp"
-#include "src/pde/operators/laplacian_pde.hpp"
-#include "src/pde/operators/spatial_operator.hpp"
-#include "src/pde/operators/operator_factory.hpp"
-#include "src/pde/core/grid.hpp"
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/pde_solver.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/pde_workspace.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/boundary_conditions.hpp"
+#include "mango/pde/operators/laplacian_pde.hpp"
+#include "mango/pde/operators/spatial_operator.hpp"
+#include "mango/pde/operators/operator_factory.hpp"
+#include "mango/pde/core/grid.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <cmath>
 #include <algorithm>
 #include <memory_resource>

--- a/tests/thomas_cubic_spline_test.cc
+++ b/tests/thomas_cubic_spline_test.cc
@@ -4,8 +4,8 @@
  * @brief Test modern C++20 Thomas solver and cubic spline
  */
 
-#include "src/math/thomas_solver.hpp"
-#include "src/math/cubic_spline_solver.hpp"
+#include "mango/math/thomas_solver.hpp"
+#include "mango/math/cubic_spline_solver.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>

--- a/tests/thread_workspace_test.cc
+++ b/tests/thread_workspace_test.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // tests/thread_workspace_test.cc
-#include "src/support/thread_workspace.hpp"
+#include "mango/support/thread_workspace.hpp"
 #include <gtest/gtest.h>
 #include <cstdint>
 

--- a/tests/time_domain_test.cc
+++ b/tests/time_domain_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/time_domain.hpp"
+#include "mango/pde/core/time_domain.hpp"
 #include <gtest/gtest.h>
 
 TEST(TimeDomainTest, BasicConfiguration) {

--- a/tests/trbdf2_config_test.cc
+++ b/tests/trbdf2_config_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/pde/core/trbdf2_config.hpp"
+#include "mango/pde/core/trbdf2_config.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/tests/tridiagonal_solver_test.cc
+++ b/tests/tridiagonal_solver_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/math/thomas_solver.hpp"
+#include "mango/math/thomas_solver.hpp"
 #include <gtest/gtest.h>
 #include <vector>
 #include <cmath>

--- a/tests/yield_curve_test.cc
+++ b/tests/yield_curve_test.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "src/math/yield_curve.hpp"
+#include "mango/math/yield_curve.hpp"
 #include <gtest/gtest.h>
 #include <cmath>
 


### PR DESCRIPTION
## Summary

Change all include paths to use `#include "mango/..."` instead of `#include "src/..."` for cleaner external API.

## Approach

Use Bazel's `strip_include_prefix` and `include_prefix` attributes on cc_library targets. The `src/` directory structure is preserved, but headers are exposed under the `mango/` namespace.

```cpp
// Before
#include "src/option/american_option.hpp"

// After  
#include "mango/option/american_option.hpp"
```

## Changes

- Add `strip_include_prefix`/`include_prefix` to 79 cc_library targets
- Update 1000+ include statements across 280+ files
- Update documentation examples (CLAUDE.md, API_GUIDE.md, etc.)
- Fix 4 relative includes within pde/operators

## Test Plan

- [x] All 117 tests pass
- [x] Benchmarks compile
- [x] Python bindings compile
- [x] compile_commands.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)