### PR TITLE
Use equidistribution-optimal sinh alpha as default

### DIFF
--- a/src/option/grid_spec_types.hpp
+++ b/src/option/grid_spec_types.hpp
@@ -1,19 +1,35 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 #include "mango/pde/core/grid.hpp"
+#include <cmath>
 #include <variant>
 #include <vector>
 
 namespace mango {
 
+/// Equidistribution-optimal sinh concentration for a given domain half-width.
+/// Derived from matching sinh density to Black-Scholes gamma profile:
+///   α = 2 · arcsinh(n_σ / √2)
+constexpr double optimal_sinh_alpha(double n_sigma) {
+    // std::asinh/std::sqrt are not constexpr in C++23 standard,
+    // but we use constexpr as a hint; works at runtime regardless.
+    return 2.0 * std::asinh(n_sigma / std::sqrt(2.0));
+}
+
 enum class GridAccuracyProfile { Low, Medium, High, Ultra };
 
 struct GridAccuracyParams {
-    /// Domain half-width in units of σ√T (default: 5.0 covers ±5 std devs)
+    /// Domain half-width in units of σ√T.
+    /// 5.0 covers ±5 std devs (99.99994% of log-normal density).
+    /// Conservative heuristic — not derived from error analysis.
+    /// Smaller values (3-4) save points but risk boundary error on
+    /// long-dated or high-vol options; larger values (6+) waste points
+    /// in regions where the solution equals the boundary value.
     double n_sigma = 5.0;
 
-    /// Sinh clustering strength (default: 2.0 concentrates points near strike)
-    double alpha = 2.0;
+    /// Sinh clustering strength (default: equidistribution-optimal for n_sigma)
+    /// α = 2 · arcsinh(n_σ / √2) ≈ 3.95 for n_sigma=5.0
+    double alpha = optimal_sinh_alpha(5.0);
 
     /// Target spatial truncation error (default: 1e-2 for ~1e-3 price accuracy)
     /// - 1e-2: Fast mode (~100-150 points, ~5ms per option)
@@ -35,7 +51,7 @@ struct GridAccuracyParams {
 };
 
 struct PDEGridConfig {
-    GridSpec<double> grid_spec = GridSpec<double>::sinh_spaced(-3.0, 3.0, 101, 2.0).value();
+    GridSpec<double> grid_spec = GridSpec<double>::sinh_spaced(-3.0, 3.0, 101, optimal_sinh_alpha(5.0)).value();
     size_t n_time = 1000;
     std::vector<double> mandatory_times = {};
 };


### PR DESCRIPTION
## Summary
- Replace hardcoded `α=2.0` default with `α = 2·arcsinh(n_σ/√2) ≈ 3.95` in `GridAccuracyParams` and `PDEGridConfig`
- Add `optimal_sinh_alpha()` utility function for reuse
- Derived from matching sinh grid density to Black-Scholes gamma profile (equidistribution principle)

## Why

The old `α=2.0` with `n_sigma=5.0` gave only 1.18x point concentration vs uniform — essentially no benefit from sinh spacing. The optimal value reduces spatial error **1.6-1.8x at zero speed cost**, as demonstrated in #328.

| Grid | Error (α=2.0) | Error (α≈3.95) | Improvement |
|------|--------------|----------------|-------------|
| 1x (101pt) | 8.37e-3 | 4.55e-3 | 1.84x |
| 2x (203pt) | 2.18e-3 | 1.23e-3 | 1.77x |
| 4x (405pt) | 590e-6 | 352e-6 | 1.68x |
| 8x (809pt) | 160e-6 | 100e-6 | 1.60x |

## Test plan
- [x] `bazel build //...` passes
- [x] `bazel test //...` — all 117 tests pass
- [x] Benchmarked in #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)