### PR TITLE
Use spot_arg in segmented surface handle lambda

### DIFF
--- a/src/option/table/adaptive_grid_builder.cpp
+++ b/src/option/table/adaptive_grid_builder.cpp
@@ -671,10 +671,9 @@ probe_and_build(
                 return std::unexpected(surface.error());
             }
             auto shared = std::make_shared<SegmentedPriceSurface>(std::move(*surface));
-            double spot = config.spot;
             return SurfaceHandle{
-                .price = [shared, spot](double /*spot_arg*/, double strike,
-                                        double tau, double sigma, double rate) -> double {
+                .price = [shared](double spot, double strike,
+                                  double tau, double sigma, double rate) -> double {
                     return shared->price(PriceQuery{spot, strike, tau, sigma, rate});
                 },
                 .pde_solves = 0


### PR DESCRIPTION
## Summary
- Segmented path's `handle.price` lambda captured `config.spot` and ignored the `spot_arg` parameter
- Currently harmless (caller always passes the same spot), but wrong if the caller ever varies spot

Closes #374 (remaining probe-validation issue is per-strike specific and was made irrelevant by #380).

## Test plan
- [x] `bazel test //tests:adaptive_grid_builder_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)