### PR TITLE
Clean up option/table naming and organization

### DIFF
--- a/benchmarks/bspline_template_vs_hardcoded.cc
+++ b/benchmarks/bspline_template_vs_hardcoded.cc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // OBSOLETE: This benchmark compared BSpline4D (removed) vs BSplineND template.
-// BSpline4D was dead code - production now uses PriceTableSurface<4> directly.
+// BSpline4D was dead code - production now uses PriceTableSurface directly.
 // Kept for historical reference but no longer builds.
 
 #include <benchmark/benchmark.h>
@@ -66,7 +66,7 @@ struct BSplineTestData {
     }
 };
 
-// REMOVED: BSpline4D was dead code, removed in favor of PriceTableSurface<4>
+// REMOVED: BSpline4D was dead code, removed in favor of PriceTableSurface
 // void BM_BSpline4D_Eval(benchmark::State& state) {
 //     ...
 // }

--- a/benchmarks/component_performance.cc
+++ b/benchmarks/component_performance.cc
@@ -54,7 +54,7 @@ double analytic_bs_price(double S, double K, double tau, double sigma, double r,
 
 struct AnalyticSurfaceFixture {
     double K_ref;
-    std::shared_ptr<const PriceTableSurface<4>> surface;
+    std::shared_ptr<const PriceTableSurface> surface;
 };
 
 const AnalyticSurfaceFixture& GetAnalyticSurfaceFixture() {
@@ -67,16 +67,16 @@ const AnalyticSurfaceFixture& GetAnalyticSurfaceFixture() {
         std::vector<double> vol_grid = {0.10, 0.15, 0.20, 0.25, 0.30};
         std::vector<double> rate_grid = {0.0, 0.025, 0.05, 0.10};
 
-        auto result = PriceTableBuilder<4>::from_vectors(
+        auto result = PriceTableBuilder::from_vectors(
             m_grid, tau_grid, vol_grid, rate_grid, 100.0,
             GridAccuracyParams{}, OptionType::PUT, 0.0);
         if (!result) {
-            throw std::runtime_error("Failed to create PriceTableBuilder");
+            throw std::runtime_error("Failed to create PriceTableBuilderND");
         }
         auto [builder, axes] = std::move(result.value());
         EEPDecomposer decomposer{OptionType::PUT, 100.0, 0.0};
         auto table = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-            [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+            [&](PriceTensor& tensor, const PriceTableAxes& a) {
                 decomposer.decompose(tensor, a);
             });
         if (!table) {

--- a/benchmarks/grid_sweep.cc
+++ b/benchmarks/grid_sweep.cc
@@ -114,7 +114,7 @@ int main() {
 
         // Build price table (Medium PDE accuracy — sufficient for table nodes)
         auto pde_accuracy = make_grid_accuracy(GridAccuracyProfile::Medium);
-        auto builder_result = PriceTableBuilder<4>::from_vectors(
+        auto builder_result = PriceTableBuilder::from_vectors(
             estimate.grids[0], estimate.grids[1], estimate.grids[2], estimate.grids[3],
             spot, pde_accuracy, OptionType::PUT, div_yield);
 
@@ -127,7 +127,7 @@ int main() {
         EEPDecomposer decomposer{OptionType::PUT, spot, div_yield};
         auto t0 = std::chrono::steady_clock::now();
         auto table_result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-            [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+            [&](PriceTensor& tensor, const PriceTableAxes& a) {
                 decomposer.decompose(tensor, a);
             });
         auto t1 = std::chrono::steady_clock::now();

--- a/benchmarks/interpolation_greek_accuracy.cc
+++ b/benchmarks/interpolation_greek_accuracy.cc
@@ -39,7 +39,7 @@ namespace {
 
 struct EEPFixture {
     StandardSurfaceWrapper wrapper;
-    std::shared_ptr<const PriceTableSurface<4>> surface;
+    std::shared_ptr<const PriceTableSurface> surface;
     double K_ref;
     double dividend_yield;
     OptionType type;
@@ -63,16 +63,16 @@ const EEPFixture& GetEEPFixture() {
         double K_ref = 100.0;
         double q = 0.02;
 
-        auto result = PriceTableBuilder<4>::from_vectors(
+        auto result = PriceTableBuilder::from_vectors(
             m_grid, tau_grid, vol_grid, rate_grid, K_ref,
             GridAccuracyParams{}, OptionType::PUT, q);
         if (!result) {
-            throw std::runtime_error("Failed to create PriceTableBuilder");
+            throw std::runtime_error("Failed to create PriceTableBuilderND");
         }
         auto [builder, axes] = std::move(result.value());
         EEPDecomposer decomposer{OptionType::PUT, K_ref, q};
         auto table = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-            [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+            [&](PriceTensor& tensor, const PriceTableAxes& a) {
                 decomposer.decompose(tensor, a);
             });
         if (!table) {

--- a/benchmarks/iv_interpolation_profile.cc
+++ b/benchmarks/iv_interpolation_profile.cc
@@ -50,7 +50,7 @@ struct AnalyticSurfaceFixture {
     std::vector<double> tau_grid;
     std::vector<double> sigma_grid;
     std::vector<double> rate_grid;
-    std::shared_ptr<const PriceTableSurface<4>> surface;
+    std::shared_ptr<const PriceTableSurface> surface;
 };
 
 const AnalyticSurfaceFixture& GetSurface() {
@@ -104,8 +104,8 @@ const AnalyticSurfaceFixture& GetSurface() {
             throw std::runtime_error("Failed to fit B-spline surface");
         }
 
-        // Create PriceTableAxes
-        PriceTableAxes<4> axes;
+        // Create PriceTableAxesND
+        PriceTableAxes axes;
         axes.grids = {
             fixture_ptr->m_grid,
             fixture_ptr->tau_grid,
@@ -120,7 +120,7 @@ const AnalyticSurfaceFixture& GetSurface() {
         };
 
         // Create surface with coefficients directly
-        auto surface_result = PriceTableSurface<4>::build(axes, fit_result->coefficients, meta);
+        auto surface_result = PriceTableSurface::build(axes, fit_result->coefficients, meta);
         if (!surface_result.has_value()) {
             throw std::runtime_error("Failed to create surface");
         }

--- a/benchmarks/market_iv_e2e_benchmark.cc
+++ b/benchmarks/market_iv_e2e_benchmark.cc
@@ -19,7 +19,7 @@
  * ```cpp
  * // Step 1: Define option surface grid (from market data)
  * auto grid_spec = GridSpec<double>::sinh_spaced(-3.0, 3.0, 101, 2.0).value();
- * auto [builder, axes] = PriceTableBuilder<4>::from_vectors(
+ * auto [builder, axes] = PriceTableBuilder::from_vectors(
  *     {0.8, 0.9, 0.95, 1.0, 1.05, 1.1, 1.2},  // moneyness
  *     {0.1, 0.25, 0.5, 1.0, 2.0},              // maturity
  *     {0.15, 0.20, 0.25, 0.30, 0.40},          // volatility
@@ -32,7 +32,7 @@
  * // Step 2: Build price table with EEP decomposition (one-time precomputation)
  * EEPDecomposer decomposer{OptionType::PUT, K_ref, dividend};
  * auto result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
- *     [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+ *     [&](PriceTensor& tensor, const PriceTableAxes& a) {
  *         decomposer.decompose(tensor, a);
  *     });
  *
@@ -188,7 +188,7 @@ static void BM_API_BuildPriceTable(benchmark::State& state) {
         }
         auto grid_spec = grid_spec_result.value();
 
-        auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+        auto builder_axes_result = PriceTableBuilder::from_vectors(
             grid.moneyness,
             grid.maturities,
             grid.volatilities,
@@ -199,7 +199,7 @@ static void BM_API_BuildPriceTable(benchmark::State& state) {
             grid.dividend);
 
         if (!builder_axes_result) {
-            state.SkipWithError("PriceTableBuilder::from_vectors failed");
+            state.SkipWithError("PriceTableBuilderND::from_vectors failed");
             return;
         }
         auto [builder, axes] = std::move(builder_axes_result.value());
@@ -208,7 +208,7 @@ static void BM_API_BuildPriceTable(benchmark::State& state) {
         auto result = builder.build(axes);
 
         if (!result) {
-            state.SkipWithError("PriceTableBuilder::build failed");
+            state.SkipWithError("PriceTableBuilderND::build failed");
             return;
         }
 
@@ -241,7 +241,7 @@ static void BM_API_ComputeIVSurface(benchmark::State& state) {
     }
     auto grid_spec = grid_spec_result.value();
 
-    auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_axes_result = PriceTableBuilder::from_vectors(
         grid.moneyness,
         grid.maturities,
         grid.volatilities,
@@ -252,19 +252,19 @@ static void BM_API_ComputeIVSurface(benchmark::State& state) {
         grid.dividend);
 
     if (!builder_axes_result) {
-        state.SkipWithError("PriceTableBuilder::from_vectors failed");
+        state.SkipWithError("PriceTableBuilderND::from_vectors failed");
         return;
     }
     auto [builder, axes] = std::move(builder_axes_result.value());
 
     EEPDecomposer decomposer{OptionType::PUT, grid.K_ref, grid.dividend};
     auto price_table_result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer.decompose(tensor, a);
         });
 
     if (!price_table_result) {
-        state.SkipWithError("PriceTableBuilder::build failed");
+        state.SkipWithError("PriceTableBuilderND::build failed");
         return;
     }
 
@@ -360,7 +360,7 @@ static void BM_API_EndToEnd(benchmark::State& state) {
         }
         auto grid_spec = grid_spec_result.value();
 
-        auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+        auto builder_axes_result = PriceTableBuilder::from_vectors(
             grid.moneyness,
             grid.maturities,
             grid.volatilities,
@@ -371,19 +371,19 @@ static void BM_API_EndToEnd(benchmark::State& state) {
             grid.dividend);
 
         if (!builder_axes_result) {
-            state.SkipWithError("PriceTableBuilder::from_vectors failed");
+            state.SkipWithError("PriceTableBuilderND::from_vectors failed");
             return;
         }
         auto [builder, axes] = std::move(builder_axes_result.value());
 
         EEPDecomposer decomposer{OptionType::PUT, grid.K_ref, grid.dividend};
         auto price_table_result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-            [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+            [&](PriceTensor& tensor, const PriceTableAxes& a) {
                 decomposer.decompose(tensor, a);
             });
 
         if (!price_table_result) {
-            state.SkipWithError("PriceTableBuilder::build failed");
+            state.SkipWithError("PriceTableBuilderND::build failed");
             return;
         }
         auto price_table = std::move(price_table_result.value());

--- a/benchmarks/readme_benchmarks.cc
+++ b/benchmarks/readme_benchmarks.cc
@@ -83,7 +83,7 @@ double analytic_bs_price(double S, double K, double tau, double sigma, double r,
 
 struct AnalyticSurfaceFixture {
     double K_ref;
-    std::shared_ptr<const PriceTableSurface<4>> surface;
+    std::shared_ptr<const PriceTableSurface> surface;
 };
 
 const AnalyticSurfaceFixture& GetAnalyticSurfaceFixture() {
@@ -96,16 +96,16 @@ const AnalyticSurfaceFixture& GetAnalyticSurfaceFixture() {
         std::vector<double> vol_grid = {0.10, 0.15, 0.20, 0.25, 0.30};
         std::vector<double> rate_grid = {0.0, 0.025, 0.05, 0.10};
 
-        auto result = PriceTableBuilder<4>::from_vectors(
+        auto result = PriceTableBuilder::from_vectors(
             m_grid, tau_grid, vol_grid, rate_grid, 100.0,
             GridAccuracyParams{}, OptionType::PUT, 0.0);
         if (!result) {
-            throw std::runtime_error("Failed to create PriceTableBuilder");
+            throw std::runtime_error("Failed to create PriceTableBuilderND");
         }
         auto [builder, axes] = std::move(result.value());
         EEPDecomposer decomposer{OptionType::PUT, 100.0, 0.0};
         auto table = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-            [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+            [&](PriceTensor& tensor, const PriceTableAxes& a) {
                 decomposer.decompose(tensor, a);
             });
         if (!table) {

--- a/docs/PYTHON_GUIDE.md
+++ b/docs/PYTHON_GUIDE.md
@@ -227,7 +227,7 @@ workspace = mo.PriceTableWorkspace.load("spy_puts.arrow")
 | `AdaptiveGridParams` | Adaptive grid refinement parameters |
 | `MultiKRefConfig` | Multi-reference-strike configuration for segmented paths |
 | `OptionGrid` | Container for chain data (spot, strikes, maturities, vols, rates) |
-| `PriceTableSurface4D` | 4D B-spline surface with `value(m, tau, sigma, r)` and `partial(axis, ...)` |
+| `PriceTableSurface` | 4D B-spline surface with `value(m, tau, sigma, r)` and `partial(axis, ...)` |
 | `PriceTableWorkspace` | Serializable price table data (save/load Arrow IPC) |
 | `SolverError` | Error detail with `code`, `iterations`, `residual` |
 

--- a/src/option/interpolated_iv_solver.hpp
+++ b/src/option/interpolated_iv_solver.hpp
@@ -186,12 +186,12 @@ public:
     explicit AnyIVSolver(InterpolatedIVSolver<StandardSurfaceWrapper> solver);
 
     /// Constructor from segmented solver (spliced surface)
-    explicit AnyIVSolver(InterpolatedIVSolver<MultiKRefSurfaceWrapperPI> solver);
+    explicit AnyIVSolver(InterpolatedIVSolver<MultiKRefPriceWrapper> solver);
 
 private:
     using SolverVariant = std::variant<
         InterpolatedIVSolver<StandardSurfaceWrapper>,
-        InterpolatedIVSolver<MultiKRefSurfaceWrapperPI>
+        InterpolatedIVSolver<MultiKRefPriceWrapper>
     >;
     SolverVariant solver_;
 };

--- a/src/option/option_spec.hpp
+++ b/src/option/option_spec.hpp
@@ -25,7 +25,7 @@ namespace mango {
 /// Full yield curve support is available in the FDM solver (AmericanOptionSolver,
 /// IVSolver) where the time-varying rate flows through the PDE discretization.
 ///
-/// Limitation: Interpolation-based solvers (InterpolatedIVSolver, PriceTableSurface)
+/// Limitation: Interpolation-based solvers (InterpolatedIVSolver, PriceTableSurfaceND)
 /// use a scalar rate axis. When a YieldCurve is provided, it is collapsed to a
 /// zero rate: -ln(D(T))/T. This provides a reasonable flat-rate approximation
 /// but does not capture the full term structure dynamics.

--- a/src/option/table/BUILD.bazel
+++ b/src/option/table/BUILD.bazel
@@ -35,6 +35,7 @@ cc_library(
     name = "price_tensor",
     hdrs = ["price_tensor.hpp"],
     deps = [
+        ":price_table_axes",
         "//src/support:aligned_allocator",
         "//src/math:safe_math",
         "@mdspan//:mdspan",
@@ -87,6 +88,7 @@ cc_library(
     srcs = ["eep_transform.cpp"],
     hdrs = ["eep_transform.hpp"],
     deps = [
+        ":price_query",
         ":price_table_surface",
         ":price_tensor",
         ":price_table_axes",
@@ -162,6 +164,7 @@ cc_library(
     srcs = ["price_table_workspace.cpp"],
     hdrs = ["price_table_workspace.hpp"],
     deps = [
+        ":price_table_metadata",
         "//src/support:error_types",
         "//src/math:bspline_basis",
         "//src/support:crc64",
@@ -222,9 +225,18 @@ cc_library(
 )
 
 cc_library(
+    name = "price_query",
+    hdrs = ["price_query.hpp"],
+    visibility = ["//visibility:public"],
+    strip_include_prefix = "/src/option/table",
+    include_prefix = "mango/option/table",
+)
+
+cc_library(
     name = "spliced_surface",
     hdrs = ["spliced_surface.hpp"],
     deps = [
+        ":price_query",
         ":price_table_metadata",
         "//src/option:option_spec",
     ],

--- a/src/option/table/adaptive_grid_builder.hpp
+++ b/src/option/table/adaptive_grid_builder.hpp
@@ -118,8 +118,8 @@ private:
         const PDEGridSpec& pde_grid,
         OptionType type,
         size_t& build_iteration,
-        std::shared_ptr<const PriceTableSurface<4>>& last_surface,
-        PriceTableAxes<4>& last_axes);
+        std::shared_ptr<const PriceTableSurface>& last_surface,
+        PriceTableAxes& last_axes);
 };
 
 }  // namespace mango

--- a/src/option/table/adaptive_grid_types.hpp
+++ b/src/option/table/adaptive_grid_types.hpp
@@ -78,10 +78,10 @@ struct IterationStats {
 /// Final result with full diagnostics
 struct AdaptiveResult {
     /// The built price table surface
-    std::shared_ptr<const PriceTableSurface<4>> surface = nullptr;
+    std::shared_ptr<const PriceTableSurface> surface = nullptr;
 
     /// Final axes used for the surface
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
 
     /// Query price from the surface
     /// Returns NaN if no surface is available (build failure or not yet built)
@@ -109,7 +109,7 @@ struct AdaptiveResult {
 
 /// Result from adaptive segmented grid building (multi-K_ref path)
 struct SegmentedAdaptiveResult {
-    MultiKRefSurfacePI surface;
+    MultiKRefPriceSurface surface;
     IVGrid grid;  ///< The grid sizes adaptive chose
     int tau_points_per_segment;
 };

--- a/src/option/table/eep_transform.cpp
+++ b/src/option/table/eep_transform.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 #include "mango/option/table/eep_transform.hpp"
-#include "mango/option/table/spliced_surface.hpp"  // for PriceQuery
 #include "mango/option/european_option.hpp"
 #include <algorithm>
 #include <cmath>
@@ -11,7 +10,7 @@ namespace mango {
 // EEPDecomposer: build-time
 // ===========================================================================
 
-void EEPDecomposer::decompose(PriceTensor<4>& tensor, const PriceTableAxes<4>& axes) const {
+void EEPDecomposer::decompose(PriceTensor& tensor, const PriceTableAxes& axes) const {
     const size_t Nm = axes.grids[0].size();
     const size_t Nt = axes.grids[1].size();
     const size_t Nv = axes.grids[2].size();

--- a/src/option/table/eep_transform.hpp
+++ b/src/option/table/eep_transform.hpp
@@ -7,11 +7,10 @@
 #include "mango/option/option_spec.hpp"
 #include "mango/option/table/price_table_axes.hpp"
 #include "mango/option/table/price_table_surface.hpp"
+#include "mango/option/table/price_query.hpp"
 #include "mango/option/table/price_tensor.hpp"
 
 namespace mango {
-
-struct PriceQuery;  // Forward declare (defined in spliced_surface.hpp)
 
 /// Build-time helper: converts normalized American prices to EEP values.
 /// EEP = American - European, with debiased softplus floor.
@@ -25,7 +24,7 @@ struct EEPDecomposer {
     ///
     /// @param tensor In/out: tensor of normalized prices (V/K_ref), overwritten with EEP
     /// @param axes Grid axes (axis 0 = log-moneyness, 1 = tau, 2 = sigma, 3 = rate)
-    void decompose(PriceTensor<4>& tensor, const PriceTableAxes<4>& axes) const;
+    void decompose(PriceTensor& tensor, const PriceTableAxes& axes) const;
 };
 
 /// Query-time Inner adapter for EEP surfaces. Satisfies SplicedInner.
@@ -37,7 +36,7 @@ struct EEPDecomposer {
 /// Encapsulates all query-time EEP math for the SplicedSurface framework.
 class EEPPriceTableInner {
 public:
-    EEPPriceTableInner(std::shared_ptr<const PriceTableSurface<4>> surface,
+    EEPPriceTableInner(std::shared_ptr<const PriceTableSurface> surface,
                        OptionType type, double K_ref, double dividend_yield)
         : surface_(std::move(surface))
         , type_(type)
@@ -48,13 +47,13 @@ public:
     [[nodiscard]] double price(const PriceQuery& q) const;
     [[nodiscard]] double vega(const PriceQuery& q) const;
 
-    [[nodiscard]] const PriceTableSurface<4>& surface() const { return *surface_; }
+    [[nodiscard]] const PriceTableSurface& surface() const { return *surface_; }
     [[nodiscard]] double K_ref() const noexcept { return K_ref_; }
     [[nodiscard]] OptionType option_type() const noexcept { return type_; }
     [[nodiscard]] double dividend_yield() const noexcept { return dividend_yield_; }
 
 private:
-    std::shared_ptr<const PriceTableSurface<4>> surface_;
+    std::shared_ptr<const PriceTableSurface> surface_;
     OptionType type_;
     double K_ref_;
     double dividend_yield_;

--- a/src/option/table/price_query.hpp
+++ b/src/option/table/price_query.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <vector>
+
+namespace mango {
+
+/// Configuration for multi-K_ref surface construction.
+/// Used by both manual and adaptive grid builders.
+struct MultiKRefConfig {
+    std::vector<double> K_refs;   ///< explicit list; if empty, use auto selection
+    int K_ref_count = 11;         ///< used when K_refs is empty
+    double K_ref_span = 0.3;      ///< +/-span around spot for auto mode (log-spaced)
+};
+
+struct PriceQuery {
+    double spot;
+    double strike;
+    double tau;
+    double sigma;
+    double rate;
+};
+
+}  // namespace mango

--- a/src/option/table/price_table_axes.hpp
+++ b/src/option/table/price_table_axes.hpp
@@ -4,12 +4,18 @@
 #include <array>
 #include <vector>
 #include <string>
+#include <cstddef>
 #include <expected>
 #include <algorithm>
 #include "mango/support/error_types.hpp"
 #include "mango/math/safe_math.hpp"
 
 namespace mango {
+
+/// Number of B-spline interpolation axes.
+/// Currently 4: (log-moneyness, τ, σ, r).
+/// See issue #382 for planned 4D→3D reduction.
+inline constexpr size_t kPriceTableDim = 4;
 
 /// Metadata for N-dimensional price table axes
 ///
@@ -18,7 +24,7 @@ namespace mango {
 ///
 /// @tparam N Number of dimensions (axes)
 template <size_t N>
-struct PriceTableAxes {
+struct PriceTableAxesND {
     std::array<std::vector<double>, N> grids;  ///< Grid points per axis
     std::array<std::string, N> names;          ///< Optional names (e.g., "moneyness", "maturity")
 
@@ -80,5 +86,8 @@ struct PriceTableAxes {
         return s;
     }
 };
+
+/// Convenience alias for the common 4D case.
+using PriceTableAxes = PriceTableAxesND<kPriceTableDim>;
 
 } // namespace mango

--- a/src/option/table/price_table_inner.hpp
+++ b/src/option/table/price_table_inner.hpp
@@ -9,11 +9,11 @@
 
 namespace mango {
 
-/// Universal adapter wrapping PriceTableSurface<4> for SplicedInner concept.
+/// Universal adapter wrapping PriceTableSurface for SplicedInner concept.
 /// Used by segmented paths (NormalizedPrice content; no EEP reconstruction).
 class PriceTableInner {
 public:
-    explicit PriceTableInner(std::shared_ptr<const PriceTableSurface<4>> surface)
+    explicit PriceTableInner(std::shared_ptr<const PriceTableSurface> surface)
         : surface_(std::move(surface)) {}
 
     [[nodiscard]] double price(const PriceQuery& q) const {
@@ -26,10 +26,10 @@ public:
         return surface_->partial(2, {x, q.tau, q.sigma, q.rate});
     }
 
-    [[nodiscard]] const PriceTableSurface<4>& surface() const { return *surface_; }
+    [[nodiscard]] const PriceTableSurface& surface() const { return *surface_; }
 
 private:
-    std::shared_ptr<const PriceTableSurface<4>> surface_;
+    std::shared_ptr<const PriceTableSurface> surface_;
 };
 
 static_assert(SplicedInner<PriceTableInner>);

--- a/src/option/table/price_table_surface.cpp
+++ b/src/option/table/price_table_surface.cpp
@@ -7,8 +7,8 @@
 namespace mango {
 
 template <size_t N>
-PriceTableSurface<N>::PriceTableSurface(
-    PriceTableAxes<N> axes,
+PriceTableSurfaceND<N>::PriceTableSurfaceND(
+    PriceTableAxesND<N> axes,
     PriceTableMetadata metadata,
     std::unique_ptr<BSplineND<double, N>> spline)
     : axes_(std::move(axes))
@@ -16,9 +16,9 @@ PriceTableSurface<N>::PriceTableSurface(
     , spline_(std::move(spline)) {}
 
 template <size_t N>
-std::expected<std::shared_ptr<const PriceTableSurface<N>>, PriceTableError>
-PriceTableSurface<N>::build(
-    PriceTableAxes<N> axes,
+std::expected<std::shared_ptr<const PriceTableSurfaceND<N>>, PriceTableError>
+PriceTableSurfaceND<N>::build(
+    PriceTableAxesND<N> axes,
     std::vector<double> coeffs,
     PriceTableMetadata metadata)
 {
@@ -66,31 +66,31 @@ PriceTableSurface<N>::build(
 
     auto spline = std::make_unique<BSplineND<double, N>>(std::move(spline_result.value()));
 
-    auto surface = std::shared_ptr<const PriceTableSurface<N>>(
-        new PriceTableSurface<N>(std::move(axes), std::move(metadata), std::move(spline)));
+    auto surface = std::shared_ptr<const PriceTableSurfaceND<N>>(
+        new PriceTableSurfaceND<N>(std::move(axes), std::move(metadata), std::move(spline)));
 
     return surface;
 }
 
 template <size_t N>
-double PriceTableSurface<N>::value(const std::array<double, N>& coords) const {
+double PriceTableSurfaceND<N>::value(const std::array<double, N>& coords) const {
     return spline_->eval(coords);
 }
 
 template <size_t N>
-double PriceTableSurface<N>::partial(size_t axis, const std::array<double, N>& coords) const {
+double PriceTableSurfaceND<N>::partial(size_t axis, const std::array<double, N>& coords) const {
     return spline_->eval_partial(axis, coords);
 }
 
 template <size_t N>
-double PriceTableSurface<N>::second_partial(size_t axis, const std::array<double, N>& coords) const {
+double PriceTableSurfaceND<N>::second_partial(size_t axis, const std::array<double, N>& coords) const {
     return spline_->eval_second_partial(axis, coords);
 }
 
 // Explicit template instantiations
-template class PriceTableSurface<2>;
-template class PriceTableSurface<3>;
-template class PriceTableSurface<4>;
-template class PriceTableSurface<5>;
+template class PriceTableSurfaceND<2>;
+template class PriceTableSurfaceND<3>;
+template class PriceTableSurfaceND<4>;
+template class PriceTableSurfaceND<5>;
 
 } // namespace mango

--- a/src/option/table/price_table_surface.hpp
+++ b/src/option/table/price_table_surface.hpp
@@ -17,7 +17,7 @@ namespace mango {
 ///
 /// @tparam N Number of dimensions
 template <size_t N>
-class PriceTableSurface {
+class PriceTableSurfaceND {
 public:
     /// Build surface from axes, coefficients, and metadata
     ///
@@ -25,11 +25,11 @@ public:
     /// @param coeffs Flattened B-spline coefficients (row-major)
     /// @param metadata Reference strike, dividends, etc.
     /// @return Shared pointer to surface or error
-    [[nodiscard]] static std::expected<std::shared_ptr<const PriceTableSurface<N>>, PriceTableError>
-    build(PriceTableAxes<N> axes, std::vector<double> coeffs, PriceTableMetadata metadata);
+    [[nodiscard]] static std::expected<std::shared_ptr<const PriceTableSurfaceND<N>>, PriceTableError>
+    build(PriceTableAxesND<N> axes, std::vector<double> coeffs, PriceTableMetadata metadata);
 
     /// Access axes
-    [[nodiscard]] const PriceTableAxes<N>& axes() const noexcept { return axes_; }
+    [[nodiscard]] const PriceTableAxesND<N>& axes() const noexcept { return axes_; }
 
     /// Access metadata
     [[nodiscard]] const PriceTableMetadata& metadata() const noexcept { return meta_; }
@@ -58,12 +58,15 @@ public:
     [[nodiscard]] double second_partial(size_t axis, const std::array<double, N>& coords) const;
 
 private:
-    PriceTableSurface(PriceTableAxes<N> axes, PriceTableMetadata metadata,
+    PriceTableSurfaceND(PriceTableAxesND<N> axes, PriceTableMetadata metadata,
                      std::unique_ptr<BSplineND<double, N>> spline);
 
-    PriceTableAxes<N> axes_;
+    PriceTableAxesND<N> axes_;
     PriceTableMetadata meta_;
     std::unique_ptr<BSplineND<double, N>> spline_;
 };
+
+/// Convenience alias for the common 4D case.
+using PriceTableSurface = PriceTableSurfaceND<kPriceTableDim>;
 
 } // namespace mango

--- a/src/option/table/price_table_workspace.cpp
+++ b/src/option/table/price_table_workspace.cpp
@@ -233,7 +233,7 @@ std::expected<PriceTableWorkspace, std::string> PriceTableWorkspace::create(
     double dividend_yield,
     double m_min,
     double m_max,
-    uint8_t surface_content)
+    SurfaceContent surface_content)
 {
     // Validate inputs first
     auto validation = validate_inputs(log_m_grid, tau_grid, sigma_grid, r_grid, coefficients);

--- a/src/option/table/price_table_workspace.hpp
+++ b/src/option/table/price_table_workspace.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <expected>
+#include "mango/option/table/price_table_metadata.hpp"
 #include "mango/support/error_types.hpp"
 #include "mango/math/bspline_basis.hpp"
 #include <experimental/mdspan>
@@ -14,7 +15,7 @@
 
 namespace mango {
 
-/// Workspace holding all data for PriceTableSurface in single contiguous allocation
+/// Workspace holding all data for PriceTableSurfaceND in single contiguous allocation
 ///
 /// Enables zero-copy mmap loading from Arrow IPC files. All numeric data is
 /// 64-byte aligned for AVX-512 SIMD operations.
@@ -55,7 +56,7 @@ public:
         double dividend_yield,
         double m_min,
         double m_max,
-        uint8_t surface_content = 0);
+        SurfaceContent surface_content = SurfaceContent::NormalizedPrice);
 
     /// Grid accessors (zero-copy spans into arena)
     /// Note: log_moneyness() returns ln(S/K), use m_min()/m_max() for original bounds
@@ -93,7 +94,7 @@ public:
     /// Metadata accessors
     double K_ref() const { return K_ref_; }
     double dividend_yield() const { return dividend_yield_; }
-    uint8_t surface_content() const { return surface_content_; }
+    SurfaceContent surface_content() const { return surface_content_; }
 
     /// Grid dimensions
     std::tuple<size_t, size_t, size_t, size_t> dimensions() const {
@@ -193,7 +194,7 @@ private:
     double dividend_yield_ = 0.0;
     double m_min_ = 0.0;  // Log-moneyness bounds ln(S/K)
     double m_max_ = 0.0;
-    uint8_t surface_content_ = 0;  // 0 = NormalizedPrice (default)
+    SurfaceContent surface_content_ = SurfaceContent::NormalizedPrice;
 };
 
 }  // namespace mango

--- a/src/option/table/recursion_helpers.hpp
+++ b/src/option/table/recursion_helpers.hpp
@@ -17,7 +17,7 @@ namespace mango {
 /// @tparam Func Callable accepting std::array<size_t, N>
 template <size_t Axis, size_t N, typename Func>
 void for_each_axis_index_impl(
-    const PriceTableAxes<N>& axes,
+    const PriceTableAxesND<N>& axes,
     std::array<size_t, N>& indices,
     Func&& func)
 {
@@ -39,7 +39,7 @@ void for_each_axis_index_impl(
 /// @tparam N Number of dimensions
 /// @tparam Func Callable accepting std::array<size_t, N>
 template <size_t StartAxis, size_t N, typename Func>
-void for_each_axis_index(const PriceTableAxes<N>& axes, Func&& func) {
+void for_each_axis_index(const PriceTableAxesND<N>& axes, Func&& func) {
     std::array<size_t, N> indices{};
     for_each_axis_index_impl<StartAxis>(axes, indices, std::forward<Func>(func));
 }

--- a/src/option/table/segmented_price_table_builder.hpp
+++ b/src/option/table/segmented_price_table_builder.hpp
@@ -55,7 +55,7 @@ public:
     ///   3. Build last segment (closest to expiry) with payoff IC.
     ///   4. Build earlier segments backward with chained IC.
     ///   5. Assemble into SegmentedSurface.
-    static std::expected<SegmentedSurfacePI, PriceTableError> build(const Config& config);
+    static std::expected<SegmentedPriceSurface, PriceTableError> build(const Config& config);
 };
 
 }  // namespace mango

--- a/src/option/table/spliced_surface.hpp
+++ b/src/option/table/spliced_surface.hpp
@@ -10,24 +10,9 @@
 #include <vector>
 
 #include "mango/option/option_spec.hpp"
+#include "mango/option/table/price_query.hpp"
 
 namespace mango {
-
-/// Configuration for multi-K_ref surface construction.
-/// Used by both manual and adaptive grid builders.
-struct MultiKRefConfig {
-    std::vector<double> K_refs;   ///< explicit list; if empty, use auto selection
-    int K_ref_count = 11;         ///< used when K_refs is empty
-    double K_ref_span = 0.3;      ///< +/-span around spot for auto mode (log-spaced)
-};
-
-struct PriceQuery {
-    double spot;
-    double strike;
-    double tau;
-    double sigma;
-    double rate;
-};
 
 struct SliceWeight {
     size_t index;

--- a/src/option/table/spliced_surface_builder.cpp
+++ b/src/option/table/spliced_surface_builder.cpp
@@ -10,7 +10,7 @@ namespace mango {
 // Segmented surface builder
 // ===========================================================================
 
-std::expected<SegmentedSurfacePI, PriceTableError>
+std::expected<SegmentedPriceSurface, PriceTableError>
 build_segmented_surface(SegmentedConfig config) {
     // Validate: non-empty segments
     if (config.segments.empty()) {
@@ -52,7 +52,7 @@ build_segmented_surface(SegmentedConfig config) {
 
     WeightedSum combiner;
 
-    return SegmentedSurfacePI(
+    return SegmentedPriceSurface(
         std::move(slices),
         std::move(lookup),
         std::move(xform),
@@ -63,7 +63,7 @@ build_segmented_surface(SegmentedConfig config) {
 // Multi-K_ref surface builder
 // ===========================================================================
 
-std::expected<MultiKRefSurfacePI, PriceTableError>
+std::expected<MultiKRefPriceSurface, PriceTableError>
 build_multi_kref_surface(std::vector<MultiKRefEntry> entries) {
     // Validate: non-empty
     if (entries.empty()) {
@@ -79,7 +79,7 @@ build_multi_kref_surface(std::vector<MultiKRefEntry> entries) {
 
     // Extract k_refs vector and slices
     std::vector<double> k_refs;
-    std::vector<SegmentedSurfacePI> slices;
+    std::vector<SegmentedPriceSurface> slices;
     k_refs.reserve(entries.size());
     slices.reserve(entries.size());
 
@@ -96,7 +96,7 @@ build_multi_kref_surface(std::vector<MultiKRefEntry> entries) {
 
     WeightedSum combiner;
 
-    return MultiKRefSurfacePI(
+    return MultiKRefPriceSurface(
         std::move(slices),
         std::move(bracket),
         std::move(xform),

--- a/src/option/table/spliced_surface_builder.hpp
+++ b/src/option/table/spliced_surface_builder.hpp
@@ -9,14 +9,12 @@
 
 namespace mango {
 
-template <size_t N> class PriceTableSurface;
-
 // ===========================================================================
 // Segmented surface builder
 // ===========================================================================
 
 struct SegmentConfig {
-    std::shared_ptr<const PriceTableSurface<4>> surface;
+    std::shared_ptr<const PriceTableSurface> surface;
     double tau_start;
     double tau_end;
 };
@@ -26,7 +24,7 @@ struct SegmentedConfig {
     double K_ref;
 };
 
-[[nodiscard]] std::expected<SegmentedSurfacePI, PriceTableError>
+[[nodiscard]] std::expected<SegmentedPriceSurface, PriceTableError>
 build_segmented_surface(SegmentedConfig config);
 
 // ===========================================================================
@@ -35,10 +33,10 @@ build_segmented_surface(SegmentedConfig config);
 
 struct MultiKRefEntry {
     double K_ref;
-    SegmentedSurfacePI surface;
+    SegmentedPriceSurface surface;
 };
 
-[[nodiscard]] std::expected<MultiKRefSurfacePI, PriceTableError>
+[[nodiscard]] std::expected<MultiKRefPriceSurface, PriceTableError>
 build_multi_kref_surface(std::vector<MultiKRefEntry> entries);
 
 }  // namespace mango

--- a/src/option/table/standard_surface.cpp
+++ b/src/option/table/standard_surface.cpp
@@ -5,7 +5,7 @@ namespace mango {
 
 std::expected<StandardSurfaceWrapper, std::string>
 make_standard_wrapper(
-    std::shared_ptr<const PriceTableSurface<4>> surface,
+    std::shared_ptr<const PriceTableSurface> surface,
     OptionType type)
 {
     if (!surface) {

--- a/src/option/table/standard_surface.hpp
+++ b/src/option/table/standard_surface.hpp
@@ -18,16 +18,16 @@ using StandardSurface = SplicedSurface<EEPPriceTableInner, SingleBracket, Identi
 using StandardSurfaceWrapper = SplicedSurfaceWrapper<StandardSurface>;
 
 /// Segmented surface types using PriceTableInner (NormalizedPrice content)
-using SegmentedSurfacePI = SegmentedSurface<PriceTableInner>;
-using MultiKRefSurfacePI = MultiKRefSurface<SegmentedSurfacePI>;
-using MultiKRefSurfaceWrapperPI = SplicedSurfaceWrapper<MultiKRefSurfacePI>;
+using SegmentedPriceSurface = SegmentedSurface<PriceTableInner>;
+using MultiKRefPriceSurface = MultiKRefSurface<SegmentedPriceSurface>;
+using MultiKRefPriceWrapper = SplicedSurfaceWrapper<MultiKRefPriceSurface>;
 
 /// Create a StandardSurfaceWrapper from a pre-built EEP surface.
 /// Reads K_ref and dividend_yield from surface metadata.
 /// Requires SurfaceContent::EarlyExercisePremium; rejects NormalizedPrice.
 [[nodiscard]] std::expected<StandardSurfaceWrapper, std::string>
 make_standard_wrapper(
-    std::shared_ptr<const PriceTableSurface<4>> surface,
+    std::shared_ptr<const PriceTableSurface> surface,
     OptionType type);
 
 }  // namespace mango

--- a/tests/eep_integration_test.cc
+++ b/tests/eep_integration_test.cc
@@ -32,7 +32,7 @@ TEST(EEPIntegrationTest, ReconstructedPriceMatchesPDE) {
     double K_ref = 100.0;
 
     // Build with auto-estimated PDE grid, then apply EEP decomposition
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, vol, rate, K_ref,
         GridAccuracyParams{},   // auto-estimate PDE grid
         OptionType::PUT,
@@ -45,7 +45,7 @@ TEST(EEPIntegrationTest, ReconstructedPriceMatchesPDE) {
     auto& [builder, axes] = *setup;
     EEPDecomposer decomposer{OptionType::PUT, K_ref, 0.0};
     auto result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer.decompose(tensor, a);
         });
     ASSERT_TRUE(result.has_value())
@@ -112,7 +112,7 @@ TEST(EEPIntegrationTest, SoftplusFloorEnsuresNonNegative) {
 
     double K_ref = 100.0;
 
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, vol, rate, K_ref,
         GridAccuracyParams{},
         OptionType::PUT,
@@ -125,7 +125,7 @@ TEST(EEPIntegrationTest, SoftplusFloorEnsuresNonNegative) {
     auto& [builder, axes] = *setup;
     EEPDecomposer decomposer{OptionType::PUT, K_ref, 0.0};
     auto result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer.decompose(tensor, a);
         });
     ASSERT_TRUE(result.has_value())
@@ -180,7 +180,7 @@ TEST(EEPIntegrationTest, MakeStandardWrapperRejectsNormalizedPrice) {
 
     double K_ref = 100.0;
 
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, vol, rate, K_ref,
         GridAccuracyParams{},
         OptionType::PUT,

--- a/tests/interpolated_iv_solver_test.cc
+++ b/tests/interpolated_iv_solver_test.cc
@@ -26,14 +26,14 @@ protected:
         std::vector<double> vol_grid = {0.10, 0.20, 0.30, 0.40};
         std::vector<double> rate_grid = {0.02, 0.04, 0.06, 0.08};
 
-        auto result = PriceTableBuilder<4>::from_vectors(
+        auto result = PriceTableBuilder::from_vectors(
             m_grid, tau_grid, vol_grid, rate_grid, K_ref_,
             GridAccuracyParams{}, OptionType::PUT, 0.0);
         ASSERT_TRUE(result.has_value()) << "Failed to build";
         auto [builder, axes] = std::move(result.value());
         EEPDecomposer decomposer{OptionType::PUT, K_ref_, 0.0};
         auto table = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-            [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+            [&](PriceTensor& tensor, const PriceTableAxes& a) {
                 decomposer.decompose(tensor, a);
             });
         ASSERT_TRUE(table.has_value()) << "Failed to build table";
@@ -46,7 +46,7 @@ protected:
         return std::move(*result);
     }
 
-    std::shared_ptr<const PriceTableSurface<4>> surface_;
+    std::shared_ptr<const PriceTableSurface> surface_;
     static constexpr double K_ref_ = 100.0;
 };
 
@@ -218,7 +218,7 @@ TEST_F(InterpolatedIVSolverTest, ConvergenceWithinIterations) {
 
 TEST_F(InterpolatedIVSolverTest, SolveWithEEPSurface) {
     // Build an EEP surface (axis 0 is log-moneyness)
-    PriceTableAxes<4> eep_axes;
+    PriceTableAxes eep_axes;
     eep_axes.grids[0] = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};
     eep_axes.grids[1] = {0.25, 0.5, 1.0, 2.0};
     eep_axes.grids[2] = {0.10, 0.20, 0.30, 0.40};
@@ -232,7 +232,7 @@ TEST_F(InterpolatedIVSolverTest, SolveWithEEPSurface) {
         .content = SurfaceContent::EarlyExercisePremium,
     };
 
-    auto eep_surface = PriceTableSurface<4>::build(eep_axes, eep_coeffs, eep_meta);
+    auto eep_surface = PriceTableSurface::build(eep_axes, eep_coeffs, eep_meta);
     ASSERT_TRUE(eep_surface.has_value());
 
     auto wrapper_result = make_standard_wrapper(eep_surface.value(), OptionType::PUT);
@@ -277,14 +277,14 @@ TEST(IVSolverInterpolatedRegressionTest, RejectsOptionTypeMismatch) {
     std::vector<double> rate_grid = {0.02, 0.04, 0.06, 0.08};
     constexpr double K_ref = 100.0;
 
-    auto result = PriceTableBuilder<4>::from_vectors(
+    auto result = PriceTableBuilder::from_vectors(
         m_grid, tau_grid, vol_grid, rate_grid, K_ref,
         GridAccuracyParams{}, OptionType::PUT, 0.0);
     ASSERT_TRUE(result.has_value());
     auto [builder, axes] = std::move(result.value());
     EEPDecomposer decomposer{OptionType::PUT, K_ref, 0.0};
     auto table = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer.decompose(tensor, a);
         });
     ASSERT_TRUE(table.has_value());
@@ -317,14 +317,14 @@ TEST(IVSolverInterpolatedRegressionTest, RejectsDividendYieldMismatch) {
     constexpr double K_ref = 100.0;
     constexpr double div_yield = 0.02;
 
-    auto result = PriceTableBuilder<4>::from_vectors(
+    auto result = PriceTableBuilder::from_vectors(
         m_grid, tau_grid, vol_grid, rate_grid, K_ref,
         GridAccuracyParams{}, OptionType::PUT, div_yield);
     ASSERT_TRUE(result.has_value());
     auto [builder, axes] = std::move(result.value());
     EEPDecomposer decomposer2{OptionType::PUT, K_ref, div_yield};
     auto table = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer2.decompose(tensor, a);
         });
     ASSERT_TRUE(table.has_value());

--- a/tests/price_table_4d_integration_test.cc
+++ b/tests/price_table_4d_integration_test.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 /**
  * @file price_table_4d_integration_test.cc
- * @brief Integration tests for PriceTableBuilder<4> with routing
+ * @brief Integration tests for PriceTableBuilder with routing
  */
 
 #include "mango/option/table/price_table_builder.hpp"
@@ -19,7 +19,7 @@ TEST(PriceTable4DIntegrationTest, FastPathEligible) {
     ASSERT_TRUE(grid_spec_result.has_value());
     auto grid_spec = grid_spec_result.value();
 
-    auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_axes_result = PriceTableBuilder::from_vectors(
         {std::log(0.9), std::log(0.95), std::log(1.0), std::log(1.05), std::log(1.1)},  // Log-moneyness (5 points)
         {0.25, 0.5, 1.0, 2.0},           // Maturity (4 points)
         {0.15, 0.20, 0.25, 0.30},        // Volatility (4 points)
@@ -51,7 +51,7 @@ TEST(PriceTable4DIntegrationTest, FallbackWideRange) {
     ASSERT_TRUE(grid_spec_result.has_value());
     auto grid_spec = grid_spec_result.value();
 
-    auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_axes_result = PriceTableBuilder::from_vectors(
         {std::log(0.5), std::log(0.7), std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.3), std::log(1.5)},  // Wide range (7 points)
         {0.25, 0.5, 1.0, 2.0},                // Maturity (4 points)
         {0.15, 0.20, 0.25, 0.30},             // Volatility (4 points)
@@ -87,7 +87,7 @@ TEST(PriceTable4DIntegrationTest, FastPathVsFallbackConsistency) {
     ASSERT_TRUE(grid_spec_fast_result.has_value());
     auto grid_spec_fast = grid_spec_fast_result.value();
 
-    auto builder_fast_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_fast_result = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate, 100.0,
         PDEGridConfig{grid_spec_fast, 1000}, OptionType::PUT, 0.02, 0.0);
     ASSERT_TRUE(builder_fast_result.has_value()) << "Failed to create builder: " << builder_fast_result.error();
@@ -99,7 +99,7 @@ TEST(PriceTable4DIntegrationTest, FastPathVsFallbackConsistency) {
     ASSERT_TRUE(grid_spec_fallback_result.has_value());
     auto grid_spec_fallback = grid_spec_fallback_result.value();
 
-    auto builder_fallback_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_fallback_result = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate, 100.0,
         PDEGridConfig{grid_spec_fallback, 1000}, OptionType::PUT, 0.02, 0.0);
     ASSERT_TRUE(builder_fallback_result.has_value()) << "Failed to create builder: " << builder_fallback_result.error();
@@ -152,7 +152,7 @@ TEST(PriceTable4DIntegrationTest, FastPathVsFallbackNormalizedPriceEquivalence) 
     ASSERT_TRUE(grid_spec_fast_result.has_value());
     auto grid_spec_fast = grid_spec_fast_result.value();
 
-    auto builder_fast_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_fast_result = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate, 100.0,
         PDEGridConfig{grid_spec_fast, 1000}, OptionType::PUT, 0.02, 0.0);
     ASSERT_TRUE(builder_fast_result.has_value()) << "Failed to create builder: " << builder_fast_result.error();
@@ -164,7 +164,7 @@ TEST(PriceTable4DIntegrationTest, FastPathVsFallbackNormalizedPriceEquivalence) 
     ASSERT_TRUE(grid_spec_fallback_result.has_value());
     auto grid_spec_fallback = grid_spec_fallback_result.value();
 
-    auto builder_fallback_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_fallback_result = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate, 100.0,
         PDEGridConfig{grid_spec_fallback, 1000}, OptionType::PUT, 0.02, 0.0);
     ASSERT_TRUE(builder_fallback_result.has_value()) << "Failed to create builder: " << builder_fallback_result.error();
@@ -235,7 +235,7 @@ TEST(PriceTable4DIntegrationTest, PerformanceFastPath) {
     ASSERT_TRUE(grid_spec_result.has_value());
     auto grid_spec = grid_spec_result.value();
 
-    auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_axes_result = PriceTableBuilder::from_vectors(
         {std::log(0.8), std::log(0.85), std::log(0.9), std::log(0.95), std::log(1.0), std::log(1.05), std::log(1.1), std::log(1.15), std::log(1.2)},  // 9 points
         {0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0},              // 7 points
         {0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40},         // 7 points
@@ -264,16 +264,16 @@ TEST(PriceTable4DIntegrationTest, PerformanceFastPath) {
     EXPECT_LT(duration_sec, 60.0);  // Complete within 1 minute
 }
 
-TEST(PriceTableSurface, ConstructsFromAxes) {
+TEST(PriceTableSurfaceND, ConstructsFromAxes) {
     std::vector<double> m = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1)};
     std::vector<double> tau = {0.1, 0.5, 1.0, 2.0};
     std::vector<double> sigma = {0.15, 0.20, 0.25, 0.30};
     std::vector<double> r = {0.02, 0.03, 0.04, 0.05};
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids = {m, tau, sigma, r};
 
-    PriceTensor<4> tensor(axes);
+    PriceTensor tensor(axes);
     // Fill with test data
     for (size_t i = 0; i < tensor.data().size(); ++i) {
         tensor.data()[i] = 10.0;
@@ -284,7 +284,7 @@ TEST(PriceTableSurface, ConstructsFromAxes) {
         .dividends = {.dividend_yield = 0.015},
     };
 
-    auto surface = PriceTableSurface<4>::create(axes, std::move(tensor), meta);
+    auto surface = PriceTableSurface::create(axes, std::move(tensor), meta);
     ASSERT_TRUE(surface.has_value());
 
     EXPECT_DOUBLE_EQ(surface->metadata().K_ref, 100.0);

--- a/tests/price_table_axes_test.cc
+++ b/tests/price_table_axes_test.cc
@@ -7,7 +7,7 @@ namespace mango {
 namespace {
 
 TEST(PriceTableAxesTest, Create4DAxes) {
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.7), std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2), std::log(1.3)};
     axes.grids[1] = {0.027, 0.1, 0.5, 1.0, 2.0};
     axes.grids[2] = {0.10, 0.20, 0.30};
@@ -23,7 +23,7 @@ TEST(PriceTableAxesTest, Create4DAxes) {
 }
 
 TEST(PriceTableAxesTest, TotalGridPoints) {
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.7), std::log(0.8), std::log(0.9), std::log(1.0)};  // 4 points
     axes.grids[1] = {0.1, 0.5};            // 2 points
     axes.grids[2] = {0.10, 0.20, 0.30};    // 3 points
@@ -34,7 +34,7 @@ TEST(PriceTableAxesTest, TotalGridPoints) {
 }
 
 TEST(PriceTableAxesTest, ValidateMonotonic) {
-    PriceTableAxes<2> axes;
+    PriceTableAxesND<2> axes;
     axes.grids[0] = {1.0, 2.0, 3.0};
     axes.grids[1] = {0.1, 0.2, 0.3};
 
@@ -43,7 +43,7 @@ TEST(PriceTableAxesTest, ValidateMonotonic) {
 }
 
 TEST(PriceTableAxesTest, RejectNonMonotonic) {
-    PriceTableAxes<2> axes;
+    PriceTableAxesND<2> axes;
     axes.grids[0] = {1.0, 3.0, 2.0};  // Non-monotonic
     axes.grids[1] = {0.1, 0.2, 0.3};
 
@@ -53,7 +53,7 @@ TEST(PriceTableAxesTest, RejectNonMonotonic) {
 }
 
 TEST(PriceTableAxesTest, RejectEmptyGrid) {
-    PriceTableAxes<2> axes;
+    PriceTableAxesND<2> axes;
     axes.grids[0] = {1.0, 2.0, 3.0};
     axes.grids[1] = {};  // Empty grid
 

--- a/tests/price_table_builder_custom_grid_advanced_test.cc
+++ b/tests/price_table_builder_custom_grid_advanced_test.cc
@@ -21,9 +21,9 @@ TEST(PriceTableBuilderCustomGridAdvancedTest, NormalizedChainWithCustomGrid) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
     axes.grids[2] = {0.20, 0.25};
@@ -90,10 +90,10 @@ TEST(PriceTableBuilderCustomGridAdvancedTest, EdgeCaseLogMoneyness) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
     // Include moneyness = 1.0 (ATM point, log(1.0) = 0.0)
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.95), std::log(1.0), std::log(1.05), std::log(1.10)};  // Includes exact ATM (log(1.0)=0.0)
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
     axes.grids[2] = {0.20};
@@ -163,9 +163,9 @@ TEST(PriceTableBuilderCustomGridAdvancedTest, SimulatePlanModification) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1)};
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
     axes.grids[2] = {0.15, 0.20, 0.25, 0.30};

--- a/tests/price_table_builder_custom_grid_diagnosis_test.cc
+++ b/tests/price_table_builder_custom_grid_diagnosis_test.cc
@@ -20,9 +20,9 @@ TEST(PriceTableBuilderCustomGridDiagnosisTest, ReproduceFailure) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0)};
     axes.grids[1] = {0.1, 0.5, 1.0};  // 3 maturity points
     axes.grids[2] = {0.20};           // 1 vol

--- a/tests/price_table_builder_custom_grid_test.cc
+++ b/tests/price_table_builder_custom_grid_test.cc
@@ -21,9 +21,9 @@ TEST(PriceTableBuilderCustomGridTest, CustomGridWithNormalizedCase) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};  // log-moneyness: 4 points
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};   // maturity: 4 points
     axes.grids[2] = {0.20, 0.25};             // volatility: 2 points
@@ -124,9 +124,9 @@ TEST(PriceTableBuilderCustomGridTest, VerifyNormalizedBatchConditions) {
         .pde_grid = PDEGridConfig{GridSpec<double>::uniform(-3.0, 3.0, 101).value(), 100}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
     axes.grids[2] = {0.20};
@@ -184,7 +184,7 @@ TEST(PriceTableBuilderCustomGridTest, AutoGridCoversWideMoneyness) {
     GridAccuracyParams accuracy;
     accuracy.tol = 1e-2;  // Fast mode for test speed
 
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate,
         100.0,                    // K_ref
         accuracy,                 // auto-estimated PDE grid
@@ -236,7 +236,7 @@ TEST(PriceTableBuilderCustomGridTest, AutoGridAccuracyParamsDriveGridChoice) {
     coarse.min_spatial_points = 51;
     coarse.max_spatial_points = 51;
 
-    auto setup_coarse = PriceTableBuilder<4>::from_vectors(
+    auto setup_coarse = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate,
         100.0, coarse, OptionType::PUT, 0.02, 0.0);
 
@@ -251,7 +251,7 @@ TEST(PriceTableBuilderCustomGridTest, AutoGridAccuracyParamsDriveGridChoice) {
     fine.min_spatial_points = 401;
     fine.max_spatial_points = 401;
 
-    auto setup_fine = PriceTableBuilder<4>::from_vectors(
+    auto setup_fine = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate,
         100.0, fine, OptionType::PUT, 0.02, 0.0);
 
@@ -298,7 +298,7 @@ TEST(PriceTableBuilderCustomGridTest, ExplicitGridFallbackCoversWideMoneyness) {
     std::vector<double> volatility = {0.10, 0.12, 0.14, 0.15};
     std::vector<double> rate = {0.03, 0.04, 0.05, 0.06};
 
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         log_moneyness, maturity, volatility, rate,
         100.0,
         explicit_pde,             // triggers fallback due to coarse spacing

--- a/tests/price_table_builder_factories_test.cc
+++ b/tests/price_table_builder_factories_test.cc
@@ -12,7 +12,7 @@ TEST(PriceTableFactoriesTest, FromVectorsCreatesBuilderAndAxes) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_vectors(
+    auto result = mango::PriceTableBuilder::from_vectors(
         log_moneyness, maturity, vol, rate,
         100.0,      // K_ref
         mango::PDEGridConfig{grid_spec, 100},
@@ -36,7 +36,7 @@ TEST(PriceTableFactoriesTest, FromVectorsSortsAndDedupes) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_vectors(
+    auto result = mango::PriceTableBuilder::from_vectors(
         log_moneyness, maturity, vol, rate,
         100.0, mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
@@ -83,7 +83,7 @@ TEST_P(FromVectorsRejectsNonPositive, ReturnsNonPositiveValueError) {
     }
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
-    auto result = mango::PriceTableBuilder<4>::from_vectors(
+    auto result = mango::PriceTableBuilder::from_vectors(
         log_moneyness, maturity, vol, rate,
         kref, mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
@@ -114,7 +114,7 @@ TEST(PriceTableFactoriesTest, FromVectorsAcceptsNegativeRates) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_vectors(
+    auto result = mango::PriceTableBuilder::from_vectors(
         log_moneyness, maturity, vol, rate,
         100.0, mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
@@ -131,7 +131,7 @@ TEST(PriceTableFactoriesTest, FromStrikesComputesLogMoneyness) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_strikes(
+    auto result = mango::PriceTableBuilder::from_strikes(
         spot, strikes, maturities, vols, rates,
         mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
@@ -159,7 +159,7 @@ TEST(PriceTableFactoriesTest, FromStrikesRejectsNegativeSpot) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_strikes(
+    auto result = mango::PriceTableBuilder::from_strikes(
         spot, strikes, maturities, vols, rates,
         mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
@@ -177,7 +177,7 @@ TEST(PriceTableFactoriesTest, FromStrikesRejectsNegativeStrikes) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_strikes(
+    auto result = mango::PriceTableBuilder::from_strikes(
         spot, strikes, maturities, vols, rates,
         mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
@@ -198,7 +198,7 @@ TEST(PriceTableFactoriesTest, FromChainExtractsFields) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_grid(
+    auto result = mango::PriceTableBuilder::from_grid(
         chain, mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
 
@@ -223,7 +223,7 @@ TEST(PriceTableFactoriesTest, FromChainUsesDividendYield) {
 
     auto grid_spec = mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value();
 
-    auto result = mango::PriceTableBuilder<4>::from_grid(
+    auto result = mango::PriceTableBuilder::from_grid(
         chain, mango::PDEGridConfig{grid_spec, 100}, mango::OptionType::PUT
     );
 

--- a/tests/price_table_builder_grid_test.cc
+++ b/tests/price_table_builder_grid_test.cc
@@ -7,7 +7,7 @@
 
 TEST(PriceTableBuilderGridTest, RespectsUserGridBounds) {
     // Create axes with specific log-moneyness range
-    mango::PriceTableAxes<4> axes;
+    mango::PriceTableAxes axes;
     axes.grids[0] = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};  // log-moneyness
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
     axes.grids[2] = {0.15, 0.20, 0.25, 0.30};
@@ -21,7 +21,7 @@ TEST(PriceTableBuilderGridTest, RespectsUserGridBounds) {
     config.K_ref = 100.0;
     config.pde_grid = mango::PDEGridConfig{mango::GridSpec<double>::uniform(-0.5, 0.5, 51).value(), 100};
 
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
     auto result = builder.build(axes);
 
     // Should succeed because grid bounds cover moneyness range
@@ -30,7 +30,7 @@ TEST(PriceTableBuilderGridTest, RespectsUserGridBounds) {
 }
 
 TEST(PriceTableBuilderGridTest, RejectsInsufficientGridBounds) {
-    mango::PriceTableAxes<4> axes;
+    mango::PriceTableAxes axes;
     axes.grids[0] = {std::log(0.5), std::log(0.75), std::log(1.0), std::log(1.5), std::log(2.0)};  // Wide log-moneyness range
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
     axes.grids[2] = {0.15, 0.20, 0.25, 0.30};
@@ -44,7 +44,7 @@ TEST(PriceTableBuilderGridTest, RejectsInsufficientGridBounds) {
     config.K_ref = 100.0;
     config.pde_grid = mango::PDEGridConfig{mango::GridSpec<double>::uniform(-0.1, 0.1, 51).value(), 100};
 
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
     auto result = builder.build(axes);
 
     // Should fail validation because grid bounds don't cover moneyness range

--- a/tests/price_table_builder_raw_price_test.cc
+++ b/tests/price_table_builder_raw_price_test.cc
@@ -12,7 +12,7 @@ TEST(PriceTableBuilderTest, DefaultBuildProducesNormalizedPrice) {
     std::vector<double> vol_grid = {0.15, 0.20, 0.30, 0.40};
     std::vector<double> rate_grid = {0.02, 0.03, 0.04, 0.05};
 
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         m_grid, tau_grid, vol_grid, rate_grid, 100.0,
         GridAccuracyParams{}, OptionType::PUT);
     ASSERT_TRUE(setup.has_value());
@@ -31,7 +31,7 @@ TEST(PriceTableBuilderTest, BuildWithEEPTransform) {
     std::vector<double> vol_grid = {0.15, 0.20, 0.30, 0.40};
     std::vector<double> rate_grid = {0.02, 0.03, 0.04, 0.05};
 
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         m_grid, tau_grid, vol_grid, rate_grid, 100.0,
         GridAccuracyParams{}, OptionType::PUT);
     ASSERT_TRUE(setup.has_value());
@@ -40,7 +40,7 @@ TEST(PriceTableBuilderTest, BuildWithEEPTransform) {
     // Build with EEP decomposition
     EEPDecomposer decomposer{OptionType::PUT, 100.0, 0.0};
     auto result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer.decompose(tensor, a);
         });
     ASSERT_TRUE(result.has_value());

--- a/tests/price_table_builder_result_test.cc
+++ b/tests/price_table_builder_result_test.cc
@@ -7,7 +7,7 @@
 
 TEST(PriceTableBuilderResultTest, BuildReturnsDiagnostics) {
     // Create minimal valid axes (4 points per axis for B-spline)
-    mango::PriceTableAxes<4> axes;
+    mango::PriceTableAxes axes;
     axes.grids[0] = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1)};  // log-moneyness
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};  // maturity
     axes.grids[2] = {0.15, 0.20, 0.25, 0.30};  // volatility
@@ -19,7 +19,7 @@ TEST(PriceTableBuilderResultTest, BuildReturnsDiagnostics) {
     config.K_ref = 100.0;
     config.pde_grid = mango::PDEGridConfig{mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value(), 100};
 
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
     auto result = builder.build(axes);
 
     ASSERT_TRUE(result.has_value()) << "Build failed: " << result.error();

--- a/tests/price_table_builder_root_cause_test.cc
+++ b/tests/price_table_builder_root_cause_test.cc
@@ -38,8 +38,8 @@ TEST(PriceTableBuilderRootCauseTest, GridWidthExceedsLimit) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder_narrow(config_narrow);
-    PriceTableAxes<4> axes;
+    PriceTableBuilder builder_narrow(config_narrow);
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0)};
     axes.grids[1] = {0.1, 0.5, 1.0};
     axes.grids[2] = {0.20};
@@ -67,7 +67,7 @@ TEST(PriceTableBuilderRootCauseTest, GridWidthExceedsLimit) {
 
     // Test 2: Use the original wide grid
     std::cout << "\n=== Test 2: Wide grid (width=6.0 > 5.8) ===" << std::endl;
-    PriceTableBuilder<4> builder_wide(config);
+    PriceTableBuilder builder_wide(config);
     auto batch2 = Access::make_batch(builder_wide, axes);
     GridSpec<double> wide_grid = explicit_grid.grid_spec;
     auto time_domain2 = TimeDomain::from_n_steps(0.0, axes.grids[1].back(), explicit_grid.n_time);

--- a/tests/price_table_builder_test.cc
+++ b/tests/price_table_builder_test.cc
@@ -18,9 +18,9 @@ TEST(PriceTableBuilderTest, BuildEmpty4DSurface) {
     PriceTableConfig config{
         .pde_grid = PDEGridConfig{GridSpec<double>::uniform(-3.0, 3.0, 101).value(), 100}  // Reduce from default 1000 for faster test
     };
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     // Minimum 4 points per axis for cubic B-spline fitting
     axes.grids[0] = {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1)};
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
@@ -33,7 +33,7 @@ TEST(PriceTableBuilderTest, BuildEmpty4DSurface) {
     EXPECT_NE(result->surface, nullptr);
 }
 
-// Note: N≠4 tests removed - PriceTableBuilder uses static_assert(N == 4)
+// Note: N≠4 tests removed - PriceTableBuilderND uses static_assert(N == 4)
 // which produces compile-time errors for unsupported dimensions.
 
 TEST(PriceTableBuilderTest, MakeBatchIteratesVolatilityAndRateOnly) {
@@ -47,9 +47,9 @@ TEST(PriceTableBuilderTest, MakeBatchIteratesVolatilityAndRateOnly) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0), std::log(1.1)};  // log-moneyness: 3 points
     axes.grids[1] = {0.1, 0.5, 1.0};      // maturity: 3 points
     axes.grids[2] = {0.15, 0.20, 0.25};   // volatility: 3 points
@@ -75,9 +75,9 @@ TEST(PriceTableBuilderTest, MakeBatch4D) {
         .dividends = {.dividend_yield = 0.02, .discrete_dividends = {{.calendar_time = 0.25, .amount = 1.0}}}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0)};  // log-moneyness: 2 points
     axes.grids[1] = {0.1, 0.5};      // maturity: 2 points
     axes.grids[2] = {0.20};          // volatility: 1 point
@@ -111,9 +111,9 @@ TEST(PriceTableBuilderTest, SolveBatchRegistersMaturitySnapshots) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0)};
     axes.grids[1] = {0.1, 0.5, 1.0};  // 3 maturity points
     axes.grids[2] = {0.20};           // 1 vol
@@ -148,9 +148,9 @@ TEST(PriceTableBuilderTest, DISABLED_ExtractTensorInterpolatesSurfaces) {
         .dividends = {.dividend_yield = 0.02}
     };
 
-    PriceTableBuilder<4> builder(config);
+    PriceTableBuilder builder(config);
 
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0), std::log(1.1)};  // 3 log-moneyness points
     axes.grids[1] = {0.1, 0.5, 1.0};      // 3 maturity points
     axes.grids[2] = {0.20};               // 1 vol
@@ -206,10 +206,10 @@ TEST(PriceTableBuilderTest, BuildRejectsInvalidConfig) {
     config.option_type = mango::OptionType::PUT;
     config.K_ref = 100.0;
 
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
 
     // Create minimal valid axes (4 points per axis for B-spline)
-    mango::PriceTableAxes<4> axes;
+    mango::PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0), std::log(1.1), std::log(1.2)};
     axes.grids[1] = {0.25, 0.5, 0.75, 1.0};
     axes.grids[2] = {0.2, 0.25, 0.3, 0.35};
@@ -221,7 +221,7 @@ TEST(PriceTableBuilderTest, BuildRejectsInvalidConfig) {
 }
 
 TEST(PriceTableBuilderTest, FromVectorsRejectsInvalidMaxFailureRate) {
-    auto result = mango::PriceTableBuilder<4>::from_vectors(
+    auto result = mango::PriceTableBuilder::from_vectors(
         {std::log(0.9), std::log(1.0), std::log(1.1)},  // log-moneyness
         {0.25, 0.5},      // maturity
         {0.2, 0.3},       // volatility
@@ -243,7 +243,7 @@ TEST(PriceTableBuilderTest, FindNearestValidNeighborFindsAdjacent) {
     slice_valid[4] = false;  // Center (1,1) invalid
 
     mango::PriceTableConfig config;
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
 
     auto result = Access::find_nearest_valid_neighbor(builder, 1, 1, 3, 3, slice_valid);
     ASSERT_TRUE(result.has_value());
@@ -258,7 +258,7 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesInterpolatesPartial) {
     // Then verify repair fills it via τ-interpolation
 
     // Use 2x3x2x2 tensor: Nm=2, Nt=3, Nσ=2, Nr=2
-    auto tensor_result = mango::PriceTensor<4>::create({2, 3, 2, 2});
+    auto tensor_result = mango::PriceTensor::create({2, 3, 2, 2});
     ASSERT_TRUE(tensor_result.has_value());
     auto& tensor = tensor_result.value();
 
@@ -278,7 +278,7 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesInterpolatesPartial) {
     tensor.view[1, 1, 0, 0] = std::numeric_limits<double>::quiet_NaN();
 
     // Create axes
-    mango::PriceTableAxes<4> axes;
+    mango::PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0)};
     axes.grids[1] = {0.25, 0.5, 0.75};
     axes.grids[2] = {0.2, 0.3};
@@ -286,7 +286,7 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesInterpolatesPartial) {
 
     // Build config and builder
     mango::PriceTableConfig config;
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
 
     // Call repair with failed_spline indicating τ=1 failed
     std::vector<size_t> failed_pde;  // No PDE failures
@@ -309,7 +309,7 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesInterpolatesPartial) {
 
 TEST(PriceTableBuilderTest, RepairFailedSlicesCopiesFromNeighbor) {
     // Create tensor with full slice NaN, verify neighbor copy
-    auto tensor_result = mango::PriceTensor<4>::create({2, 2, 2, 2});
+    auto tensor_result = mango::PriceTensor::create({2, 2, 2, 2});
     ASSERT_TRUE(tensor_result.has_value());
     auto& tensor = tensor_result.value();
 
@@ -331,14 +331,14 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesCopiesFromNeighbor) {
         }
     }
 
-    mango::PriceTableAxes<4> axes;
+    mango::PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0)};
     axes.grids[1] = {0.25, 0.5};
     axes.grids[2] = {0.2, 0.3};
     axes.grids[3] = {0.05, 0.06};
 
     mango::PriceTableConfig config;
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
 
     // PDE failed at flat index 0 (σ=0, r=0)
     std::vector<size_t> failed_pde = {0};
@@ -361,7 +361,7 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesCopiesFromNeighbor) {
 
 TEST(PriceTableBuilderTest, RepairFailedSlicesFailsWhenNoValidDonor) {
     // All slices invalid, verify returns error
-    auto tensor_result = mango::PriceTensor<4>::create({2, 2, 1, 1});
+    auto tensor_result = mango::PriceTensor::create({2, 2, 1, 1});
     ASSERT_TRUE(tensor_result.has_value());
     auto& tensor = tensor_result.value();
 
@@ -372,14 +372,14 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesFailsWhenNoValidDonor) {
         }
     }
 
-    mango::PriceTableAxes<4> axes;
+    mango::PriceTableAxes axes;
     axes.grids[0] = {std::log(0.9), std::log(1.0)};
     axes.grids[1] = {0.25, 0.5};
     axes.grids[2] = {0.2};
     axes.grids[3] = {0.05};
 
     mango::PriceTableConfig config;
-    mango::PriceTableBuilder<4> builder(config);
+    mango::PriceTableBuilder builder(config);
 
     std::vector<size_t> failed_pde = {0};  // Only slice failed
     std::vector<std::tuple<size_t, size_t, size_t>> failed_spline;
@@ -392,7 +392,7 @@ TEST(PriceTableBuilderTest, RepairFailedSlicesFailsWhenNoValidDonor) {
 }
 
 TEST(PriceTableBuilderTest, BuildPopulatesTotalSlicesAndPoints) {
-    auto result = mango::PriceTableBuilder<4>::from_vectors(
+    auto result = mango::PriceTableBuilder::from_vectors(
         {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1)}, {0.25, 0.5, 0.75, 1.0}, {0.15, 0.2, 0.25, 0.3}, {0.02, 0.04, 0.06, 0.08},
         100.0,
         mango::PDEGridConfig{mango::GridSpec<double>::uniform(-3.0, 3.0, 51).value(), 500});
@@ -408,7 +408,7 @@ TEST(PriceTableBuilderTest, BuildPopulatesTotalSlicesAndPoints) {
 
 // Default mode always produces NormalizedPrice metadata
 TEST(PriceTableBuilderTest, DefaultModeProducesNormalizedPriceMetadata) {
-    auto setup = PriceTableBuilder<4>::from_vectors(
+    auto setup = PriceTableBuilder::from_vectors(
         {std::log(0.8), std::log(0.9), std::log(1.0), std::log(1.1)},
         {0.25, 0.5, 0.75, 1.0},
         {0.15, 0.20, 0.25, 0.30},

--- a/tests/price_table_builder_test_access.hpp
+++ b/tests/price_table_builder_test_access.hpp
@@ -6,24 +6,24 @@ namespace mango::testing {
 
 template <size_t N>
 struct PriceTableBuilderAccess {
-    static inline auto make_batch(const PriceTableBuilder<N>& b, const PriceTableAxes<N>& a) {
+    static inline auto make_batch(const PriceTableBuilderND<N>& b, const PriceTableAxesND<N>& a) {
         return b.make_batch(a);
     }
-    static inline auto solve_batch(const PriceTableBuilder<N>& b,
+    static inline auto solve_batch(const PriceTableBuilderND<N>& b,
                                     const std::vector<PricingParams>& batch,
-                                    const PriceTableAxes<N>& a) {
+                                    const PriceTableAxesND<N>& a) {
         return b.solve_batch(batch, a);
     }
-    static inline auto extract_tensor(const PriceTableBuilder<N>& b,
+    static inline auto extract_tensor(const PriceTableBuilderND<N>& b,
                                        const BatchAmericanOptionResult& batch,
-                                       const PriceTableAxes<N>& a) {
+                                       const PriceTableAxesND<N>& a) {
         return b.extract_tensor(batch, a);
     }
     // Note: fit_coeffs returns FitCoeffsResult (private struct).
     // The _for_testing methods extracted .coefficients. We replicate that.
-    static inline auto fit_coeffs(const PriceTableBuilder<N>& b,
-                                   const PriceTensor<N>& tensor,
-                                   const PriceTableAxes<N>& a) {
+    static inline auto fit_coeffs(const PriceTableBuilderND<N>& b,
+                                   const PriceTensorND<N>& tensor,
+                                   const PriceTableAxesND<N>& a) {
         auto result = b.fit_coeffs(tensor, a);
         if (!result.has_value()) {
             return std::expected<std::vector<double>, PriceTableError>(
@@ -32,17 +32,17 @@ struct PriceTableBuilderAccess {
         return std::expected<std::vector<double>, PriceTableError>(
             std::move(result.value().coefficients));
     }
-    static inline auto find_nearest_valid_neighbor(const PriceTableBuilder<N>& b,
+    static inline auto find_nearest_valid_neighbor(const PriceTableBuilderND<N>& b,
                                                     size_t s_idx, size_t r_idx,
                                                     size_t Ns, size_t Nr,
                                                     const std::vector<bool>& valid) {
         return b.find_nearest_valid_neighbor(s_idx, r_idx, Ns, Nr, valid);
     }
-    static inline auto repair_failed_slices(const PriceTableBuilder<N>& b,
-                                             PriceTensor<N>& tensor,
+    static inline auto repair_failed_slices(const PriceTableBuilderND<N>& b,
+                                             PriceTensorND<N>& tensor,
                                              const std::vector<size_t>& failed_pde,
                                              const std::vector<std::tuple<size_t, size_t, size_t>>& failed_spline,
-                                             const PriceTableAxes<N>& axes) {
+                                             const PriceTableAxesND<N>& axes) {
         return b.repair_failed_slices(tensor, failed_pde, failed_spline, axes);
     }
 };

--- a/tests/price_table_end_to_end_performance_test.cc
+++ b/tests/price_table_end_to_end_performance_test.cc
@@ -78,7 +78,7 @@ TEST_F(PriceTableEndToEndPerformanceTest, BandedSolverSpeedup) {
         ASSERT_TRUE(grid_spec_result.has_value());
         auto grid_spec = grid_spec_result.value();
 
-        auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+        auto builder_axes_result = PriceTableBuilder::from_vectors(
             moneyness, maturity, volatility, rate, 100.0,
             PDEGridConfig{grid_spec, 1000}, OptionType::PUT, 0.02, 0.0, false);
         ASSERT_TRUE(builder_axes_result.has_value()) << "Failed to create builder: " << builder_axes_result.error();
@@ -130,7 +130,7 @@ TEST_F(PriceTableEndToEndPerformanceTest, SmallerGridSanityCheck) {
     ASSERT_TRUE(grid_spec_result.has_value());
     auto grid_spec = grid_spec_result.value();
 
-    auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_axes_result = PriceTableBuilder::from_vectors(
         moneyness, maturity, volatility, rate, 100.0,
         PDEGridConfig{grid_spec, 1000}, OptionType::PUT, 0.02);
     ASSERT_TRUE(builder_axes_result.has_value()) << "Failed to create builder: " << builder_axes_result.error();

--- a/tests/price_table_workspace_test.cc
+++ b/tests/price_table_workspace_test.cc
@@ -510,7 +510,7 @@ TEST(PriceTableWorkspaceTest, DefaultSurfaceContentIsZero) {
         log_m_grid, tau_grid, sigma_grid, r_grid, coeffs, 100.0, 0.02, 0.8, 1.1);
 
     ASSERT_TRUE(ws_result.has_value());
-    EXPECT_EQ(ws_result.value().surface_content(), 0);
+    EXPECT_EQ(ws_result.value().surface_content(), mango::SurfaceContent::NormalizedPrice);
 }
 
 TEST(PriceTableWorkspaceTest, DISABLED_RoundTripSurfaceContent) {
@@ -523,10 +523,10 @@ TEST(PriceTableWorkspaceTest, DISABLED_RoundTripSurfaceContent) {
     // Create workspace with surface_content=1 (EEP)
     auto ws_result = mango::PriceTableWorkspace::create(
         log_m_grid, tau_grid, sigma_grid, r_grid, coeffs, 100.0, 0.02, 0.8, 1.1,
-        /*surface_content=*/1);
+        mango::SurfaceContent::EarlyExercisePremium);
 
     ASSERT_TRUE(ws_result.has_value());
-    EXPECT_EQ(ws_result.value().surface_content(), 1);
+    EXPECT_EQ(ws_result.value().surface_content(), mango::SurfaceContent::EarlyExercisePremium);
 
     // Save to temp file
     const std::string filepath = "/tmp/test_surface_content_roundtrip.arrow";
@@ -538,7 +538,7 @@ TEST(PriceTableWorkspaceTest, DISABLED_RoundTripSurfaceContent) {
     ASSERT_TRUE(load_result.has_value()) << "Load failed";
 
     // Verify surface_content round-trips correctly
-    EXPECT_EQ(load_result.value().surface_content(), 1);
+    EXPECT_EQ(load_result.value().surface_content(), mango::SurfaceContent::EarlyExercisePremium);
 
     // Cleanup
     std::filesystem::remove(filepath);

--- a/tests/price_tensor_test.cc
+++ b/tests/price_tensor_test.cc
@@ -6,7 +6,7 @@ namespace mango {
 namespace {
 
 TEST(PriceTensorTest, Create2DTensor) {
-    auto result = PriceTensor<2>::create({3, 4});
+    auto result = PriceTensorND<2>::create({3, 4});
     ASSERT_TRUE(result.has_value());
 
     auto tensor = result.value();
@@ -15,7 +15,7 @@ TEST(PriceTensorTest, Create2DTensor) {
 }
 
 TEST(PriceTensorTest, AccessElements) {
-    auto tensor = PriceTensor<2>::create({2, 3}).value();
+    auto tensor = PriceTensorND<2>::create({2, 3}).value();
 
     // Write via mdspan
     tensor.view[0, 0] = 1.0;
@@ -29,7 +29,7 @@ TEST(PriceTensorTest, AccessElements) {
 }
 
 TEST(PriceTensorTest, Create4DTensor) {
-    auto result = PriceTensor<4>::create({5, 4, 3, 2});
+    auto result = PriceTensor::create({5, 4, 3, 2});
     ASSERT_TRUE(result.has_value());
 
     auto tensor = result.value();
@@ -48,13 +48,13 @@ TEST(PriceTensorTest, Create4DTensor) {
 
 TEST(PriceTensorTest, ShapeOverflow) {
     // Request a shape that would overflow size_t
-    auto result = PriceTensor<3>::create({SIZE_MAX, SIZE_MAX, SIZE_MAX});
+    auto result = PriceTensorND<3>::create({SIZE_MAX, SIZE_MAX, SIZE_MAX});
     EXPECT_FALSE(result.has_value());
     EXPECT_NE(result.error().find("overflow"), std::string::npos);
 }
 
 TEST(PriceTensorTest, Create1DTensor) {
-    auto result = PriceTensor<1>::create({10});
+    auto result = PriceTensorND<1>::create({10});
     ASSERT_TRUE(result.has_value());
 
     auto tensor = result.value();
@@ -66,7 +66,7 @@ TEST(PriceTensorTest, Create1DTensor) {
 }
 
 TEST(PriceTensorTest, Create5DTensor) {
-    auto result = PriceTensor<5>::create({2, 3, 4, 5, 6});
+    auto result = PriceTensorND<5>::create({2, 3, 4, 5, 6});
     ASSERT_TRUE(result.has_value());
 
     auto tensor = result.value();
@@ -92,7 +92,7 @@ TEST(PriceTensorTest, Create5DTensor) {
 // Issue: Missing @mdspan//:mdspan dependency in BUILD.bazel would cause compile failure
 TEST(PriceTensorTest, MdspanTypesCompile) {
     // This test verifies that mdspan types are available and work correctly
-    auto tensor = PriceTensor<2>::create({3, 4}).value();
+    auto tensor = PriceTensorND<2>::create({3, 4}).value();
 
     // Verify mdspan types are accessible
     using MdspanType = decltype(tensor.view);
@@ -115,7 +115,7 @@ TEST(PriceTensorTest, MdspanTypesCompile) {
 
 // REGRESSION TEST: Verify mdspan works for higher dimensions
 TEST(PriceTensorTest, Mdspan4DTypesCompile) {
-    auto tensor = PriceTensor<4>::create({2, 3, 4, 5}).value();
+    auto tensor = PriceTensor::create({2, 3, 4, 5}).value();
 
     // Verify 4D indexing compiles and works
     tensor.view[0, 1, 2, 3] = 42.0;
@@ -133,7 +133,7 @@ TEST(PriceTensorTest, Mdspan4DTypesCompile) {
 
 // REGRESSION TEST: Verify storage is 64-byte aligned for SIMD operations
 TEST(PriceTensorTest, StorageIsAligned) {
-    auto tensor = PriceTensor<2>::create({10, 10}).value();
+    auto tensor = PriceTensorND<2>::create({10, 10}).value();
 
     // Verify the storage pointer is 64-byte aligned
     uintptr_t addr = reinterpret_cast<uintptr_t>(tensor.storage->data());
@@ -142,7 +142,7 @@ TEST(PriceTensorTest, StorageIsAligned) {
 
 // REGRESSION TEST: Verify shared_ptr semantics work correctly
 TEST(PriceTensorTest, SharedOwnership) {
-    auto tensor1 = PriceTensor<2>::create({5, 5}).value();
+    auto tensor1 = PriceTensorND<2>::create({5, 5}).value();
 
     // Write a value
     tensor1.view[2, 2] = 42.0;

--- a/tests/production_config_integration_test.cc
+++ b/tests/production_config_integration_test.cc
@@ -11,7 +11,7 @@
  * Key differences from unit tests:
  * - Explicit small grid sizes (51 pts vs default 101)
  * - Realistic market data grids (SPY-like parameters)
- * - Full PriceTableBuilder workflow
+ * - Full PriceTableBuilderND workflow
  */
 
 #include <gtest/gtest.h>
@@ -92,7 +92,7 @@ MarketGrid generate_small_market_grid() {
 }  // namespace
 
 // ============================================================================
-// PriceTableBuilder Integration Tests
+// PriceTableBuilderND Integration Tests
 // ============================================================================
 
 // This test directly mirrors the benchmark that exposed issue #272
@@ -105,7 +105,7 @@ TEST(ProductionConfig, PriceTableBuilder_SmallGrid_51Points) {
     ASSERT_TRUE(grid_spec_result.has_value());
     auto grid_spec = grid_spec_result.value();
 
-    auto builder_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_result = PriceTableBuilder::from_vectors(
         grid.log_moneyness,
         grid.maturities,
         grid.volatilities,
@@ -117,7 +117,7 @@ TEST(ProductionConfig, PriceTableBuilder_SmallGrid_51Points) {
         0.0);    // max_failure_rate
 
     ASSERT_TRUE(builder_result.has_value())
-        << "PriceTableBuilder::from_vectors failed";
+        << "PriceTableBuilderND::from_vectors failed";
 
     auto [builder, axes] = std::move(builder_result.value());
 
@@ -125,7 +125,7 @@ TEST(ProductionConfig, PriceTableBuilder_SmallGrid_51Points) {
     auto result = builder.build(axes);
 
     ASSERT_TRUE(result.has_value())
-        << "PriceTableBuilder::build failed with error code "
+        << "PriceTableBuilderND::build failed with error code "
         << static_cast<int>(result.error().code)
         << ", axis_index=" << result.error().axis_index
         << ", count=" << result.error().count;
@@ -141,7 +141,7 @@ TEST(ProductionConfig, PriceTableBuilder_VerySmallGrid_31Points) {
     auto grid_spec_result = GridSpec<double>::sinh_spaced(-3.0, 3.0, 31, 2.0);
     ASSERT_TRUE(grid_spec_result.has_value());
 
-    auto builder_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_result = PriceTableBuilder::from_vectors(
         grid.log_moneyness,
         grid.maturities,
         grid.volatilities,
@@ -166,7 +166,7 @@ TEST(ProductionConfig, PriceTableBuilder_LargeGrid_201Points) {
     auto grid_spec_result = GridSpec<double>::sinh_spaced(-3.0, 3.0, 201, 2.0);
     ASSERT_TRUE(grid_spec_result.has_value());
 
-    auto builder_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_result = PriceTableBuilder::from_vectors(
         grid.log_moneyness,
         grid.maturities,
         grid.volatilities,
@@ -190,7 +190,7 @@ TEST(ProductionConfig, PriceTableBuilder_FullMarketGrid) {
     auto grid_spec_result = GridSpec<double>::sinh_spaced(-3.0, 3.0, 51, 2.0);
     ASSERT_TRUE(grid_spec_result.has_value());
 
-    auto builder_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_result = PriceTableBuilder::from_vectors(
         grid.log_moneyness,
         grid.maturities,
         grid.volatilities,
@@ -459,7 +459,7 @@ TEST(BenchmarkAsTest, MarketIVE2E_BuildPriceTable) {
     auto grid_spec_result = GridSpec<double>::sinh_spaced(-3.0, 3.0, 51, 2.0);
     ASSERT_TRUE(grid_spec_result.has_value());
 
-    auto builder_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_result = PriceTableBuilder::from_vectors(
         grid.log_moneyness,
         grid.maturities,
         grid.volatilities,
@@ -471,13 +471,13 @@ TEST(BenchmarkAsTest, MarketIVE2E_BuildPriceTable) {
         0.0);    // max_failure_rate
 
     ASSERT_TRUE(builder_result.has_value())
-        << "PriceTableBuilder::from_vectors failed";
+        << "PriceTableBuilderND::from_vectors failed";
 
     auto [builder, axes] = std::move(builder_result.value());
     auto result = builder.build(axes);
 
     ASSERT_TRUE(result.has_value())
-        << "PriceTableBuilder::build failed with error code "
+        << "PriceTableBuilderND::build failed with error code "
         << static_cast<int>(result.error().code);
 
     // Verify result structure
@@ -494,7 +494,7 @@ TEST(BenchmarkAsTest, MarketIVE2E_IVSolverCreation) {
     auto grid_spec_result = GridSpec<double>::sinh_spaced(-3.0, 3.0, 51, 2.0);
     ASSERT_TRUE(grid_spec_result.has_value());
 
-    auto builder_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_result = PriceTableBuilder::from_vectors(
         grid.log_moneyness,
         grid.maturities,
         grid.volatilities,
@@ -509,7 +509,7 @@ TEST(BenchmarkAsTest, MarketIVE2E_IVSolverCreation) {
     auto [builder, axes] = std::move(builder_result.value());
     EEPDecomposer decomposer{OptionType::PUT, grid.K_ref, grid.dividend};
     auto table_result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer.decompose(tensor, a);
         });
     ASSERT_TRUE(table_result.has_value());

--- a/tests/quantlib_accuracy_batch_test.cc
+++ b/tests/quantlib_accuracy_batch_test.cc
@@ -110,7 +110,7 @@ TEST(QuantLibBatchTest, StandardScenarios_IV_Interpolated) {
             << "Interpolated IV test expects a single dividend yield across scenarios";
     }
 
-    auto builder_axes_result = PriceTableBuilder<4>::from_vectors(
+    auto builder_axes_result = PriceTableBuilder::from_vectors(
         moneyness_grid,
         maturity_grid,
         vol_grid,
@@ -126,7 +126,7 @@ TEST(QuantLibBatchTest, StandardScenarios_IV_Interpolated) {
     // Pre-compute prices for PUT options with EEP decomposition
     EEPDecomposer decomposer{OptionType::PUT, 100.0, dividend_yield};
     auto precompute_result = builder.build(axes, SurfaceContent::EarlyExercisePremium,
-        [&](PriceTensor<4>& tensor, const PriceTableAxes<4>& a) {
+        [&](PriceTensor& tensor, const PriceTableAxes& a) {
             decomposer.decompose(tensor, a);
         });
     ASSERT_TRUE(precompute_result.has_value())

--- a/tests/recursion_helpers_test.cc
+++ b/tests/recursion_helpers_test.cc
@@ -7,7 +7,7 @@ namespace mango {
 namespace {
 
 TEST(RecursionHelpersTest, ForEachAxisIndex2D) {
-    PriceTableAxes<2> axes;
+    PriceTableAxesND<2> axes;
     axes.grids[0] = {0.9, 1.0};       // 2 points
     axes.grids[1] = {0.1, 0.5, 1.0};  // 3 points
 
@@ -28,7 +28,7 @@ TEST(RecursionHelpersTest, ForEachAxisIndex2D) {
 }
 
 TEST(RecursionHelpersTest, ForEachAxisIndex4D) {
-    PriceTableAxes<4> axes;
+    PriceTableAxes axes;
     axes.grids[0] = {0.9, 1.0};       // 2
     axes.grids[1] = {0.1, 0.5};       // 2
     axes.grids[2] = {0.15, 0.25};     // 2

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -268,12 +268,12 @@ def test_price_table_workspace():
 
 
 def test_price_table_surface():
-    """Test PriceTableSurface4D build and query"""
+    """Test PriceTableSurface build and query"""
     import math
-    print("Testing PriceTableSurface4D...")
+    print("Testing PriceTableSurface...")
 
     # Create axes
-    axes = mango_option.PriceTableAxes4D()
+    axes = mango_option.PriceTableAxes()
     axes.grids = [
         np.array([math.log(0.8), math.log(0.9), math.log(1.0), math.log(1.1), math.log(1.2)]),  # log-moneyness
         np.array([0.1, 0.25, 0.5, 1.0]),       # maturity
@@ -295,7 +295,7 @@ def test_price_table_surface():
     coeffs = np.random.rand(n_coeffs) * 10.0
 
     # Build surface
-    surface = mango_option.PriceTableSurface4D.build(axes, coeffs, meta)
+    surface = mango_option.PriceTableSurface.build(axes, coeffs, meta)
     print(f"✓ Built surface")
 
     # Query value at ATM (log(1.0) = 0.0)
@@ -380,7 +380,7 @@ def test_error_handling():
         print(f"✓ Insufficient grid points raises ValueError: {e}")
 
     # PriceTableAxes with wrong number of grids
-    axes = mango_option.PriceTableAxes4D()
+    axes = mango_option.PriceTableAxes()
     try:
         axes.grids = [np.array([1.0, 2.0, 3.0, 4.0])]  # Only 1 grid instead of 4
         assert False, "Should have raised ValueError"


### PR DESCRIPTION
## Summary
- Rename PI suffix aliases to descriptive names (`SegmentedSurfacePI` → `SegmentedPriceSurface`, etc.)
- Rename templates to ND suffix (`PriceTableBuilder` → `PriceTableBuilderND`) and add dimension-agnostic aliases via `kPriceTableDim` constexpr, preparing for #382
- Extract `PriceQuery` and `MultiKRefConfig` to own header (`price_query.hpp`)
- Use `SurfaceContent` enum instead of `uint8_t` in `PriceTableWorkspace`
- Remove redundant forward declaration from `spliced_surface_builder.hpp`

## Test plan
- [x] All 115 tests pass (`bazel test //...`)
- [x] Benchmarks build (`bazel build //benchmarks/...`)
- [x] Python bindings build (`bazel build //src/python:mango_option`)
- [x] Zero stale references (`SurfacePI`, `WrapperPI`, `PriceTableBuilder<4>`, `uint8_t surface_content`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)