### PR TITLE
Support discrete dividends in FDM IVSolver

### DIFF
--- a/src/option/iv_solver.cpp
+++ b/src/option/iv_solver.cpp
@@ -55,6 +55,7 @@ double IVSolver::objective_function(const IVQuery& query, double volatility) con
     option_params.rate = query.rate;
     option_params.dividend_yield = query.dividend_yield;
     option_params.option_type = query.option_type;
+    option_params.discrete_dividends = query.discrete_dividends;
 
     // Resolve grid from config_.grid (GridAccuracyParams or PDEGridConfig)
     GridSpec<double> grid_spec = GridSpec<double>::uniform(0.0, 1.0, 10).value();  // Will be replaced

--- a/src/option/option_spec.cpp
+++ b/src/option/option_spec.cpp
@@ -86,6 +86,31 @@ std::expected<void, ValidationError> validate_iv_query(const IVQuery& query) {
             query.market_price));
     }
 
+    // Validate discrete dividends (mirrors validate_pricing_params): each
+    // ex-dividend instant must fall within (0, maturity] and the amount be
+    // non-negative and finite. The FDM IVSolver honors these dividends.
+    for (size_t i = 0; i < query.discrete_dividends.size(); ++i) {
+        const auto& div = query.discrete_dividends[i];
+        if (div.calendar_time < 0.0 || div.calendar_time > query.maturity) {
+            return std::unexpected(ValidationError(
+                ValidationErrorCode::InvalidDividend,
+                div.calendar_time,
+                i));
+        }
+        if (div.amount < 0.0) {
+            return std::unexpected(ValidationError(
+                ValidationErrorCode::InvalidDividend,
+                div.amount,
+                i));
+        }
+        if (!std::isfinite(div.calendar_time) || !std::isfinite(div.amount)) {
+            return std::unexpected(ValidationError(
+                ValidationErrorCode::InvalidDividend,
+                div.calendar_time,
+                i));
+        }
+    }
+
     return {};
 }
 

--- a/src/option/option_spec.hpp
+++ b/src/option/option_spec.hpp
@@ -216,10 +216,19 @@ std::expected<void, ValidationError> validate_option_spec(const OptionSpec& spec
 struct IVQuery : OptionSpec {
     double market_price = 0.0;    ///< Observed market price to match
 
+    /// Discrete dividend schedule: (calendar_time, amount) pairs.
+    /// Honored by the FDM IVSolver, which prices each candidate volatility with
+    /// these dividends (mandatory grid times are placed at each ex-dividend
+    /// instant). Defaults to empty (continuous-yield-only behavior).
+    std::vector<Dividend> discrete_dividends;
+
     IVQuery() = default;
 
-    IVQuery(const OptionSpec& spec, double market_price_)
-        : OptionSpec(spec), market_price(market_price_) {}
+    IVQuery(const OptionSpec& spec, double market_price_,
+            std::vector<Dividend> discrete_dividends_ = {})
+        : OptionSpec(spec)
+        , market_price(market_price_)
+        , discrete_dividends(std::move(discrete_dividends_)) {}
 };
 
 /**

--- a/src/python/mango_bindings.cpp
+++ b/src/python/mango_bindings.cpp
@@ -398,6 +398,15 @@ PYBIND11_MODULE(mango_option, m) {
         .def_readwrite("dividend_yield", &mango::IVQuery::dividend_yield)
         .def_readwrite("option_type", &mango::IVQuery::option_type)
         .def_readwrite("market_price", &mango::IVQuery::market_price)
+        .def_property("discrete_dividends",
+            [](const mango::IVQuery& self) {
+                return dividends_to_python(self.discrete_dividends);
+            },
+            [](mango::IVQuery& self, const py::object& obj) {
+                self.discrete_dividends = python_to_dividends(obj);
+            },
+            "Discrete dividend schedule (list of Dividend or (time, amount) tuples). "
+            "Honored by the FDM IVSolver.")
         .def("__repr__", [](const mango::IVQuery& q) {
             return "<IVQuery spot=" + std::to_string(q.spot) +
                    " strike=" + std::to_string(q.strike) +

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -459,6 +459,7 @@ cc_test(
     name = "iv_solver_test",
     srcs = ["iv_solver_test.cc"],
     deps = [
+        "//src/option:american_option",
         "//src/option:iv_solver",
         "@googletest//:gtest_main",
     ],

--- a/tests/iv_solver_test.cc
+++ b/tests/iv_solver_test.cc
@@ -2,7 +2,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "mango/option/iv_solver.hpp"
+#include "mango/option/american_option.hpp"
 #include <cmath>
+#include <vector>
 
 using namespace mango;
 
@@ -247,4 +249,61 @@ TEST_F(IVSolverTest, GridAccuracyReducesError) {
     EXPECT_LT(result_default->implied_vol, 0.35);
     EXPECT_GT(result_finer->implied_vol, 0.15);
     EXPECT_LT(result_finer->implied_vol, 0.35);
+}
+
+// ===========================================================================
+// Regression tests for bugs found during code review
+// ===========================================================================
+
+// Regression: FDM IVSolver must honor discrete dividends carried by the query.
+// Bug: IVQuery had no discrete_dividends field, so IVSolver::objective_function
+// built PricingParams with an always-empty dividend schedule. The discrete
+// dividends were silently ignored, so IV solved against a no-dividend price.
+TEST_F(IVSolverTest, DiscreteDividendIVRoundTrip) {
+    const double sigma_true = 0.25;
+    std::vector<Dividend> divs = {Dividend{.calendar_time = 0.5, .amount = 2.0}};
+
+    OptionSpec spec{.spot = 100.0, .strike = 100.0, .maturity = 1.0,
+                    .rate = 0.05, .option_type = OptionType::PUT};
+
+    // Reference price from the FDM pricer WITH the discrete dividend.
+    PricingParams pp(spec, sigma_true, divs);
+    auto priced = solve_american_option(pp);
+    ASSERT_TRUE(priced.has_value());
+    const double market = priced->value_at(spec.spot);
+
+    // IV query carrying the same discrete dividend must recover sigma_true.
+    IVQuery div_query(spec, market);
+    div_query.discrete_dividends = divs;
+
+    IVSolver solver(config);
+    auto result = solver.solve(div_query);
+    ASSERT_TRUE(result.has_value())
+        << "Error code: " << static_cast<int>(result.error().code);
+    EXPECT_NEAR(result->implied_vol, sigma_true, 0.01);
+
+    // Sanity: solving the SAME market price without the dividend yields a
+    // materially different IV — proving the schedule is actually used, not
+    // ignored. The dividend lowers the forward, raising a put's value, so at a
+    // fixed market price the no-dividend fit must imply a different vol.
+    IVQuery no_div_query(spec, market);
+    auto no_div = solver.solve(no_div_query);
+    ASSERT_TRUE(no_div.has_value());
+    EXPECT_GT(std::abs(no_div->implied_vol - sigma_true), 0.02)
+        << "no-dividend IV=" << no_div->implied_vol
+        << " should differ from " << sigma_true;
+}
+
+// Regression: invalid discrete-dividend schedules in an IV query must be
+// rejected by validation, mirroring validate_pricing_params.
+TEST_F(IVSolverTest, DiscreteDividendIVInvalidScheduleRejected) {
+    OptionSpec spec{.spot = 100.0, .strike = 100.0, .maturity = 1.0,
+                    .rate = 0.05, .option_type = OptionType::PUT};
+    IVQuery bad_query(spec, 10.0);
+    // Dividend after maturity is invalid.
+    bad_query.discrete_dividends = {Dividend{.calendar_time = 2.0, .amount = 1.0}};
+
+    IVSolver solver(config);
+    auto result = solver.solve(bad_query);
+    ASSERT_FALSE(result.has_value());
 }

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -245,12 +245,69 @@ def test_typed_exceptions_for_validation_and_persistence():
             assert hasattr(e, "code")
 
 
+def test_fdm_iv_solver_honors_discrete_dividends():
+    # Regression: the FDM IVSolver must honor discrete dividends set on the
+    # query. Before IVQuery exposed discrete_dividends in the binding, Python
+    # FDM IV solves ran with an empty schedule and reproduced the C++ bug.
+    divs = [mo.Dividend(0.5, 2.0)]
+
+    p = mo.PricingParams()
+    p.spot = 100.0
+    p.strike = 100.0
+    p.maturity = 1.0
+    p.rate = 0.05
+    p.dividend_yield = 0.0
+    p.volatility = 0.25
+    p.option_type = mo.OptionType.PUT
+    p.discrete_dividends = divs
+
+    market = mo.american_option_price(p).value_at(100.0)
+    assert_finite_number(market)
+
+    q = mo.IVQuery()
+    q.spot = 100.0
+    q.strike = 100.0
+    q.maturity = 1.0
+    q.rate = 0.05
+    q.dividend_yield = 0.0
+    q.option_type = mo.OptionType.PUT
+    q.market_price = market
+    q.discrete_dividends = divs
+
+    # The property round-trips what we set.
+    assert len(q.discrete_dividends) == 1
+    assert q.discrete_dividends[0].calendar_time == 0.5
+    assert q.discrete_dividends[0].amount == 2.0
+    # Tuple form is also accepted (matching PricingParams.discrete_dividends).
+    q.discrete_dividends = [(0.5, 2.0)]
+    assert len(q.discrete_dividends) == 1
+
+    success, result, error = mo.IVSolver(mo.IVSolverConfig()).solve(q)
+    assert success, error
+    assert abs(result.implied_vol - 0.25) < 0.01
+
+    # Sanity: dropping the dividend yields a materially different IV, proving
+    # the schedule is actually used.
+    q_no_div = mo.IVQuery()
+    q_no_div.spot = 100.0
+    q_no_div.strike = 100.0
+    q_no_div.maturity = 1.0
+    q_no_div.rate = 0.05
+    q_no_div.dividend_yield = 0.0
+    q_no_div.option_type = mo.OptionType.PUT
+    q_no_div.market_price = market
+    ok2, res2, err2 = mo.IVSolver(mo.IVSolverConfig()).solve(q_no_div)
+    assert ok2, err2
+    assert abs(res2.implied_vol - 0.25) > 0.02
+
+
 def main():
     tests = [
         test_rate_spec_conversions,
         test_sequence_conversions_for_vectors_and_axes,
         test_optional_and_backend_variant_conversions,
         test_dividend_conversions,
+        test_fdm_iv_solver_honors_discrete_dividends,
         test_bspline_4d_price_table_workflow_and_persistence_paths,
         test_price_table_validation_and_iv_error_parity,
         test_legacy_interpolated_iv_solver_factory_still_works,


### PR DESCRIPTION
## Summary

The FDM `IVSolver` silently ignored discrete dividends: `IVQuery` had no
schedule field, so `IVSolver::objective_function` always built `PricingParams`
with an empty dividend schedule. The grid machinery that places mandatory time
points at each ex-dividend instant was already wired in `objective_function` —
it just never received any dividends to act on.

This plumbs the schedule through so implied vol is solved against the correct
discrete-dividend price (matching what the FDM pricer already does for
`solve_american_option`/`american_option_price`), and exposes the new field on
the Python `IVQuery` binding so Python callers of the same solver are fixed too.

## Changes

**C++ (`8030bbe3`)**
- Add `discrete_dividends` to `IVQuery` (`option_spec.hpp`), with a defaulted
  constructor argument so existing call sites are unaffected.
- Copy `query.discrete_dividends` into the per-candidate `PricingParams` in
  `IVSolver::objective_function` (`iv_solver.cpp`), activating the existing
  ex-dividend mandatory-time handling.
- Validate the IV schedule in `validate_iv_query`, mirroring
  `validate_pricing_params`.

**Python binding (`e95f7895`)**
- Expose `discrete_dividends` on the pybind11 `IVQuery` binding (property
  mirroring `PricingParams`), so Python FDM IV no longer runs with an empty
  schedule.

## Testing

- C++ `DiscreteDividendIVRoundTrip` — price an American put with a $2.00
  discrete dividend at σ=0.25, recover σ within 0.01, plus a contrast assertion
  proving the schedule is used (no-dividend fit yields a different vol).
- C++ `DiscreteDividendIVInvalidScheduleRejected` — dividend after maturity is
  rejected by validation.
- Python `test_fdm_iv_solver_honors_discrete_dividends` — same round-trip + the
  property round-trips list/tuple forms.
- Full suite **130/130 pass**; Python bindings test passes; benchmarks build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)