### PR TITLE
Simplify IV solver factory dispatch

### DIFF
--- a/benchmarks/interp_iv_safety.cc
+++ b/benchmarks/interp_iv_safety.cc
@@ -123,7 +123,7 @@ static PriceGrid generate_prices(bool with_dividends, double div_yield = kDivYie
 // ============================================================================
 
 // Vanilla: one solver covering all maturities via BSpline + adaptive grid
-static AnyIVSolver build_vanilla_solver() {
+static AnyInterpIVSolver build_vanilla_solver() {
     // Maturity grid for price table — deliberately offset from test maturities
     // so most test points require real interpolation
     IVSolverFactoryConfig config{
@@ -151,8 +151,8 @@ static AnyIVSolver build_vanilla_solver() {
 }
 
 // Dividends: one solver per maturity via BSpline + discrete dividends + adaptive grid
-static std::vector<std::pair<size_t, AnyIVSolver>> build_div_solvers() {
-    std::vector<std::pair<size_t, AnyIVSolver>> solvers;
+static std::vector<std::pair<size_t, AnyInterpIVSolver>> build_div_solvers() {
+    std::vector<std::pair<size_t, AnyInterpIVSolver>> solvers;
 
     for (size_t ti = 0; ti < kNT; ++ti) {
         double mat = kMaturities[ti];
@@ -222,7 +222,7 @@ static double solve_fdm_iv_div(double strike, double maturity,
 using ErrorTable = std::array<std::array<double, kNS>, kNT>;
 
 static ErrorTable compute_errors_vanilla(const PriceGrid& prices,
-                                          const AnyIVSolver& interp_solver,
+                                          const AnyInterpIVSolver& interp_solver,
                                           size_t vol_idx,
                                           double div_yield = kDivYield) {
     ErrorTable errors{};
@@ -281,7 +281,7 @@ static ErrorTable compute_errors_vanilla(const PriceGrid& prices,
 
 static ErrorTable compute_errors_div(
     const PriceGrid& prices,
-    const std::vector<std::pair<size_t, AnyIVSolver>>& div_solvers,
+    const std::vector<std::pair<size_t, AnyInterpIVSolver>>& div_solvers,
     size_t vol_idx) {
     ErrorTable errors{};
 
@@ -864,7 +864,7 @@ run_chebyshev_dividends(const PriceGrid& prices) {
 // q=0 comparison: 4D B-spline vs 3D dimensionless (B-spline & Chebyshev)
 // ============================================================================
 
-static AnyIVSolver build_bspline_q0() {
+static AnyInterpIVSolver build_bspline_q0() {
     IVSolverFactoryConfig config{
         .option_type = OptionType::PUT,
         .spot = kSpot,
@@ -888,7 +888,7 @@ static AnyIVSolver build_bspline_q0() {
     return std::move(*solver);
 }
 
-static std::expected<AnyIVSolver, ValidationError>
+static std::expected<AnyInterpIVSolver, ValidationError>
 build_dimless_3d(DimensionlessBackend::Interpolant interp) {
     IVSolverFactoryConfig config{
         .option_type = OptionType::PUT,

--- a/benchmarks/iv_interpolation_sweep.cc
+++ b/benchmarks/iv_interpolation_sweep.cc
@@ -437,7 +437,7 @@ BENCHMARK(BM_Chebyshev_IV)
 // ============================================================================
 
 struct Dimensionless3DSolverEntry {
-    std::unique_ptr<AnyIVSolver> solver;
+    std::unique_ptr<AnyInterpIVSolver> solver;
     double build_time_ms = 0.0;
     size_t n_pde_solves = 0;
 };
@@ -468,7 +468,7 @@ static const Dimensionless3DSolverEntry& get_dimensionless_solver() {
         double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 
         Dimensionless3DSolverEntry e;
-        e.solver = std::make_unique<AnyIVSolver>(std::move(*solver));
+        e.solver = std::make_unique<AnyInterpIVSolver>(std::move(*solver));
         e.build_time_ms = ms;
         return e;
     }();

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -608,7 +608,7 @@ auto solver = mango::make_interpolated_iv_solver(config);
 
 ### Querying the Solver
 
-Both paths produce an `AnyIVSolver` with the same interface:
+Both paths produce an `AnyInterpIVSolver` with the same interface:
 
 ```cpp
 mango::IVQuery query(

--- a/src/option/interpolated_iv_solver.hpp
+++ b/src/option/interpolated_iv_solver.hpp
@@ -5,7 +5,7 @@
  *
  * Provides:
  * - InterpolatedIVSolver<Surface>: Newton-Raphson IV solver on any PriceTable
- * - AnyIVSolver: type-erased wrapper for convenient use
+ * - AnyInterpIVSolver: type-erased wrapper for convenient use
  * - make_interpolated_iv_solver(): factory that builds the price surface and solver
  *
  * Two construction paths:
@@ -201,7 +201,7 @@ struct IVSolverFactoryConfig {
 /// Type-erased IV solver wrapping any PriceTable backend
 ///
 /// Impl is defined in the .cpp — only the factory can construct instances.
-class AnyIVSolver {
+class AnyInterpIVSolver {
 public:
     /// Solve for implied volatility (single query)
     std::expected<IVSuccess, IVError> solve(const IVQuery& query) const;
@@ -211,10 +211,10 @@ public:
 
     // Pimpl: move-only, defined in .cpp
     struct Impl;
-    explicit AnyIVSolver(std::unique_ptr<Impl> impl);
-    AnyIVSolver(AnyIVSolver&&) noexcept;
-    AnyIVSolver& operator=(AnyIVSolver&&) noexcept;
-    ~AnyIVSolver();
+    explicit AnyInterpIVSolver(std::unique_ptr<Impl> impl);
+    AnyInterpIVSolver(AnyInterpIVSolver&&) noexcept;
+    AnyInterpIVSolver& operator=(AnyInterpIVSolver&&) noexcept;
+    ~AnyInterpIVSolver();
 
 private:
     std::unique_ptr<Impl> impl_;
@@ -232,8 +232,8 @@ private:
 /// grid density until the target IV error is met.
 ///
 /// @param config Solver configuration
-/// @return Type-erased AnyIVSolver or ValidationError
-std::expected<AnyIVSolver, ValidationError> make_interpolated_iv_solver(const IVSolverFactoryConfig& config);
+/// @return Type-erased AnyInterpIVSolver or ValidationError
+std::expected<AnyInterpIVSolver, ValidationError> make_interpolated_iv_solver(const IVSolverFactoryConfig& config);
 
 // =====================================================================
 // Template implementation (must be in header for template instantiation)

--- a/src/python/mango_bindings.cpp
+++ b/src/python/mango_bindings.cpp
@@ -828,10 +828,10 @@ PYBIND11_MODULE(mango_option, m) {
                 else c.discrete_dividends = obj.cast<mango::DiscreteDividendConfig>();
             });
 
-    // AnyIVSolver (exposed as InterpolatedIVSolver for Python)
-    py::class_<mango::AnyIVSolver>(m, "InterpolatedIVSolver")
+    // AnyInterpIVSolver (exposed as InterpolatedIVSolver for Python)
+    py::class_<mango::AnyInterpIVSolver>(m, "InterpolatedIVSolver")
         .def("solve",
-            [](const mango::AnyIVSolver& solver, const mango::IVQuery& query) {
+            [](const mango::AnyInterpIVSolver& solver, const mango::IVQuery& query) {
                 auto result = solver.solve(query);
                 if (result.has_value()) {
                     return py::make_tuple(true, result.value(), mango::IVError{});
@@ -852,7 +852,7 @@ PYBIND11_MODULE(mango_option, m) {
                     Tuple of (success: bool, result: IVSuccess, error: IVError)
             )pbdoc")
         .def("solve_batch",
-            [](const mango::AnyIVSolver& solver, const std::vector<mango::IVQuery>& queries) {
+            [](const mango::AnyInterpIVSolver& solver, const std::vector<mango::IVQuery>& queries) {
                 auto batch_result = solver.solve_batch(queries);
                 py::list results;
                 for (const auto& r : batch_result.results) {

--- a/src/simple/vol_surface.cpp
+++ b/src/simple/vol_surface.cpp
@@ -51,7 +51,7 @@ std::optional<double> VolatilitySurface::iv_at(double strike, double tau) const 
 std::expected<VolatilitySurface, ComputeError> compute_vol_surface(
     const OptionChain& chain,
     const MarketContext& ctx,
-    const mango::AnyIVSolver* solver,
+    const mango::AnyInterpIVSolver* solver,
     const IVComputeConfig& config,
     PriceSource price_source)
 {

--- a/src/simple/vol_surface.hpp
+++ b/src/simple/vol_surface.hpp
@@ -98,7 +98,7 @@ enum class PriceSource {
 std::expected<VolatilitySurface, ComputeError> compute_vol_surface(
     const OptionChain& chain,
     const MarketContext& ctx,
-    const mango::AnyIVSolver* solver = nullptr,
+    const mango::AnyInterpIVSolver* solver = nullptr,
     const IVComputeConfig& config = {},
     PriceSource price_source = PriceSource::Mid);
 

--- a/tests/discrete_dividend_iv_integration_test.cc
+++ b/tests/discrete_dividend_iv_integration_test.cc
@@ -34,10 +34,10 @@ protected:
         };
         auto result = make_interpolated_iv_solver(config);
         ASSERT_TRUE(result.has_value()) << "Failed to build solver";
-        solver_ = std::make_unique<AnyIVSolver>(std::move(*result));
+        solver_ = std::make_unique<AnyInterpIVSolver>(std::move(*result));
     }
 
-    std::unique_ptr<AnyIVSolver> solver_;
+    std::unique_ptr<AnyInterpIVSolver> solver_;
 };
 
 TEST_F(DiscreteDividendIVIntegrationTest, ATMPutIVRoundTrip) {

--- a/tests/iv_solver_factory_test.cc
+++ b/tests/iv_solver_factory_test.cc
@@ -32,7 +32,7 @@ IVSolverFactoryConfig make_base_config() {
     return config;
 }
 
-AnyIVSolver build_solver(const IVSolverFactoryConfig& config) {
+AnyInterpIVSolver build_solver(const IVSolverFactoryConfig& config) {
     auto result = make_interpolated_iv_solver(config);
     EXPECT_TRUE(result.has_value()) << "Solver build failed";
     return std::move(*result);


### PR DESCRIPTION
## Summary
- Merge segmented build functions into their backend's main build function
- Factory dispatches on backend type only; each backend handles dividends internally
- Net -27 lines, two fewer static functions

## Changes
- `build_bspline_segmented()` folded into `build_bspline()`
- `build_chebyshev_segmented()` folded into `build_chebyshev()`
- Chebyshev segmented adaptive/manual paths deduplicated via `.transform()`
- `make_interpolated_iv_solver()` simplified from 6-branch to 3-branch dispatch
- `if constexpr` reordered: B-spline → Chebyshev → Dimensionless

## Testing
- `iv_solver_factory_test` passes (exercises all backend × dividend × adaptive paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)