### PR TITLE
Bump Python toolchain from 3.11 to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,10 @@ jobs:
             ~/.cache/bazel
           # Unique key per run so each CI job can save updated artifacts.
           # restore-keys ensures partial cache hits from prior runs.
-          key: bazel-v6-${{ hashFiles('.bazelversion', 'MODULE.bazel', '.bazelrc') }}-${{ github.sha }}
+          key: bazel-v7-${{ hashFiles('.bazelversion', 'MODULE.bazel', '.bazelrc') }}-${{ github.sha }}
           restore-keys: |
-            bazel-v6-${{ hashFiles('.bazelversion', 'MODULE.bazel', '.bazelrc') }}-
-            bazel-v6-
+            bazel-v7-${{ hashFiles('.bazelversion', 'MODULE.bazel', '.bazelrc') }}-
+            bazel-v7-
 
       - name: Build all targets
         run: bazel build //... --build_tag_filters=-benchmark

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,16 +32,16 @@ register_toolchains("//toolchain:cc_toolchain_for_k8")
 # Python configuration - allow running as root for CI/Docker environments
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    python_version = "3.11",
+    python_version = "3.13",
     ignore_root_user_error = True,
 )
-use_repo(python, "python_3_11")
+use_repo(python, "python_3_13")
 
 # Python pip dependencies
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "pip",
-    python_version = "3.11",
+    python_version = "3.13",
     requirements_lock = "//third_party:requirements.txt",
 )
 use_repo(pip, "pip")


### PR DESCRIPTION
## Summary
- `pybind_extension` links against the toolchain Python's C ABI, so a 3.11-pinned toolchain produces a `mango_option.so` that won't load under Python 3.13.
- This bumps `MODULE.bazel`'s `python.toolchain` and `pip.parse` from 3.11 → 3.13 to match host Python on current dev/CI environments.
- Reported after v0.4.0 was cut; release ships only source/tag, so no published artifact is affected.

## Changes
- `MODULE.bazel`: `python_version` 3.11 → 3.13 in toolchain and pip.parse; repo alias `python_3_11` → `python_3_13`.

## Testing
- [x] `bazel build //src/python:mango_option`
- [x] Verified `import mango_option` succeeds under `python3.13`
- [x] `bazel test //tests:python_bindings_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)