### PR TITLE
Remove dead code from APS removal

### DIFF
--- a/src/option/interpolated_iv_solver.cpp
+++ b/src/option/interpolated_iv_solver.cpp
@@ -151,9 +151,8 @@ BatchIVResult AnyIVSolver::solve_batch(const std::vector<IVQuery>& queries) cons
 static std::expected<AnyIVSolver, ValidationError>
 wrap_surface(std::shared_ptr<const PriceTableSurface<4>> surface,
              OptionType option_type,
-             double dividend_yield,
              const InterpolatedIVSolverConfig& solver_config) {
-    auto wrapper = build_standard_surface(surface, option_type, dividend_yield);
+    auto wrapper = make_standard_wrapper(surface, option_type);
     if (!wrapper.has_value()) {
         return std::unexpected(ValidationError{
             ValidationErrorCode::InvalidGridSize, 0.0});
@@ -200,8 +199,7 @@ build_standard_adaptive(const IVSolverFactoryConfig& config,
             ValidationErrorCode::InvalidGridSize, 0.0});
     }
 
-    return wrap_surface(result->surface, config.option_type,
-                        config.dividend_yield, config.solver_config);
+    return wrap_surface(result->surface, config.option_type, config.solver_config);
 }
 
 // ---------------------------------------------------------------------------
@@ -241,8 +239,7 @@ build_standard(const IVSolverFactoryConfig& config, const StandardIVPath& path) 
             ValidationErrorCode::InvalidGridSize, 0.0});
     }
 
-    return wrap_surface(table_result->surface, config.option_type,
-                        config.dividend_yield, config.solver_config);
+    return wrap_surface(table_result->surface, config.option_type, config.solver_config);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/option/table/adaptive_grid_builder.cpp
+++ b/src/option/table/adaptive_grid_builder.cpp
@@ -1029,7 +1029,7 @@ AdaptiveGridBuilder::build_cached_surface(
 
     // Return a handle that queries the surface (reconstruct full American price)
     auto surface_ptr = surface.value();
-    auto wrapper = build_standard_surface(surface_ptr, type, dividend_yield);
+    auto wrapper = make_standard_wrapper(surface_ptr, type);
     if (!wrapper.has_value()) {
         return std::unexpected(PriceTableError{PriceTableErrorCode::InvalidConfig});
     }

--- a/src/option/table/eep_transform.hpp
+++ b/src/option/table/eep_transform.hpp
@@ -34,7 +34,7 @@ struct EEPDecomposer {
 ///   price = EEP(ln(S/K)) * (K/K_ref) + V_european(S, K, tau, sigma, rate)
 ///   vega  = dEEP/dsigma  * (K/K_ref) + vega_european(S, K, tau, sigma, rate)
 ///
-/// This encapsulates all query-time EEP math, replacing AmericanPriceSurface.
+/// Encapsulates all query-time EEP math for the SplicedSurface framework.
 class EEPPriceTableInner {
 public:
     EEPPriceTableInner(std::shared_ptr<const PriceTableSurface<4>> surface,

--- a/src/option/table/price_table_inner.hpp
+++ b/src/option/table/price_table_inner.hpp
@@ -10,7 +10,7 @@
 namespace mango {
 
 /// Universal adapter wrapping PriceTableSurface<4> for SplicedInner concept.
-/// Replaces AmericanPriceSurfaceAdapter. Used by both standard and segmented paths.
+/// Used by segmented paths (NormalizedPrice content; no EEP reconstruction).
 class PriceTableInner {
 public:
     explicit PriceTableInner(std::shared_ptr<const PriceTableSurface<4>> surface)

--- a/src/option/table/segmented_price_table_builder.cpp
+++ b/src/option/table/segmented_price_table_builder.cpp
@@ -240,7 +240,7 @@ SegmentedPriceTableBuilder::build(const Config& config) {
     // =====================================================================
     // Step 4: Build segments (last first, then backward)
     // =====================================================================
-    // We'll store AmericanPriceSurface for each segment, then assemble.
+    // Build each segment's surface, then assemble into SegmentedSurface.
     // Index 0 = closest to expiry.
     std::vector<SegmentConfig> segment_configs;
     segment_configs.reserve(n_segments);

--- a/src/option/table/spliced_surface.hpp
+++ b/src/option/table/spliced_surface.hpp
@@ -212,52 +212,6 @@ private:
     std::vector<double> tau_end_;
 };
 
-class LinearBracket {
-public:
-    explicit LinearBracket(std::vector<double> grid)
-        : grid_(std::move(grid))
-    {}
-
-    [[nodiscard]] double key(const PriceQuery& q) const noexcept { return q.tau; }
-    [[nodiscard]] size_t num_slices() const noexcept { return grid_.size(); }
-
-    [[nodiscard]] Bracket bracket(double tau) const noexcept {
-        Bracket br;
-        const size_t n = grid_.size();
-        if (n == 0) {
-            return br;
-        }
-        if (tau <= grid_.front()) {
-            br.items[0] = SliceWeight{0, 1.0};
-            br.size = 1;
-            return br;
-        }
-        if (tau >= grid_.back()) {
-            br.items[0] = SliceWeight{n - 1, 1.0};
-            br.size = 1;
-            return br;
-        }
-
-        size_t hi = 1;
-        while (hi < n && grid_[hi] < tau) {
-            ++hi;
-        }
-        size_t lo = hi - 1;
-
-        double tau_lo = grid_[lo];
-        double tau_hi = grid_[hi];
-        double t = (tau - tau_lo) / (tau_hi - tau_lo);
-
-        br.items[0] = SliceWeight{lo, 1.0 - t};
-        br.items[1] = SliceWeight{hi, t};
-        br.size = 2;
-        return br;
-    }
-
-private:
-    std::vector<double> grid_;
-};
-
 /// Split strategy for K_ref bracket interpolation.
 /// Finds two K_refs bracketing the query strike and computes linear weights.
 class KRefBracket {

--- a/src/option/table/spliced_surface_builder.cpp
+++ b/src/option/table/spliced_surface_builder.cpp
@@ -7,42 +7,6 @@
 namespace mango {
 
 // ===========================================================================
-// Standard surface builder
-// ===========================================================================
-
-std::expected<StandardSurfaceWrapper, PriceTableError>
-build_standard_surface(std::shared_ptr<const PriceTableSurface<4>> surface,
-                       OptionType option_type,
-                       double dividend_yield) {
-    if (!surface) {
-        return std::unexpected(PriceTableError{
-            PriceTableErrorCode::InvalidConfig, 0, 0});
-    }
-
-    const auto& meta = surface->metadata();
-    const auto& axes = surface->axes();
-    double K_ref = meta.K_ref;
-
-    // Create EEP-reconstructing inner adapter
-    EEPPriceTableInner inner(surface, option_type, K_ref, dividend_yield);
-
-    // Wrap in StandardSurface (1 slice, identity transform)
-    StandardSurface std_surface(
-        {std::move(inner)}, SingleBracket{}, IdentityTransform{}, WeightedSum{});
-
-    // Extract bounds from surface metadata/axes
-    StandardSurfaceWrapper::Bounds bounds{
-        .m_min = meta.m_min, .m_max = meta.m_max,
-        .tau_min = axes.grids[1].front(), .tau_max = axes.grids[1].back(),
-        .sigma_min = axes.grids[2].front(), .sigma_max = axes.grids[2].back(),
-        .rate_min = axes.grids[3].front(), .rate_max = axes.grids[3].back(),
-    };
-
-    return StandardSurfaceWrapper(
-        std::move(std_surface), bounds, option_type, dividend_yield);
-}
-
-// ===========================================================================
 // Segmented surface builder
 // ===========================================================================
 

--- a/src/option/table/spliced_surface_builder.hpp
+++ b/src/option/table/spliced_surface_builder.hpp
@@ -12,24 +12,6 @@ namespace mango {
 template <size_t N> class PriceTableSurface;
 
 // ===========================================================================
-// Standard surface builder
-// ===========================================================================
-
-/// Build a StandardSurfaceWrapper from a pre-built EEP price table surface.
-///
-/// Wraps the surface in EEPPriceTableInner (query-time EEP reconstruction)
-/// and SplicedSurfaceWrapper (PriceSurface-compatible bounds).
-///
-/// @param surface EEP price table surface (from PriceTableBuilder)
-/// @param option_type PUT or CALL
-/// @param dividend_yield Continuous dividend yield
-/// @return StandardSurfaceWrapper or error
-[[nodiscard]] std::expected<StandardSurfaceWrapper, PriceTableError>
-build_standard_surface(std::shared_ptr<const PriceTableSurface<4>> surface,
-                       OptionType option_type,
-                       double dividend_yield);
-
-// ===========================================================================
 // Segmented surface builder
 // ===========================================================================
 

--- a/src/option/table/standard_surface.hpp
+++ b/src/option/table/standard_surface.hpp
@@ -17,7 +17,7 @@ namespace mango {
 using StandardSurface = SplicedSurface<EEPPriceTableInner, SingleBracket, IdentityTransform, WeightedSum>;
 using StandardSurfaceWrapper = SplicedSurfaceWrapper<StandardSurface>;
 
-/// Segmented surface types using PriceTableInner (replaces AmericanPriceSurfaceAdapter defaults)
+/// Segmented surface types using PriceTableInner (NormalizedPrice content)
 using SegmentedSurfacePI = SegmentedSurface<PriceTableInner>;
 using MultiKRefSurfacePI = MultiKRefSurface<SegmentedSurfacePI>;
 using MultiKRefSurfaceWrapperPI = SplicedSurfaceWrapper<MultiKRefSurfacePI>;

--- a/tests/interpolated_iv_solver_test.cc
+++ b/tests/interpolated_iv_solver_test.cc
@@ -216,7 +216,7 @@ TEST_F(InterpolatedIVSolverTest, ConvergenceWithinIterations) {
     }
 }
 
-TEST_F(InterpolatedIVSolverTest, SolveWithAmericanPriceSurface) {
+TEST_F(InterpolatedIVSolverTest, SolveWithEEPSurface) {
     // Build an EEP surface (axis 0 is log-moneyness)
     PriceTableAxes<4> eep_axes;
     eep_axes.grids[0] = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};
@@ -306,8 +306,8 @@ TEST(IVSolverInterpolatedRegressionTest, RejectsOptionTypeMismatch) {
 }
 
 // Regression: InterpolatedIVSolver must reject queries with wrong dividend_yield
-// Bug: AmericanPriceSurface bakes in dividend_yield at construction; callers
-// with a different yield got wrong prices silently
+// Bug: StandardSurfaceWrapper bakes in dividend_yield at construction; callers
+// with a different yield get wrong prices silently
 TEST(IVSolverInterpolatedRegressionTest, RejectsDividendYieldMismatch) {
     // Build surface with dividend_yield = 0.02 (log-moneyness)
     std::vector<double> m_grid = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};


### PR DESCRIPTION
## Summary
- Remove `build_standard_surface` (duplicate of `make_standard_wrapper`); callers now use the canonical function which reads `dividend_yield` from surface metadata
- Move `LinearBracket` from production header to test file (zero production callers)
- Clean up stale `AmericanPriceSurface` references in comments and test names

## Test plan
- [x] 115/115 tests pass
- [x] Benchmarks compile
- [x] Python bindings compile
- [x] `grep -r build_standard_surface src/ tests/` returns zero matches
- [x] `grep -r AmericanPriceSurface src/ tests/` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)