### PR TITLE
Add Rust binding for the interpolation path (price table + interpolated IV)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,8 +8,8 @@ Mango Option is a pricing and implied-volatility library whose public surface sp
 Every supported C++ capability is reachable from Python through an idiomatic Python surface, even when the Python shape does not mirror C++ templates or helper types one-to-one.
 _Avoid_: Binding parity, wrapper parity, pybind coverage
 
-**Rust binding (core)**:
-A safe Rust surface (the `mango-option` crate over `mango-option-sys` and an `extern "C"` shim) exposing American option pricing with Greeks and FDM implied volatility, with full constant-rate/yield-curve and continuous/discrete-dividend fidelity. Unlike the Python API, it is a deliberately focused subset rather than full parity: price tables, interpolated IV, and batch solving are out of scope.
+**Rust binding**:
+A safe Rust surface (the `mango-option` crate over `mango-option-sys` and an `extern "C"` shim) exposing both the FDM path (American option pricing with Greeks, FDM implied volatility) and the interpolation path (a reusable B-spline price table and the fast interpolated IV solver, with adaptive-grid and discrete-dividend config and batch solving), all with full constant-rate/yield-curve and continuous/discrete-dividend fidelity. Unlike the Python API, it is a deliberately focused subset rather than full parity: only the B-spline backend is bound (Chebyshev/Dimensionless are out of scope), and lower-level surface construction and serialization are not exposed.
 _Avoid_: Rust parity, full Rust API, GPU rewrite
 
 **C++ capability**:

--- a/crates/mango-option-sys/src/lib.rs
+++ b/crates/mango-option-sys/src/lib.rs
@@ -2,6 +2,7 @@
 //! Raw FFI bindings to the mango-option C ABI (`src/ffi/mango_c_api.h`).
 //! 1:1 with the C header; no safety. Use the `mango-option` crate instead.
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 
 pub type MangoStatus = i32;
 pub const MANGO_OK: i32 = 0;
@@ -66,6 +67,7 @@ pub struct MangoIvQuery {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct MangoIvSuccess {
     pub implied_vol: f64,
     pub iterations: u64,
@@ -79,6 +81,84 @@ pub struct MangoIvSuccess {
 pub struct MangoIvConfig {
     pub brent_tol_abs: f64,
     pub max_iter: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MangoInterpSolverConfig {
+    pub max_iter: u64,
+    pub tolerance: f64,
+    pub sigma_min: f64,
+    pub sigma_max: f64,
+    pub vega_threshold: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MangoAdaptiveGridParams {
+    pub target_iv_error: f64,
+    pub max_iter: u64,
+    pub max_points_per_dim: u64,
+    pub min_moneyness_points: u64,
+    pub validation_samples: u64,
+    pub refinement_factor: f64,
+    pub lhs_seed: u64,
+    pub vega_floor: f64,
+    pub max_failure_rate: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MangoMultiKRef {
+    pub K_refs: *const f64,
+    pub n_K_refs: u64,
+    pub K_ref_count: i32,
+    pub K_ref_span: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MangoDiscreteDividendConfig {
+    pub maturity: f64,
+    pub dividends: *const MangoDividend,
+    pub n_dividends: u64,
+    pub kref_config: MangoMultiKRef,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MangoIvFactoryConfig {
+    pub option_type: MangoOptionType,
+    pub spot: f64,
+    pub dividend_yield: f64,
+    pub moneyness: *const f64,
+    pub n_moneyness: u64,
+    pub vol: *const f64,
+    pub n_vol: u64,
+    pub rate: *const f64,
+    pub n_rate: u64,
+    pub maturity_grid: *const f64,
+    pub n_maturity: u64,
+    pub solver_config: MangoInterpSolverConfig,
+    pub adaptive: *const MangoAdaptiveGridParams,
+    pub discrete_dividends: *const MangoDiscreteDividendConfig,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MangoIvBatchSlot {
+    pub status: i32,
+    pub success: MangoIvSuccess,
+}
+
+#[repr(C)]
+pub struct MangoInterpIvSolver {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct MangoPriceTable {
+    _private: [u8; 0],
 }
 
 #[repr(C)]
@@ -109,4 +189,71 @@ extern "C" {
         out_success: *mut MangoIvSuccess,
         out_err: *mut MangoError,
     ) -> MangoStatus;
+
+    pub fn mango_make_interp_iv_solver(
+        cfg: *const MangoIvFactoryConfig,
+        out: *mut *mut MangoInterpIvSolver,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_interp_iv_solve(
+        s: *const MangoInterpIvSolver,
+        q: *const MangoIvQuery,
+        out: *mut MangoIvSuccess,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_interp_iv_solve_batch(
+        s: *const MangoInterpIvSolver,
+        queries: *const MangoIvQuery,
+        n: u64,
+        out_slots: *mut MangoIvBatchSlot,
+        out_failed_count: *mut u64,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_interp_iv_solver_free(s: *mut MangoInterpIvSolver);
+
+    pub fn mango_make_price_table(
+        cfg: *const MangoIvFactoryConfig,
+        out: *mut *mut MangoPriceTable,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_validate(
+        t: *const MangoPriceTable,
+        p: *const MangoPricingParams,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_price(t: *const MangoPriceTable, p: *const MangoPricingParams) -> f64;
+    pub fn mango_price_table_vega(t: *const MangoPriceTable, p: *const MangoPricingParams) -> f64;
+    pub fn mango_price_table_delta(
+        t: *const MangoPriceTable,
+        p: *const MangoPricingParams,
+        out: *mut f64,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_gamma(
+        t: *const MangoPriceTable,
+        p: *const MangoPricingParams,
+        out: *mut f64,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_theta(
+        t: *const MangoPriceTable,
+        p: *const MangoPricingParams,
+        out: *mut f64,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_rho(
+        t: *const MangoPriceTable,
+        p: *const MangoPricingParams,
+        out: *mut f64,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_option_type(t: *const MangoPriceTable) -> MangoOptionType;
+    pub fn mango_price_table_dividend_yield(t: *const MangoPriceTable) -> f64;
+    pub fn mango_price_table_make_iv_solver(
+        t: *const MangoPriceTable,
+        cfg: *const MangoInterpSolverConfig,
+        out: *mut *mut MangoInterpIvSolver,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_free(t: *mut MangoPriceTable);
 }

--- a/crates/mango-option-sys/src/lib.rs
+++ b/crates/mango-option-sys/src/lib.rs
@@ -72,6 +72,7 @@ pub struct MangoIvSuccess {
     pub final_error: f64,
     pub vega: f64,
     pub has_vega: i32,
+    pub used_rate_approximation: i32,
 }
 
 #[repr(C)]

--- a/crates/mango-option-sys/tests/layout.rs
+++ b/crates/mango-option-sys/tests/layout.rs
@@ -31,6 +31,7 @@ fn small_struct_layouts() {
     assert_eq!(offset_of!(MangoError, message), 4);
     assert_eq!(size_of::<MangoIvSuccess>(), 40);
     assert_eq!(offset_of!(MangoIvSuccess, has_vega), 32);
+    assert_eq!(offset_of!(MangoIvSuccess, used_rate_approximation), 36);
     assert_eq!(size_of::<MangoIvConfig>(), 16);
     assert_eq!(offset_of!(MangoIvConfig, max_iter), 8);
 }

--- a/crates/mango-option-sys/tests/layout.rs
+++ b/crates/mango-option-sys/tests/layout.rs
@@ -35,3 +35,71 @@ fn small_struct_layouts() {
     assert_eq!(size_of::<MangoIvConfig>(), 16);
     assert_eq!(offset_of!(MangoIvConfig, max_iter), 8);
 }
+
+#[test]
+fn interp_solver_config_layout() {
+    assert_eq!(size_of::<MangoInterpSolverConfig>(), 40);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, max_iter), 0);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, tolerance), 8);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, sigma_min), 16);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, sigma_max), 24);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, vega_threshold), 32);
+}
+
+#[test]
+fn adaptive_grid_params_layout() {
+    assert_eq!(size_of::<MangoAdaptiveGridParams>(), 72);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, target_iv_error), 0);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, max_iter), 8);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, max_points_per_dim), 16);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, min_moneyness_points), 24);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, validation_samples), 32);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, refinement_factor), 40);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, lhs_seed), 48);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, vega_floor), 56);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, max_failure_rate), 64);
+}
+
+#[test]
+fn multi_kref_layout() {
+    assert_eq!(size_of::<MangoMultiKRef>(), 32);
+    assert_eq!(offset_of!(MangoMultiKRef, K_refs), 0);
+    assert_eq!(offset_of!(MangoMultiKRef, n_K_refs), 8);
+    assert_eq!(offset_of!(MangoMultiKRef, K_ref_count), 16);
+    assert_eq!(offset_of!(MangoMultiKRef, K_ref_span), 24);
+}
+
+#[test]
+fn discrete_dividend_config_layout() {
+    assert_eq!(size_of::<MangoDiscreteDividendConfig>(), 56);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, maturity), 0);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, dividends), 8);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, n_dividends), 16);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, kref_config), 24);
+}
+
+#[test]
+fn iv_factory_config_layout() {
+    assert_eq!(size_of::<MangoIvFactoryConfig>(), 144);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, option_type), 0);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, spot), 8);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, dividend_yield), 16);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, moneyness), 24);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_moneyness), 32);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, vol), 40);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_vol), 48);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, rate), 56);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_rate), 64);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, maturity_grid), 72);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_maturity), 80);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, solver_config), 88);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, adaptive), 128);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, discrete_dividends), 136);
+}
+
+#[test]
+fn iv_batch_slot_layout() {
+    assert_eq!(size_of::<MangoIvBatchSlot>(), 48);
+    assert_eq!(offset_of!(MangoIvBatchSlot, status), 0);
+    assert_eq!(offset_of!(MangoIvBatchSlot, success), 8);
+}

--- a/crates/mango-option/BUILD.bazel
+++ b/crates/mango-option/BUILD.bazel
@@ -9,6 +9,7 @@ rust_library(
         "src/iv.rs",
         "src/lib.rs",
         "src/pricing.rs",
+        "src/table.rs",
         "src/types.rs",
     ],
     edition = "2021",

--- a/crates/mango-option/BUILD.bazel
+++ b/crates/mango-option/BUILD.bazel
@@ -5,6 +5,7 @@ rust_library(
     name = "mango_option",
     srcs = [
         "src/error.rs",
+        "src/interp.rs",
         "src/iv.rs",
         "src/lib.rs",
         "src/pricing.rs",
@@ -18,6 +19,13 @@ rust_library(
 rust_test(
     name = "integration_test",
     srcs = ["tests/integration.rs"],
+    edition = "2021",
+    deps = [":mango_option"],
+)
+
+rust_test(
+    name = "interpolation_test",
+    srcs = ["tests/interpolation.rs"],
     edition = "2021",
     deps = [":mango_option"],
 )

--- a/crates/mango-option/src/interp.rs
+++ b/crates/mango-option/src/interp.rs
@@ -178,23 +178,24 @@ impl InterpIvSolver {
     }
 
     pub fn solve_batch(&self, queries: &[IvQuery]) -> BatchResult {
-        // Build C queries; keep their backing arrays alive until the call returns.
+        // Per-query failures are isolated to their slot (a bad query does not
+        // fail the whole batch). Rust-side conversion errors (e.g. an empty
+        // yield curve, which would otherwise silently become rate 0 at the C
+        // boundary) are recorded per-slot here; C-side build/solve failures are
+        // recorded per-slot by the shim.
+        let mut results: Vec<Option<Result<IvSuccess, Error>>> =
+            (0..queries.len()).map(|_| None).collect();
         let mut c_queries = Vec::with_capacity(queries.len());
         let mut keepalive = Vec::with_capacity(queries.len());
-        for q in queries {
+        let mut valid_idx = Vec::with_capacity(queries.len()); // original index per c_query
+        for (i, q) in queries.iter().enumerate() {
             match iv_query_to_c(q) {
                 Ok((c, keep)) => {
                     c_queries.push(c);
                     keepalive.push(keep);
+                    valid_idx.push(i);
                 }
-                Err(e) => {
-                    // A structurally-invalid query fails the whole batch up front,
-                    // mirroring the shim's per-query build validation.
-                    return BatchResult {
-                        results: queries.iter().map(|_| Err(e.clone())).collect(),
-                        failed: queries.len(),
-                    };
-                }
+                Err(e) => results[i] = Some(Err(e)),
             }
         }
         let n = c_queries.len() as u64;
@@ -216,24 +217,27 @@ impl InterpIvSolver {
         // keepalive must outlive the FFI call above.
         let _ = &keepalive;
         if status != sys::MANGO_OK {
+            // Whole-call failure (e.g. null handle): mark every still-pending
+            // (successfully-converted) slot with the error.
             let e = Error::from_c(status, &err);
-            return BatchResult {
-                results: queries.iter().map(|_| Err(e.clone())).collect(),
-                failed: queries.len(),
-            };
-        }
-        let results = slots
-            .iter()
-            .map(|s| {
-                if s.status == sys::MANGO_OK {
+            for &i in &valid_idx {
+                results[i] = Some(Err(e.clone()));
+            }
+        } else {
+            for (k, &i) in valid_idx.iter().enumerate() {
+                let s = &slots[k];
+                results[i] = Some(if s.status == sys::MANGO_OK {
                     Ok(iv_success_from_c(&s.success))
                 } else {
                     Err(Error { kind: ErrorKind::from_status(s.status),
                                 message: batch_error_message(s.status) })
-                }
-            })
-            .collect();
-        BatchResult { results, failed: failed as usize }
+                });
+            }
+        }
+        let results: Vec<Result<IvSuccess, Error>> =
+            results.into_iter().map(|r| r.expect("every slot resolved")).collect();
+        let failed = results.iter().filter(|r| r.is_err()).count();
+        BatchResult { results, failed }
     }
 }
 

--- a/crates/mango-option/src/interp.rs
+++ b/crates/mango-option/src/interp.rs
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: MIT
+use crate::error::{Error, ErrorKind};
+use crate::iv::{IvQuery, IvSuccess};
+use crate::pricing::{blank_error, div_ptr_or_null, dividend_array, ptr_or_null, tenor_array};
+use crate::types::{Dividend, OptionType, Rate};
+use mango_option_sys as sys;
+
+/// IV grid axes (S/K moneyness, NOT log). Default mirrors the C++ IVGrid.
+#[derive(Debug, Clone)]
+pub struct IvGrid {
+    pub moneyness: Vec<f64>,
+    pub vol: Vec<f64>,
+    pub rate: Vec<f64>,
+}
+impl Default for IvGrid {
+    fn default() -> Self {
+        IvGrid {
+            moneyness: vec![0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3],
+            vol: vec![0.05, 0.10, 0.20, 0.30, 0.50],
+            rate: vec![0.01, 0.03, 0.05, 0.10],
+        }
+    }
+}
+
+/// Newton config for the interpolated solver. Default mirrors C++ defaults.
+#[derive(Debug, Clone, Copy)]
+pub struct InterpSolverConfig {
+    pub max_iter: usize,
+    pub tolerance: f64,
+    pub sigma_min: f64,
+    pub sigma_max: f64,
+    pub vega_threshold: f64,
+}
+impl Default for InterpSolverConfig {
+    fn default() -> Self {
+        InterpSolverConfig {
+            max_iter: 50,
+            tolerance: 1e-6,
+            sigma_min: 0.01,
+            sigma_max: 3.0,
+            vega_threshold: 1e-4,
+        }
+    }
+}
+impl InterpSolverConfig {
+    pub(crate) fn to_c(self) -> sys::MangoInterpSolverConfig {
+        sys::MangoInterpSolverConfig {
+            max_iter: self.max_iter as u64,
+            tolerance: self.tolerance,
+            sigma_min: self.sigma_min,
+            sigma_max: self.sigma_max,
+            vega_threshold: self.vega_threshold,
+        }
+    }
+}
+
+/// Adaptive grid refinement params. Default mirrors C++ defaults.
+#[derive(Debug, Clone, Copy)]
+pub struct AdaptiveGridParams {
+    pub target_iv_error: f64,
+    pub max_iter: usize,
+    pub max_points_per_dim: usize,
+    pub min_moneyness_points: usize,
+    pub validation_samples: usize,
+    pub refinement_factor: f64,
+    pub lhs_seed: u64,
+    pub vega_floor: f64,
+    pub max_failure_rate: f64,
+}
+impl Default for AdaptiveGridParams {
+    fn default() -> Self {
+        AdaptiveGridParams {
+            target_iv_error: 2e-5,
+            max_iter: 5,
+            max_points_per_dim: 160,
+            min_moneyness_points: 60,
+            validation_samples: 64,
+            refinement_factor: 1.3,
+            lhs_seed: 42,
+            vega_floor: 1e-4,
+            max_failure_rate: 0.5,
+        }
+    }
+}
+impl AdaptiveGridParams {
+    fn to_c(&self) -> sys::MangoAdaptiveGridParams {
+        sys::MangoAdaptiveGridParams {
+            target_iv_error: self.target_iv_error,
+            max_iter: self.max_iter as u64,
+            max_points_per_dim: self.max_points_per_dim as u64,
+            min_moneyness_points: self.min_moneyness_points as u64,
+            validation_samples: self.validation_samples as u64,
+            refinement_factor: self.refinement_factor,
+            lhs_seed: self.lhs_seed,
+            vega_floor: self.vega_floor,
+            max_failure_rate: self.max_failure_rate,
+        }
+    }
+}
+
+/// Multi reference-strike config for the discrete-dividend path.
+#[derive(Debug, Clone)]
+pub struct MultiKRef {
+    pub k_refs: Vec<f64>,
+    pub k_ref_count: i32,
+    pub k_ref_span: f64,
+}
+impl Default for MultiKRef {
+    fn default() -> Self {
+        MultiKRef { k_refs: Vec::new(), k_ref_count: 11, k_ref_span: 0.3 }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscreteDividendConfig {
+    pub maturity: f64,
+    pub dividends: Vec<Dividend>,
+    pub kref_config: MultiKRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactoryConfig {
+    pub option_type: OptionType,
+    pub spot: f64,
+    pub dividend_yield: f64,
+    pub grid: IvGrid,
+    pub maturity_grid: Vec<f64>,
+    pub solver: InterpSolverConfig,
+    pub adaptive: Option<AdaptiveGridParams>,
+    pub discrete_dividends: Option<DiscreteDividendConfig>,
+}
+
+/// Result of a batch solve: per-query results plus the failure count.
+#[derive(Debug)]
+pub struct BatchResult {
+    pub results: Vec<Result<IvSuccess, Error>>,
+    pub failed: usize,
+}
+
+/// Interpolated IV solver over a pre-built B-spline surface. Thread-safe to
+/// query concurrently (immutable surface).
+pub struct InterpIvSolver {
+    handle: *mut sys::MangoInterpIvSolver,
+}
+// SAFETY: the C++ AnyInterpIVSolver wraps an immutable surface; solve()/
+// solve_batch() are const and documented thread-safe.
+unsafe impl Send for InterpIvSolver {}
+unsafe impl Sync for InterpIvSolver {}
+
+impl core::fmt::Debug for InterpIvSolver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "InterpIvSolver({:p})", self.handle)
+    }
+}
+
+impl InterpIvSolver {
+    pub fn new(cfg: &FactoryConfig) -> Result<Self, Error> {
+        Ok(InterpIvSolver { handle: make_factory_handle(cfg)? })
+    }
+
+    /// Wrap a raw solver handle (e.g. one derived from a `PriceTable`). The
+    /// returned `InterpIvSolver` takes ownership and frees it on drop.
+    pub(crate) fn from_raw(handle: *mut sys::MangoInterpIvSolver) -> Self {
+        InterpIvSolver { handle }
+    }
+
+    pub fn solve(&self, query: &IvQuery) -> Result<IvSuccess, Error> {
+        let (c, _keep) = iv_query_to_c(query)?;
+        let mut out = blank_iv_success();
+        let mut err = blank_error();
+        let status =
+            unsafe { sys::mango_interp_iv_solve(self.handle, &c, &mut out, &mut err) };
+        if status == sys::MANGO_OK {
+            Ok(iv_success_from_c(&out))
+        } else {
+            Err(Error::from_c(status, &err))
+        }
+    }
+
+    pub fn solve_batch(&self, queries: &[IvQuery]) -> BatchResult {
+        // Build C queries; keep their backing arrays alive until the call returns.
+        let mut c_queries = Vec::with_capacity(queries.len());
+        let mut keepalive = Vec::with_capacity(queries.len());
+        for q in queries {
+            match iv_query_to_c(q) {
+                Ok((c, keep)) => {
+                    c_queries.push(c);
+                    keepalive.push(keep);
+                }
+                Err(e) => {
+                    // A structurally-invalid query fails the whole batch up front,
+                    // mirroring the shim's per-query build validation.
+                    return BatchResult {
+                        results: queries.iter().map(|_| Err(e.clone())).collect(),
+                        failed: queries.len(),
+                    };
+                }
+            }
+        }
+        let n = c_queries.len() as u64;
+        let mut slots: Vec<sys::MangoIvBatchSlot> = (0..c_queries.len())
+            .map(|_| sys::MangoIvBatchSlot { status: 0, success: blank_iv_success() })
+            .collect();
+        let mut failed: u64 = 0;
+        let mut err = blank_error();
+        let status = unsafe {
+            sys::mango_interp_iv_solve_batch(
+                self.handle,
+                if c_queries.is_empty() { core::ptr::null() } else { c_queries.as_ptr() },
+                n,
+                if slots.is_empty() { core::ptr::null_mut() } else { slots.as_mut_ptr() },
+                &mut failed,
+                &mut err,
+            )
+        };
+        // keepalive must outlive the FFI call above.
+        let _ = &keepalive;
+        if status != sys::MANGO_OK {
+            let e = Error::from_c(status, &err);
+            return BatchResult {
+                results: queries.iter().map(|_| Err(e.clone())).collect(),
+                failed: queries.len(),
+            };
+        }
+        let results = slots
+            .iter()
+            .map(|s| {
+                if s.status == sys::MANGO_OK {
+                    Ok(iv_success_from_c(&s.success))
+                } else {
+                    Err(Error { kind: ErrorKind::from_status(s.status),
+                                message: batch_error_message(s.status) })
+                }
+            })
+            .collect();
+        BatchResult { results, failed: failed as usize }
+    }
+}
+
+impl Drop for InterpIvSolver {
+    fn drop(&mut self) {
+        unsafe { sys::mango_interp_iv_solver_free(self.handle) }
+    }
+}
+
+// --- shared helpers used by interp.rs and table.rs ---
+
+pub(crate) fn blank_iv_success() -> sys::MangoIvSuccess {
+    sys::MangoIvSuccess {
+        implied_vol: 0.0, iterations: 0, final_error: 0.0,
+        vega: 0.0, has_vega: 0, used_rate_approximation: 0,
+    }
+}
+
+pub(crate) fn iv_success_from_c(out: &sys::MangoIvSuccess) -> IvSuccess {
+    IvSuccess {
+        implied_vol: out.implied_vol,
+        iterations: out.iterations as usize,
+        final_error: out.final_error,
+        vega: if out.has_vega != 0 { Some(out.vega) } else { None },
+        used_rate_approximation: out.used_rate_approximation != 0,
+    }
+}
+
+fn batch_error_message(status: i32) -> String {
+    format!("interpolated IV solve failed ({})", ErrorKind::from_status(status))
+}
+
+// Backing arrays that must outlive an FFI call referencing their pointers.
+pub(crate) struct IvQueryKeepalive {
+    _tenors: Vec<sys::MangoTenorPoint>,
+    _divs: Vec<sys::MangoDividend>,
+}
+
+pub(crate) fn iv_query_to_c(
+    query: &IvQuery,
+) -> Result<(sys::MangoIvQuery, IvQueryKeepalive), Error> {
+    if matches!(&query.spec.rate, Rate::Curve(v) if v.is_empty()) {
+        return Err(Error { kind: ErrorKind::Validation,
+                           message: "yield curve has no tenor points".to_string() });
+    }
+    let tenors = tenor_array(&query.spec.rate);
+    let divs = dividend_array(&query.spec.discrete_dividends);
+    let rate_const = match query.spec.rate {
+        Rate::Const(r) => r,
+        Rate::Curve(_) => 0.0,
+    };
+    let c = sys::MangoIvQuery {
+        spot: query.spec.spot,
+        strike: query.spec.strike,
+        maturity: query.spec.maturity,
+        dividend_yield: query.spec.dividend_yield,
+        market_price: query.market_price,
+        rate_const,
+        tenor_points: ptr_or_null(&tenors),
+        n_tenor_points: tenors.len() as u64,
+        dividends: div_ptr_or_null(&divs),
+        n_dividends: divs.len() as u64,
+        option_type: query.spec.option_type.to_c(),
+    };
+    Ok((c, IvQueryKeepalive { _tenors: tenors, _divs: divs }))
+}
+
+// Build the C factory config, keeping every Vec alive across the FFI call,
+// then invoke `f` with a pointer to the config and the error out-param.
+pub(crate) fn with_c_config<T>(
+    cfg: &FactoryConfig,
+    f: impl FnOnce(*const sys::MangoIvFactoryConfig, *mut sys::MangoError) -> (i32, T),
+) -> Result<T, Error> {
+    let moneyness = cfg.grid.moneyness.clone();
+    let vol = cfg.grid.vol.clone();
+    let rate = cfg.grid.rate.clone();
+    let maturity = cfg.maturity_grid.clone();
+
+    let adaptive_c = cfg.adaptive.as_ref().map(|a| a.to_c());
+    // Discrete-dividend sub-config: keep its Vecs alive too.
+    let dd = cfg.discrete_dividends.as_ref().map(|d| {
+        let divs = dividend_array(&d.dividends);
+        let krefs = d.kref_config.k_refs.clone();
+        let c = sys::MangoDiscreteDividendConfig {
+            maturity: d.maturity,
+            dividends: div_ptr_or_null(&divs),
+            n_dividends: divs.len() as u64,
+            kref_config: sys::MangoMultiKRef {
+                K_refs: if krefs.is_empty() { core::ptr::null() } else { krefs.as_ptr() },
+                n_K_refs: krefs.len() as u64,
+                K_ref_count: d.kref_config.k_ref_count,
+                K_ref_span: d.kref_config.k_ref_span,
+            },
+        };
+        (c, divs, krefs)
+    });
+
+    let f64_ptr = |v: &[f64]| if v.is_empty() { core::ptr::null() } else { v.as_ptr() };
+
+    let c = sys::MangoIvFactoryConfig {
+        option_type: cfg.option_type.to_c(),
+        spot: cfg.spot,
+        dividend_yield: cfg.dividend_yield,
+        moneyness: f64_ptr(&moneyness),
+        n_moneyness: moneyness.len() as u64,
+        vol: f64_ptr(&vol),
+        n_vol: vol.len() as u64,
+        rate: f64_ptr(&rate),
+        n_rate: rate.len() as u64,
+        maturity_grid: f64_ptr(&maturity),
+        n_maturity: maturity.len() as u64,
+        solver_config: cfg.solver.to_c(),
+        adaptive: adaptive_c.as_ref().map_or(core::ptr::null(), |a| a as *const _),
+        discrete_dividends: dd.as_ref().map_or(core::ptr::null(), |(c, _, _)| c as *const _),
+    };
+
+    let mut err = blank_error();
+    let (status, value) = f(&c, &mut err);
+    // keepalive: moneyness/vol/rate/maturity/adaptive_c/dd live until here.
+    let _ = (&moneyness, &vol, &rate, &maturity, &adaptive_c, &dd);
+    if status == sys::MANGO_OK {
+        Ok(value)
+    } else {
+        Err(Error::from_c(status, &err))
+    }
+}
+
+pub(crate) fn make_factory_handle(
+    cfg: &FactoryConfig,
+) -> Result<*mut sys::MangoInterpIvSolver, Error> {
+    let mut handle: *mut sys::MangoInterpIvSolver = core::ptr::null_mut();
+    with_c_config(cfg, |c, err| unsafe {
+        (sys::mango_make_interp_iv_solver(c, &mut handle, err), handle)
+    })
+}
+
+pub(crate) fn make_price_table_handle(
+    cfg: &FactoryConfig,
+) -> Result<*mut sys::MangoPriceTable, Error> {
+    let mut handle: *mut sys::MangoPriceTable = core::ptr::null_mut();
+    with_c_config(cfg, |c, err| unsafe {
+        (sys::mango_make_price_table(c, &mut handle, err), handle)
+    })
+}

--- a/crates/mango-option/src/iv.rs
+++ b/crates/mango-option/src/iv.rs
@@ -21,6 +21,7 @@ pub struct IvSuccess {
     pub iterations: usize,
     pub final_error: f64,
     pub vega: Option<f64>,
+    pub used_rate_approximation: bool,
 }
 
 pub fn solve_iv(query: &IvQuery, config: &IvConfig) -> Result<IvSuccess, Error> {
@@ -57,6 +58,7 @@ pub fn solve_iv(query: &IvQuery, config: &IvConfig) -> Result<IvSuccess, Error> 
         final_error: 0.0,
         vega: 0.0,
         has_vega: 0,
+        used_rate_approximation: 0,
     };
     let mut err = blank_error();
     let status = unsafe { sys::mango_solve_iv(&c, &cfg, &mut out, &mut err) };
@@ -66,6 +68,7 @@ pub fn solve_iv(query: &IvQuery, config: &IvConfig) -> Result<IvSuccess, Error> 
             iterations: out.iterations as usize,
             final_error: out.final_error,
             vega: if out.has_vega != 0 { Some(out.vega) } else { None },
+            used_rate_approximation: out.used_rate_approximation != 0,
         })
     } else {
         Err(Error::from_c(status, &err))

--- a/crates/mango-option/src/lib.rs
+++ b/crates/mango-option/src/lib.rs
@@ -2,11 +2,16 @@
 //! Safe Rust bindings for the mango-option American option pricer and FDM
 //! implied-vol solver. Callers write no `unsafe`.
 mod error;
+mod interp;
 mod iv;
 mod pricing;
 mod types;
 
 pub use error::{Error, ErrorKind};
+pub use interp::{
+    AdaptiveGridParams, BatchResult, DiscreteDividendConfig, FactoryConfig, InterpIvSolver,
+    InterpSolverConfig, IvGrid, MultiKRef,
+};
 pub use iv::{solve_iv, IvConfig, IvQuery, IvSuccess};
 pub use pricing::{price_american, PriceResult, PricingParams};
 pub use types::{Dividend, OptionSpec, OptionType, Rate, TenorPoint};

--- a/crates/mango-option/src/lib.rs
+++ b/crates/mango-option/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod interp;
 mod iv;
 mod pricing;
+mod table;
 mod types;
 
 pub use error::{Error, ErrorKind};
@@ -14,4 +15,5 @@ pub use interp::{
 };
 pub use iv::{solve_iv, IvConfig, IvQuery, IvSuccess};
 pub use pricing::{price_american, PriceResult, PricingParams};
+pub use table::PriceTable;
 pub use types::{Dividend, OptionSpec, OptionType, Rate, TenorPoint};

--- a/crates/mango-option/src/pricing.rs
+++ b/crates/mango-option/src/pricing.rs
@@ -51,11 +51,33 @@ impl Drop for PriceResult {
 }
 
 pub fn price_american(params: &PricingParams) -> Result<PriceResult, Error> {
+    let (c, _keep) = pricing_params_to_c(params)?;
+    let mut handle: *mut sys::MangoAmericanResult = core::ptr::null_mut();
+    let mut err = blank_error();
+    let status = unsafe { sys::mango_price_american(&c, &mut handle, &mut err) };
+    // keepalive must outlive the FFI call above.
+    let _ = &_keep;
+    if status == sys::MANGO_OK {
+        Ok(PriceResult { handle })
+    } else {
+        Err(Error::from_c(status, &err))
+    }
+}
+
+// Backing arrays that must outlive an FFI call referencing the pointers in the
+// returned `MangoPricingParams` (mirrors `IvQueryKeepalive` in interp.rs).
+pub(crate) struct PricingKeepalive {
+    _tenors: Vec<sys::MangoTenorPoint>,
+    _divs: Vec<sys::MangoDividend>,
+}
+
+pub(crate) fn pricing_params_to_c(
+    params: &PricingParams,
+) -> Result<(sys::MangoPricingParams, PricingKeepalive), Error> {
     if matches!(&params.spec.rate, Rate::Curve(v) if v.is_empty()) {
         return Err(Error { kind: ErrorKind::Validation,
                            message: "yield curve has no tenor points".to_string() });
     }
-    // Keep arrays alive for the duration of the call.
     let tenors = tenor_array(&params.spec.rate);
     let divs = dividend_array(&params.spec.discrete_dividends);
     let rate_const = match params.spec.rate {
@@ -75,14 +97,7 @@ pub fn price_american(params: &PricingParams) -> Result<PriceResult, Error> {
         n_dividends: divs.len() as u64,
         option_type: params.spec.option_type.to_c(),
     };
-    let mut handle: *mut sys::MangoAmericanResult = core::ptr::null_mut();
-    let mut err = blank_error();
-    let status = unsafe { sys::mango_price_american(&c, &mut handle, &mut err) };
-    if status == sys::MANGO_OK {
-        Ok(PriceResult { handle })
-    } else {
-        Err(Error::from_c(status, &err))
-    }
+    Ok((c, PricingKeepalive { _tenors: tenors, _divs: divs }))
 }
 
 // --- shared marshalling helpers (also used by iv.rs) ---

--- a/crates/mango-option/src/table.rs
+++ b/crates/mango-option/src/table.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+use crate::error::Error;
+use crate::interp::{make_price_table_handle, FactoryConfig, InterpIvSolver, InterpSolverConfig};
+use crate::pricing::{blank_error, pricing_params_to_c, PricingParams};
+use crate::types::OptionType;
+use mango_option_sys as sys;
+
+/// A reusable, immutable B-spline price surface. Thread-safe to query.
+pub struct PriceTable {
+    handle: *mut sys::MangoPriceTable,
+}
+// SAFETY: the C++ AnyPriceTable wraps an immutable surface; all query methods
+// are const and documented thread-safe.
+unsafe impl Send for PriceTable {}
+unsafe impl Sync for PriceTable {}
+
+impl core::fmt::Debug for PriceTable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "PriceTable({:p})", self.handle)
+    }
+}
+
+impl PriceTable {
+    pub fn new(cfg: &FactoryConfig) -> Result<Self, Error> {
+        Ok(PriceTable { handle: make_price_table_handle(cfg)? })
+    }
+
+    /// Opt-in bounds check; out-of-domain params => Err. `price`/`vega` do NOT
+    /// call this and will extrapolate.
+    pub fn validate(&self, params: &PricingParams) -> Result<(), Error> {
+        let (c, _keep) = pricing_params_to_c(params)?;
+        let mut err = blank_error();
+        let status = unsafe { sys::mango_price_table_validate(self.handle, &c, &mut err) };
+        let _ = &_keep;
+        if status == sys::MANGO_OK { Ok(()) } else { Err(Error::from_c(status, &err)) }
+    }
+
+    /// Interpolated price. Extrapolates out of the surface domain; returns NaN
+    /// only on an internal failure. Call `validate` first if you need bounds.
+    pub fn price(&self, params: &PricingParams) -> f64 {
+        match pricing_params_to_c(params) {
+            Ok((c, _keep)) => {
+                let v = unsafe { sys::mango_price_table_price(self.handle, &c) };
+                let _ = &_keep;
+                v
+            }
+            Err(_) => f64::NAN,
+        }
+    }
+    pub fn vega(&self, params: &PricingParams) -> f64 {
+        match pricing_params_to_c(params) {
+            Ok((c, _keep)) => {
+                let v = unsafe { sys::mango_price_table_vega(self.handle, &c) };
+                let _ = &_keep;
+                v
+            }
+            Err(_) => f64::NAN,
+        }
+    }
+
+    pub fn delta(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_delta)
+    }
+    pub fn gamma(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_gamma)
+    }
+    pub fn theta(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_theta)
+    }
+    pub fn rho(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_rho)
+    }
+
+    fn greek(
+        &self,
+        params: &PricingParams,
+        f: unsafe extern "C" fn(*const sys::MangoPriceTable, *const sys::MangoPricingParams,
+                                *mut f64, *mut sys::MangoError) -> sys::MangoStatus,
+    ) -> Result<f64, Error> {
+        let (c, _keep) = pricing_params_to_c(params)?;
+        let mut out = 0.0;
+        let mut err = blank_error();
+        let status = unsafe { f(self.handle, &c, &mut out, &mut err) };
+        let _ = &_keep;
+        if status == sys::MANGO_OK { Ok(out) } else { Err(Error::from_c(status, &err)) }
+    }
+
+    pub fn option_type(&self) -> OptionType {
+        let t = unsafe { sys::mango_price_table_option_type(self.handle) };
+        if t == sys::MANGO_CALL { OptionType::Call } else { OptionType::Put }
+    }
+    pub fn dividend_yield(&self) -> f64 {
+        unsafe { sys::mango_price_table_dividend_yield(self.handle) }
+    }
+
+    /// Derive an IV solver from this already-built surface (no rebuild).
+    pub fn iv_solver(&self, cfg: Option<&InterpSolverConfig>) -> Result<InterpIvSolver, Error> {
+        let c = cfg.map(|c| c.to_c());
+        let mut handle: *mut sys::MangoInterpIvSolver = core::ptr::null_mut();
+        let mut err = blank_error();
+        let status = unsafe {
+            sys::mango_price_table_make_iv_solver(
+                self.handle,
+                c.as_ref().map_or(core::ptr::null(), |c| c as *const _),
+                &mut handle,
+                &mut err,
+            )
+        };
+        if status == sys::MANGO_OK {
+            Ok(InterpIvSolver::from_raw(handle))
+        } else {
+            Err(Error::from_c(status, &err))
+        }
+    }
+}
+
+impl Drop for PriceTable {
+    fn drop(&mut self) {
+        unsafe { sys::mango_price_table_free(self.handle) }
+    }
+}

--- a/crates/mango-option/tests/interpolation.rs
+++ b/crates/mango-option/tests/interpolation.rs
@@ -127,3 +127,44 @@ fn solver_is_send_sync() {
     }).collect();
     for h in handles { assert!(h.join().unwrap().is_ok()); }
 }
+
+use mango_option::{PriceTable, PricingParams};
+
+#[test]
+fn price_table_queries() {
+    let table = PriceTable::new(&base_config()).expect("build table");
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(0.03), discrete_dividends: vec![], option_type: OptionType::Put,
+    };
+    let pp = PricingParams { spec: spec.clone(), volatility: 0.25 };
+    let price = table.price(&pp);
+    assert!(price.is_finite() && price > 0.0);
+    assert!(table.vega(&pp).is_finite());
+    let delta = table.delta(&pp).expect("delta");
+    assert!(delta < 0.0, "put delta should be negative: {}", delta);
+    assert!(table.gamma(&pp).is_ok());
+    assert!(table.theta(&pp).is_ok());
+    assert!(table.rho(&pp).is_ok());
+    assert_eq!(table.option_type(), OptionType::Put);
+
+    // Reference FDM price for sanity (interpolation tolerance is loose).
+    let fdm = price_american(&pp).unwrap().value();
+    assert!((price - fdm).abs() < 0.5, "interp {} vs fdm {}", price, fdm);
+
+    // Opt-in validation.
+    assert!(table.validate(&pp).is_ok());
+    let oob = PricingParams { spec, volatility: 5.0 }; // far outside vol grid
+    assert!(table.validate(&oob).is_err());
+}
+
+#[test]
+fn price_table_derives_iv_solver() {
+    let table = PriceTable::new(&base_config()).unwrap();
+    let solver = table.iv_solver(None).expect("derive solver");
+    let (spec, sigma) = put_spec(0.25);
+    let pp = PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let r = solver.solve(&IvQuery { spec, market_price: price }).expect("solve");
+    assert!((r.implied_vol - sigma).abs() < 1e-2);
+}

--- a/crates/mango-option/tests/interpolation.rs
+++ b/crates/mango-option/tests/interpolation.rs
@@ -202,6 +202,30 @@ fn interp_solve_non_finite_rate_is_validation_error() {
     assert_eq!(err.kind, mango_option::ErrorKind::Validation);
 }
 
+// Regression: an invalid-input query in a batch must fail only its own slot,
+// not abort the whole batch.
+// Bug: a per-query build failure (e.g. non-finite rate) returned a top-level
+// MANGO_ERR_VALIDATION, so the Rust wrapper marked every slot failed. Fix:
+// per-slot build failures in mango_interp_iv_solve_batch + Rust solve_batch.
+#[test]
+fn batch_isolates_invalid_input() {
+    let solver = InterpIvSolver::new(&base_config()).unwrap();
+    let (good_spec, sigma) = put_spec(0.25);
+    let pp = PricingParams { spec: good_spec.clone(), volatility: sigma };
+    let good_price = price_american(&pp).unwrap().value();
+    let good = IvQuery { spec: good_spec, market_price: good_price };
+    let bad_spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(f64::NAN), discrete_dividends: vec![], option_type: OptionType::Put,
+    };
+    let bad = IvQuery { spec: bad_spec, market_price: 5.0 };
+    let batch = solver.solve_batch(&[good, bad]);
+    assert_eq!(batch.failed, 1);
+    assert!(batch.results[0].is_ok(), "valid query should still solve");
+    assert_eq!(batch.results[1].as_ref().unwrap_err().kind,
+               mango_option::ErrorKind::Validation);
+}
+
 // Regression: option-type mismatch against the surface must map to Validation.
 // Bug: map_iv_error lacked arms for the interpolated solver's validation codes
 // (OptionTypeMismatch/InvalidGridConfig/DividendYieldMismatch), so they fell

--- a/crates/mango-option/tests/interpolation.rs
+++ b/crates/mango-option/tests/interpolation.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+use mango_option::{
+    price_american, AdaptiveGridParams, DiscreteDividendConfig, Dividend, FactoryConfig,
+    InterpIvSolver, InterpSolverConfig, IvGrid, IvQuery, MultiKRef, OptionSpec, OptionType, Rate,
+};
+
+fn base_config() -> FactoryConfig {
+    FactoryConfig {
+        option_type: OptionType::Put,
+        spot: 100.0,
+        dividend_yield: 0.0,
+        grid: IvGrid {
+            // Each axis needs >= 4 points for the cubic B-spline builder.
+            moneyness: vec![0.8, 0.9, 1.0, 1.1, 1.2],
+            vol: vec![0.10, 0.20, 0.30, 0.40],
+            rate: vec![0.01, 0.03, 0.05, 0.07],
+        },
+        // >= 4 maturity points: the B-spline builder requires at least 4
+        // control points per axis (axis 1 is the maturity grid).
+        maturity_grid: vec![0.25, 0.5, 0.75, 1.0],
+        solver: InterpSolverConfig::default(),
+        adaptive: None,
+        discrete_dividends: None,
+    }
+}
+
+fn put_spec(sigma: f64) -> (OptionSpec, f64) {
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(0.03), discrete_dividends: vec![], option_type: OptionType::Put,
+    };
+    (spec, sigma)
+}
+
+#[test]
+fn iv_round_trip_continuous() {
+    let solver = InterpIvSolver::new(&base_config()).expect("build solver");
+    let (spec, sigma) = put_spec(0.25);
+    // Reference price from the FDM path at the true sigma.
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let q = IvQuery { spec, market_price: price };
+    let r = solver.solve(&q).expect("solve iv");
+    assert!((r.implied_vol - sigma).abs() < 1e-2, "iv={} sigma={}", r.implied_vol, sigma);
+}
+
+#[test]
+fn batch_with_one_failure() {
+    let solver = InterpIvSolver::new(&base_config()).unwrap();
+    let (spec, sigma) = put_spec(0.25);
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let good_price = price_american(&pp).unwrap().value();
+    let good = IvQuery { spec: spec.clone(), market_price: good_price };
+    // Arbitrage-violating price (above strike for a put) => solve failure.
+    let bad = IvQuery { spec, market_price: 1_000.0 };
+    let batch = solver.solve_batch(&[good, bad]);
+    assert_eq!(batch.failed, 1);
+    assert!(batch.results[0].is_ok());
+    assert!(batch.results[1].is_err());
+}
+
+#[test]
+fn adaptive_build_solves() {
+    let mut cfg = base_config();
+    cfg.adaptive = Some(AdaptiveGridParams {
+        target_iv_error: 1e-3, max_iter: 2, validation_samples: 16,
+        min_moneyness_points: 20, ..AdaptiveGridParams::default()
+    });
+    let solver = InterpIvSolver::new(&cfg).expect("adaptive build");
+    let (spec, sigma) = put_spec(0.25);
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let r = solver.solve(&IvQuery { spec, market_price: price }).expect("solve");
+    assert!((r.implied_vol - sigma).abs() < 2e-2);
+}
+
+#[test]
+fn discrete_dividend_build_solves() {
+    let mut cfg = base_config();
+    cfg.discrete_dividends = Some(DiscreteDividendConfig {
+        maturity: 1.0,
+        dividends: vec![Dividend { calendar_time: 0.5, amount: 2.0 }],
+        kref_config: MultiKRef { k_refs: vec![90.0, 100.0, 110.0], ..MultiKRef::default() },
+    });
+    let solver = InterpIvSolver::new(&cfg).expect("discrete build");
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(0.03),
+        discrete_dividends: vec![Dividend { calendar_time: 0.5, amount: 2.0 }],
+        option_type: OptionType::Put,
+    };
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: 0.25 };
+    let price = price_american(&pp).unwrap().value();
+    let r = solver.solve(&IvQuery { spec, market_price: price }).expect("solve");
+    assert!((r.implied_vol - 0.25).abs() < 3e-2, "iv={}", r.implied_vol);
+}
+
+#[test]
+fn empty_maturity_grid_continuous_is_validation_error() {
+    let mut cfg = base_config();
+    cfg.maturity_grid = vec![];
+    let err = InterpIvSolver::new(&cfg).unwrap_err();
+    assert_eq!(err.kind, mango_option::ErrorKind::Validation);
+}
+
+#[test]
+fn non_finite_spot_is_validation_error() {
+    let mut cfg = base_config();
+    cfg.spot = f64::NAN;
+    let err = InterpIvSolver::new(&cfg).unwrap_err();
+    assert_eq!(err.kind, mango_option::ErrorKind::Validation);
+}
+
+#[test]
+fn solver_is_send_sync() {
+    let solver = InterpIvSolver::new(&base_config()).unwrap();
+    let (spec, sigma) = put_spec(0.25);
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let s = std::sync::Arc::new(solver);
+    let handles: Vec<_> = (0..2).map(|_| {
+        let s = s.clone();
+        let spec = spec.clone();
+        std::thread::spawn(move || {
+            s.solve(&IvQuery { spec, market_price: price }).map(|r| r.implied_vol)
+        })
+    }).collect();
+    for h in handles { assert!(h.join().unwrap().is_ok()); }
+}

--- a/crates/mango-option/tests/interpolation.rs
+++ b/crates/mango-option/tests/interpolation.rs
@@ -168,3 +168,52 @@ fn price_table_derives_iv_solver() {
     let r = solver.solve(&IvQuery { spec, market_price: price }).expect("solve");
     assert!((r.implied_vol - sigma).abs() < 1e-2);
 }
+
+// ===========================================================================
+// Regression tests for bugs found during pre-merge (Codex) review
+// ===========================================================================
+
+// Regression: Greeks must reject out-of-domain queries, not extrapolate to Ok.
+// Bug: greek_call computed the Greek directly; the B-spline evaluator clamps/
+// extrapolates and returned Ok(value) for params outside the surface domain.
+// Fix: validate_pricing_params first in greek_call.
+#[test]
+fn greek_out_of_domain_is_validation_error() {
+    let table = PriceTable::new(&base_config()).unwrap();
+    let (spec, _) = put_spec(0.25);
+    // Volatility far outside the grid (max 0.40) -> out of domain.
+    let oob = PricingParams { spec, volatility: 5.0 };
+    let err = table.delta(&oob).unwrap_err();
+    assert_eq!(err.kind, mango_option::ErrorKind::Validation);
+}
+
+// Regression: a non-finite flat rate in an interpolated IV query must be a
+// validation error, not arbitrage/solver.
+// Bug: build_iv_query did no finite-input pre-validation, so the IV path mapped
+// invalid rate to ArbitrageViolation. Fix: pre-validate in build_iv_query.
+#[test]
+fn interp_solve_non_finite_rate_is_validation_error() {
+    let solver = InterpIvSolver::new(&base_config()).unwrap();
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(f64::NAN), discrete_dividends: vec![], option_type: OptionType::Put,
+    };
+    let err = solver.solve(&IvQuery { spec, market_price: 5.0 }).unwrap_err();
+    assert_eq!(err.kind, mango_option::ErrorKind::Validation);
+}
+
+// Regression: option-type mismatch against the surface must map to Validation.
+// Bug: map_iv_error lacked arms for the interpolated solver's validation codes
+// (OptionTypeMismatch/InvalidGridConfig/DividendYieldMismatch), so they fell
+// through to MANGO_ERR_SOLVER. Fix: add those arms to map_iv_error.
+#[test]
+fn interp_solve_option_type_mismatch_is_validation_error() {
+    // base_config builds a PUT surface; query with a CALL.
+    let solver = InterpIvSolver::new(&base_config()).unwrap();
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(0.03), discrete_dividends: vec![], option_type: OptionType::Call,
+    };
+    let err = solver.solve(&IvQuery { spec, market_price: 5.0 }).unwrap_err();
+    assert_eq!(err.kind, mango_option::ErrorKind::Validation);
+}

--- a/docs/RUST_GUIDE.md
+++ b/docs/RUST_GUIDE.md
@@ -161,6 +161,226 @@ let spec = OptionSpec {
 
 `calendar_time` is measured in years from today. Dividends must fall within `(0, maturity)`.
 
+## Interpolation path
+
+The interpolation path trades a one-time build cost for very fast repeated
+queries. You pre-compute a B-spline price surface over a grid of
+(moneyness, maturity, vol, rate), then either solve implied volatility against it
+(`InterpIvSolver`) or query prices and greeks directly (`PriceTable`). Both
+handles wrap an immutable surface and are `Send + Sync`, so you can share them
+across threads behind an `Arc`.
+
+Everything is driven by a single `FactoryConfig`:
+
+```rust
+use mango_option::{FactoryConfig, InterpSolverConfig, IvGrid, OptionType};
+
+let config = FactoryConfig {
+    option_type: OptionType::Put,
+    spot: 100.0,
+    dividend_yield: 0.0,
+    grid: IvGrid {
+        // S/K moneyness (NOT log). Each axis needs >= 4 points.
+        moneyness: vec![0.8, 0.9, 1.0, 1.1, 1.2],
+        vol: vec![0.10, 0.20, 0.30, 0.40],
+        rate: vec![0.01, 0.03, 0.05, 0.07],
+    },
+    // The maturity axis also needs >= 4 points.
+    maturity_grid: vec![0.25, 0.5, 0.75, 1.0],
+    solver: InterpSolverConfig::default(),
+    adaptive: None,
+    discrete_dividends: None,
+};
+```
+
+> **Grid-size constraint.** The cubic B-spline builder needs **at least 4 points
+> on every axis** — `grid.moneyness`, `grid.vol`, `grid.rate`, and
+> `maturity_grid`. A shorter axis fails the build with
+> `ErrorKind::Validation` (an `InvalidGridSize` on the C++ side). `IvGrid::default()`
+> already satisfies this; supply your own `maturity_grid`.
+
+### Interpolated IV solver
+
+Build an `InterpIvSolver` from the config, then call `solve` for a single query:
+
+```rust
+use mango_option::{InterpIvSolver, IvQuery, OptionSpec, OptionType, Rate};
+
+let solver = InterpIvSolver::new(&config)?;
+
+let spec = OptionSpec {
+    spot: 100.0,
+    strike: 100.0,
+    maturity: 1.0,
+    dividend_yield: 0.0,
+    rate: Rate::Const(0.03),
+    discrete_dividends: vec![],
+    option_type: OptionType::Put,
+};
+
+let query = IvQuery { spec, market_price: 5.40 };
+let iv = solver.solve(&query)?;
+
+println!("implied vol : {}", iv.implied_vol);
+println!("iterations  : {}", iv.iterations);
+if iv.used_rate_approximation {
+    // A yield-curve query was collapsed to a single flat rate to hit the
+    // surface; treat the result as approximate (see note below).
+    eprintln!("note: rate approximated to a flat value");
+}
+```
+
+`solve` returns the same `IvSuccess` as the FDM path, with one extra field:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `implied_vol` | `f64` | Solved implied volatility |
+| `iterations` | `usize` | Newton iterations |
+| `final_error` | `f64` | Residual price error at solution |
+| `vega` | `Option<f64>` | Vega estimate, if available |
+| `used_rate_approximation` | `bool` | `true` when a `Rate::Curve` query was collapsed to a flat rate to query the surface |
+
+`used_rate_approximation` is always `false` for `Rate::Const` queries. It is set
+only when the solver had to flatten a yield curve to a single rate to land on the
+surface's rate axis; in that case the implied vol is an approximation rather than
+a curve-exact solve.
+
+### Batch solving
+
+`solve_batch` solves a slice of queries and returns a `BatchResult`:
+
+```rust
+let queries = vec![query_a, query_b, query_c];
+let batch = solver.solve_batch(&queries);
+
+println!("failed: {}", batch.failed);
+for (i, r) in batch.results.iter().enumerate() {
+    match r {
+        Ok(iv) => println!("[{i}] iv = {}", iv.implied_vol),
+        Err(e) => println!("[{i}] failed: {:?}", e.kind),
+    }
+}
+```
+
+`BatchResult` has two fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `results` | `Vec<Result<IvSuccess, Error>>` | One result per input query, in order |
+| `failed` | `usize` | Number of failed slots |
+
+> **Batch error detail.** A failed slot in `results` carries only an error
+> **category** (`Error::kind`) — its `message` is a generic placeholder, not the
+> full diagnostic. If you need the precise reason a particular query failed,
+> re-run it through the single `solve`, which surfaces the full C++ message.
+
+### Price table
+
+A `PriceTable` exposes the surface directly for pricing and greeks. Queries take
+a `PricingParams` (the same type as `price_american`):
+
+```rust
+use mango_option::{PriceTable, PricingParams};
+
+let table = PriceTable::new(&config)?;
+
+let pp = PricingParams { spec, volatility: 0.25 };
+
+let price = table.price(&pp);      // infallible f64
+let vega  = table.vega(&pp);       // infallible f64
+let delta = table.delta(&pp)?;     // Result<f64, Error>
+let gamma = table.gamma(&pp)?;
+let theta = table.theta(&pp)?;
+let rho   = table.rho(&pp)?;
+
+println!("price={price} vega={vega} delta={delta}");
+println!("option type    : {:?}", table.option_type());
+println!("dividend yield : {}", table.dividend_yield());
+```
+
+`PriceTable` query methods:
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `price(&PricingParams)` | `f64` | Infallible; extrapolates out of domain |
+| `vega(&PricingParams)` | `f64` | Infallible; extrapolates out of domain |
+| `delta` / `gamma` / `theta` / `rho` | `Result<f64, Error>` | `Err` when out of domain or numerically unstable |
+| `option_type()` | `OptionType` | The surface's option type |
+| `dividend_yield()` | `f64` | The surface's continuous dividend yield |
+
+> **Extrapolation caveat.** `price` and `vega` perform **no implicit bounds
+> check** — outside the grid domain they extrapolate the B-spline and can return
+> meaningless values (they only return `NaN` on an internal failure, never as an
+> out-of-bounds signal). If you need an explicit domain check, call
+> `validate(&params)` first; it returns `Err(ErrorKind::Validation)` for
+> out-of-domain points:
+
+```rust
+table.validate(&pp)?;          // Err if pp is outside the surface domain
+let price = table.price(&pp);  // now safe to trust
+```
+
+### Deriving an IV solver from a table
+
+If you already built a `PriceTable`, derive an `InterpIvSolver` from it instead
+of rebuilding the surface. Pass `None` to use the default Newton config, or
+`Some(&InterpSolverConfig { .. })` to override it:
+
+```rust
+let table = PriceTable::new(&config)?;
+let solver = table.iv_solver(None)?;     // reuses the table's surface
+let iv = solver.solve(&query)?;
+```
+
+### Adaptive grid refinement
+
+Set `adaptive: Some(AdaptiveGridParams { .. })` to have the builder refine the
+grid until it meets a target IV error, instead of using the fixed grid as-is:
+
+```rust
+use mango_option::AdaptiveGridParams;
+
+let mut config = config;
+config.adaptive = Some(AdaptiveGridParams {
+    target_iv_error: 1e-3,
+    max_iter: 2,
+    validation_samples: 16,
+    min_moneyness_points: 20,
+    ..AdaptiveGridParams::default()
+});
+let solver = InterpIvSolver::new(&config)?;
+```
+
+This raises build time but tightens interpolation accuracy. `AdaptiveGridParams::default()`
+mirrors the C++ defaults; override only the fields you care about.
+
+### Discrete dividends
+
+For discrete cash dividends on the interpolation path, set
+`discrete_dividends: Some(DiscreteDividendConfig { .. })`. The surface is built
+across multiple reference strikes (`MultiKRef`) so it can reconstruct prices for
+the segmented dividend geometry:
+
+```rust
+use mango_option::{DiscreteDividendConfig, Dividend, MultiKRef};
+
+let mut config = config;
+config.discrete_dividends = Some(DiscreteDividendConfig {
+    maturity: 1.0,
+    dividends: vec![Dividend { calendar_time: 0.5, amount: 2.0 }],
+    kref_config: MultiKRef {
+        k_refs: vec![90.0, 100.0, 110.0],
+        ..MultiKRef::default()
+    },
+});
+let solver = InterpIvSolver::new(&config)?;
+```
+
+Queries against this solver must carry the **same** `discrete_dividends` in their
+`OptionSpec`. `MultiKRef::default()` supplies sensible `k_ref_count` /
+`k_ref_span` defaults; an empty `k_refs` lets the builder pick reference strikes
+automatically.
+
 ## Error handling
 
 All fallible functions return `Result<_, Error>`. `Error` carries:
@@ -204,9 +424,23 @@ match price_american(&params) {
 | `PriceResult` | Pricing result with `value`, `value_at`, `delta`, `gamma`, `theta` |
 | `IvQuery` | IV input: `spec: OptionSpec` + `market_price: f64` |
 | `IvConfig` | IV solver config: `max_iter`, `brent_tol_abs` |
-| `IvSuccess` | IV result: `implied_vol`, `iterations`, `final_error`, `vega` |
+| `IvSuccess` | IV result: `implied_vol`, `iterations`, `final_error`, `vega`, `used_rate_approximation` |
 | `Error` | Error with `kind: ErrorKind` and `message: String` |
 | `ErrorKind` | `Validation`, `Arbitrage`, `NoConvergence`, `Bracketing`, `Solver` |
+
+#### Interpolation path
+
+| Type | Description |
+|------|-------------|
+| `FactoryConfig` | B-spline surface build config: `option_type`, `spot`, `dividend_yield`, `grid`, `maturity_grid`, `solver`, `adaptive`, `discrete_dividends` |
+| `IvGrid` | Grid axes: `moneyness` (S/K), `vol`, `rate` (each >= 4 points) |
+| `InterpSolverConfig` | Newton config: `max_iter`, `tolerance`, `sigma_min`, `sigma_max`, `vega_threshold` |
+| `AdaptiveGridParams` | Adaptive refinement: `target_iv_error`, `max_iter`, `max_points_per_dim`, … |
+| `MultiKRef` | Reference strikes: `k_refs`, `k_ref_count`, `k_ref_span` |
+| `DiscreteDividendConfig` | `maturity`, `dividends`, `kref_config` |
+| `InterpIvSolver` | Interpolated IV solver (`new`, `solve`, `solve_batch`); `Send + Sync` |
+| `BatchResult` | Batch output: `results: Vec<Result<IvSuccess, Error>>`, `failed: usize` |
+| `PriceTable` | Reusable price surface (`new`, `validate`, `price`, `vega`, greeks, `option_type`, `dividend_yield`, `iv_solver`); `Send + Sync` |
 
 ### Functions
 
@@ -214,3 +448,16 @@ match price_american(&params) {
 |----------|-----------|
 | `price_american` | `(&PricingParams) -> Result<PriceResult, Error>` |
 | `solve_iv` | `(&IvQuery, &IvConfig) -> Result<IvSuccess, Error>` |
+
+### Constructors / methods (interpolation path)
+
+| Item | Signature |
+|------|-----------|
+| `InterpIvSolver::new` | `(&FactoryConfig) -> Result<InterpIvSolver, Error>` |
+| `InterpIvSolver::solve` | `(&IvQuery) -> Result<IvSuccess, Error>` |
+| `InterpIvSolver::solve_batch` | `(&[IvQuery]) -> BatchResult` |
+| `PriceTable::new` | `(&FactoryConfig) -> Result<PriceTable, Error>` |
+| `PriceTable::validate` | `(&PricingParams) -> Result<(), Error>` |
+| `PriceTable::price` / `vega` | `(&PricingParams) -> f64` (infallible, extrapolates) |
+| `PriceTable::delta` / `gamma` / `theta` / `rho` | `(&PricingParams) -> Result<f64, Error>` |
+| `PriceTable::iv_solver` | `(Option<&InterpSolverConfig>) -> Result<InterpIvSolver, Error>` |

--- a/docs/plans/2026-06-05-rust-interpolation-binding-design.md
+++ b/docs/plans/2026-06-05-rust-interpolation-binding-design.md
@@ -1,0 +1,405 @@
+# Rust Binding Design (v2: Interpolation Path)
+
+**Date**: 2026-06-05
+**Status**: Design
+**Goal**: Extend the existing Rust binding to cover the *interpolation path* — the
+pre-computed B-spline price surface and the fast interpolated implied-vol solver.
+
+## Problem
+
+The merged v1 binding (PR #430) covers the *FDM path*: per-query American
+pricing (value + Greeks) and FDM implied vol (~8 ms/query). The library also
+exposes an *interpolation path* that pre-computes a B-spline price surface once
+and then answers queries cheaply — interpolated IV at ~3.5 µs/query versus ~8 ms
+for FDM, a ~2000× speedup for repeated solves over the same surface. Rust
+consumers doing volume IV work (option chains, calibration) need this path.
+
+The Python parity layer (PR #427) already exposes it. The C++ entry points are:
+
+- `make_interpolated_iv_solver(IVSolverFactoryConfig) -> std::expected<AnyInterpIVSolver, ValidationError>`
+  — builds a surface and wraps it in a solver with `.solve(IVQuery)` /
+  `.solve_batch(...)`.
+- `make_price_table(IVSolverFactoryConfig) -> std::expected<AnyPriceTable, ValidationError>`
+  — builds the reusable surface, queried via `PricingParams` for
+  `price`/`vega`/`delta`/`gamma`/`theta`/`rho`, plus `make_iv_solver(...)` to
+  derive a solver from an already-built table without rebuilding the surface.
+
+These lean on the same non-C-ABI features v1 dealt with (`std::expected`,
+type-erased pimpl handles, move-only results) **plus** a large nested config
+(`IVSolverFactoryConfig`) carrying vectors, two optional sub-structs, and a
+`std::variant` backend. The binding cannot be generated mechanically.
+
+## Goals
+
+1. Build an interpolated IV solver from Rust and solve single + batch IV queries
+   against it.
+2. Build a reusable price table (surface) from Rust and query
+   `price`/`vega`/`delta`/`gamma`/`theta`/`rho` via `PricingParams`, plus derive
+   a solver from a built table.
+3. Faithful config fidelity for the **B-spline** path: the `IVGrid`
+   (moneyness/vol/rate), the B-spline `maturity_grid`, the Newton
+   `solver_config`, optional **adaptive grid** refinement, and optional
+   **discrete dividends** (schedule + multi-K_ref config).
+4. Idiomatic Rust surface: callers write zero `unsafe`; errors are `Result`;
+   handles are RAII (`Drop`) and `Send + Sync` (surfaces are immutable and the
+   C++ guarantees query thread-safety).
+5. Reuse v1 FFI types and the existing Bazel `rules_rust` link plumbing; the only
+   new C++ surface is the additional `extern "C"` shim functions. No library
+   changes.
+
+## Non-Goals (v2)
+
+- **Non-B-spline backends.** `ChebyshevBackend` and `DimensionlessBackend` (the
+  other two `std::variant` arms) are out of scope. Modeling a tagged union across
+  the C ABI is deferred; B-spline is the documented, headline backend. Adding the
+  others later is an additive change (new ABI tag + struct), not a rewrite.
+- **Lower-level surface construction** (`PriceTableBuilder<4>::from_vectors` /
+  `make_bspline_surface` / raw `BSplinePriceTable` with the 5-arg
+  `price(spot,strike,tau,sigma,rate)`). Rust uses the type-erased
+  `AnyPriceTable` (which queries via `PricingParams`), matching the Python
+  surface.
+- **Bounds accessors and pre-query bounds validation.** The type-erased
+  `AnyPriceTable` does not expose grid bounds; `price()`/`vega()` mirror the raw
+  C++ signature (return `f64`, no validation — out-of-domain queries
+  extrapolate). The extrapolation caveat is documented. (The Python layer adds a
+  bounds check using internals not on the type-erased handle; we do not
+  replicate it.)
+- **Surface serialization** (Parquet load/save) and `surface_type()` string
+  accessor.
+- Publishing to crates.io. v2 ships in-tree via Bazel, like v1.
+
+## Approach
+
+Same as v1: **hand-written `extern "C"` shim + raw `-sys` crate + safe wrapper
+crate**, guarded by bidirectional ABI layout tests (`static_assert(offsetof)` in
+the C header mirrored by `offset_of!` in `-sys`). New types and functions are
+added to the existing `src/ffi/mango_c_api.{h,cpp}`, `crates/mango-option-sys`,
+and `crates/mango-option`.
+
+Because B-spline is the only backend, the `std::variant` collapses to a single
+`maturity_grid` array — **no tagged union crosses the C ABI**. The factory config
+becomes a flat struct using the same pointer+length idiom already used for
+`tenor_points`/`dividends` in v1, plus two nullable sub-struct pointers for the
+optionals (`adaptive`, `discrete_dividends`).
+
+## C ABI (added to `src/ffi/mango_c_api.h` / `.cpp`)
+
+Reused unchanged from v1: `MangoStatus`/`MANGO_ERR_*`, `MangoOptionType`,
+`MangoError`, `MangoDividend`, `MangoTenorPoint`, `MangoPricingParams`,
+`MangoIvQuery`, `MangoIvSuccess`.
+
+New POD config types (all sizes/offsets pinned by `static_assert`):
+
+```c
+// InterpolatedIVSolverConfig (Newton config)
+typedef struct {
+  uint64_t max_iter;        // size_t; 0 => library default (50)
+  double tolerance;         // 0 => default (1e-6)
+  double sigma_min;         // 0 => default (0.01)
+  double sigma_max;         // 0 => default (3.0)
+  double vega_threshold;    // 0 => default (1e-4)
+} MangoInterpSolverConfig;
+
+// AdaptiveGridParams (all 9 fields; passed only when non-null)
+typedef struct {
+  double   target_iv_error;
+  uint64_t max_iter;
+  uint64_t max_points_per_dim;
+  uint64_t min_moneyness_points;
+  uint64_t validation_samples;
+  double   refinement_factor;
+  uint64_t lhs_seed;
+  double   vega_floor;
+  double   max_failure_rate;
+} MangoAdaptiveGridParams;
+
+// MultiKRefConfig
+typedef struct {
+  const double* K_refs;     // may be null when n_K_refs == 0 (auto mode)
+  uint64_t      n_K_refs;
+  int32_t       K_ref_count;
+  double        K_ref_span;
+} MangoMultiKRef;
+
+// DiscreteDividendConfig
+typedef struct {
+  double               maturity;
+  const MangoDividend* dividends;   // may be null when n_dividends == 0
+  uint64_t             n_dividends;
+  MangoMultiKRef       kref_config;
+} MangoDiscreteDividendConfig;
+
+// IVSolverFactoryConfig (B-spline backend only)
+typedef struct {
+  MangoOptionType option_type;
+  double          spot;
+  double          dividend_yield;
+  const double*   moneyness;   uint64_t n_moneyness;  // IVGrid
+  const double*   vol;         uint64_t n_vol;
+  const double*   rate;        uint64_t n_rate;
+  const double*   maturity_grid; uint64_t n_maturity; // BSplineBackend
+  MangoInterpSolverConfig solver_config;
+  const MangoAdaptiveGridParams*     adaptive;            // null => fixed grid
+  const MangoDiscreteDividendConfig* discrete_dividends;  // null => continuous
+} MangoIvFactoryConfig;
+
+// Per-query batch result slot (caller-allocated array of length n)
+typedef struct {
+  int32_t        status;   // MangoStatus: MANGO_OK or an error category
+  MangoIvSuccess success;  // valid iff status == MANGO_OK
+} MangoIvBatchSlot;
+
+typedef struct MangoInterpIvSolver MangoInterpIvSolver;  // opaque
+typedef struct MangoPriceTable     MangoPriceTable;      // opaque
+```
+
+Functions:
+
+```c
+// Interpolated IV solver
+MangoStatus mango_make_interp_iv_solver(const MangoIvFactoryConfig* cfg,
+                                        MangoInterpIvSolver** out, MangoError* err);
+MangoStatus mango_interp_iv_solve(const MangoInterpIvSolver* s,
+                                  const MangoIvQuery* q,
+                                  MangoIvSuccess* out, MangoError* err);
+MangoStatus mango_interp_iv_solve_batch(const MangoInterpIvSolver* s,
+                                        const MangoIvQuery* queries, uint64_t n,
+                                        MangoIvBatchSlot* out_slots /*[n]*/,
+                                        uint64_t* out_failed_count, MangoError* err);
+void mango_interp_iv_solver_free(MangoInterpIvSolver* s);
+
+// Price table (type-erased AnyPriceTable)
+MangoStatus mango_make_price_table(const MangoIvFactoryConfig* cfg,
+                                   MangoPriceTable** out, MangoError* err);
+double mango_price_table_price(const MangoPriceTable* t, const MangoPricingParams* p);
+double mango_price_table_vega (const MangoPriceTable* t, const MangoPricingParams* p);
+MangoStatus mango_price_table_delta(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err);
+MangoStatus mango_price_table_gamma(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err);
+MangoStatus mango_price_table_theta(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err);
+MangoStatus mango_price_table_rho  (const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err);
+MangoOptionType mango_price_table_option_type(const MangoPriceTable* t);
+double          mango_price_table_dividend_yield(const MangoPriceTable* t);
+MangoStatus mango_price_table_make_iv_solver(const MangoPriceTable* t,
+                                             const MangoInterpSolverConfig* cfg /*nullable*/,
+                                             MangoInterpIvSolver** out, MangoError* err);
+void mango_price_table_free(MangoPriceTable* t);
+```
+
+### Shim behavior
+
+- **Config translation.** The shim reads the flat `MangoIvFactoryConfig` into a
+  C++ `IVSolverFactoryConfig`: copies the three grid vectors and `maturity_grid`
+  into `IVGrid` / `BSplineBackend{maturity_grid}`; sets `backend` to the
+  B-spline arm; applies `solver_config` (treating an all-zero
+  `MangoInterpSolverConfig` field as "use default" per-field — a zero
+  `tolerance`/`sigma_*`/`vega_threshold`/`max_iter` is never a valid user value);
+  sets `adaptive`/`discrete_dividends` only when the corresponding pointer is
+  non-null. `K_refs == null` (n=0) maps to auto K_ref selection.
+- **Pre-validation in the shim** (before calling into C++, matching v1's IV
+  pre-validation): reject non-finite `spot`/`dividend_yield`; reject
+  `option_type` not in {0,1}; reject any non-finite dividend amount/time in a
+  discrete schedule. These map to `MANGO_ERR_VALIDATION`.
+- **Error mapping.** Factory `ValidationError` → `MANGO_ERR_VALIDATION` with its
+  message. `IVError` → existing `map_iv_error` (Validation / Arbitrage /
+  NoConvergence / Bracketing / Solver). `GreekError` → `MANGO_ERR_SOLVER` (or
+  Validation for an out-of-domain param) with message. Reuse v1's
+  `set_err`/`map_*` helpers.
+- **Batch.** `solve_batch` runs the C++ batch (OpenMP). For each result, the
+  slot gets `status = MANGO_OK` + the `IVSuccess`, or `status =` the mapped error
+  category and a zeroed `IVSuccess`. `*out_failed_count` mirrors
+  `BatchIVResult::failed_count`. **Known limitation:** the per-slot result keeps
+  only an error *category*, not the full `IVError` message/iterations — callers
+  needing detail re-run the single `solve()`. (This matches the Python batch
+  shape, which returns coded results.) The function itself returns `MANGO_OK`
+  unless the batch call throws/setup fails; per-query failures live in the slots.
+- **Greeks / price / vega** call through to `AnyPriceTable`. `price`/`vega`
+  return `double` directly (no out-of-band error; extrapolates out of domain).
+  Greeks are `std::expected` → `MangoStatus` + out-param.
+- **Null-guarding.** Every getter null-checks its handle and returns `nan("")`
+  (price/vega) or a validation error (greeks) on null, as v1 does.
+
+### ABI guards
+
+`static_assert(sizeof(...))` and `static_assert(offsetof(...))` for every new
+struct in the header (C11 `_Static_assert` / C++ `static_assert`), mirrored
+field-for-field by `offset_of!` assertions in
+`crates/mango-option-sys/tests/layout.rs`. Exact byte offsets are computed during
+implementation (Task: header + layout test land together, the layout test is
+written to fail first against wrong offsets).
+
+## Safe Rust API (`crates/mango-option`)
+
+Two new modules, `interp.rs` and `table.rs`, re-exported from `lib.rs`. Reuse v1
+`OptionType`, `Rate`, `Dividend`, `PricingParams`, `IvQuery`, `IvSuccess`,
+`Error`, `ErrorKind`.
+
+```rust
+// ---- interp.rs ----
+/// IVGrid axes (S/K moneyness, not log). `Default` mirrors the C++ defaults.
+pub struct IvGrid { pub moneyness: Vec<f64>, pub vol: Vec<f64>, pub rate: Vec<f64> }
+impl Default for IvGrid { /* {0.7..1.3}, {0.05..0.5}, {0.01..0.10} */ }
+
+/// Newton config for the interpolated solver. `Default` mirrors C++ defaults.
+pub struct InterpSolverConfig {
+    pub max_iter: usize,        // 50
+    pub tolerance: f64,         // 1e-6
+    pub sigma_min: f64,         // 0.01
+    pub sigma_max: f64,         // 3.0
+    pub vega_threshold: f64,    // 1e-4
+}
+impl Default for InterpSolverConfig { /* … */ }
+
+/// Adaptive grid refinement params. `Default` mirrors C++ defaults.
+pub struct AdaptiveGridParams {
+    pub target_iv_error: f64,        // 2e-5
+    pub max_iter: usize,             // 5
+    pub max_points_per_dim: usize,   // 160
+    pub min_moneyness_points: usize, // 60
+    pub validation_samples: usize,   // 64
+    pub refinement_factor: f64,      // 1.3
+    pub lhs_seed: u64,               // 42
+    pub vega_floor: f64,             // 1e-4
+    pub max_failure_rate: f64,       // 0.5
+}
+impl Default for AdaptiveGridParams { /* … */ }
+
+pub struct MultiKRef { pub k_refs: Vec<f64>, pub k_ref_count: i32, pub k_ref_span: f64 }
+impl Default for MultiKRef { /* {empty}, 11, 0.3 */ }
+
+pub struct DiscreteDividendConfig {
+    pub maturity: f64,
+    pub dividends: Vec<Dividend>,
+    pub kref_config: MultiKRef,
+}
+
+pub struct FactoryConfig {
+    pub option_type: OptionType,
+    pub spot: f64,
+    pub dividend_yield: f64,
+    pub grid: IvGrid,
+    pub maturity_grid: Vec<f64>,
+    pub solver: InterpSolverConfig,
+    pub adaptive: Option<AdaptiveGridParams>,
+    pub discrete_dividends: Option<DiscreteDividendConfig>,
+}
+// No blanket Default: maturity_grid has no sensible default; callers set it.
+
+pub struct BatchResult {
+    pub results: Vec<Result<IvSuccess, Error>>,
+    pub failed: usize,
+}
+
+pub struct InterpIvSolver { /* owns *mut sys::MangoInterpIvSolver; Drop frees */ }
+impl InterpIvSolver {
+    pub fn new(cfg: &FactoryConfig) -> Result<Self, Error>;
+    pub fn solve(&self, query: &IvQuery) -> Result<IvSuccess, Error>;
+    pub fn solve_batch(&self, queries: &[IvQuery]) -> BatchResult;
+}
+unsafe impl Send for InterpIvSolver {}
+unsafe impl Sync for InterpIvSolver {}
+
+// ---- table.rs ----
+pub struct PriceTable { /* owns *mut sys::MangoPriceTable; Drop frees */ }
+impl PriceTable {
+    pub fn new(cfg: &FactoryConfig) -> Result<Self, Error>;
+    pub fn price(&self, params: &PricingParams) -> f64;   // extrapolates out of domain
+    pub fn vega(&self, params: &PricingParams) -> f64;
+    pub fn delta(&self, params: &PricingParams) -> Result<f64, Error>;
+    pub fn gamma(&self, params: &PricingParams) -> Result<f64, Error>;
+    pub fn theta(&self, params: &PricingParams) -> Result<f64, Error>;
+    pub fn rho(&self,   params: &PricingParams) -> Result<f64, Error>;
+    pub fn option_type(&self) -> OptionType;
+    pub fn dividend_yield(&self) -> f64;
+    /// Derive a solver from this already-built surface (no rebuild).
+    pub fn iv_solver(&self, cfg: Option<&InterpSolverConfig>) -> Result<InterpIvSolver, Error>;
+}
+unsafe impl Send for PriceTable {}
+unsafe impl Sync for PriceTable {}
+```
+
+The safe layer owns all the temporary slices it passes as pointers (the `Vec`s
+in `FactoryConfig` outlive the FFI call; sub-struct C views are stack locals
+populated just before the call). `solve_batch` allocates a `Vec<MangoIvBatchSlot>`
+of `queries.len()`, calls the C batch, then maps each slot to
+`Result<IvSuccess, Error>` (status `MANGO_OK` → `Ok`, else `Err` with the
+per-kind message).
+
+## Error fidelity & documented tradeoffs
+
+1. **Batch loses per-query message detail** (category only). Single `solve()`
+   keeps full fidelity. Documented in the rustdoc for `solve_batch`.
+2. **`price()`/`vega()` do not bounds-validate** and extrapolate out of domain;
+   documented on both methods.
+3. **`InterpSolverConfig` zero-means-default** at the C boundary: a literal
+   user value of `0.0` for `tolerance`/`sigma_*`/`vega_threshold` or `0` for
+   `max_iter` is indistinguishable from "unset" and yields the library default.
+   These are never meaningful user values, so the safe API's `Default` supplies
+   the real defaults and this is invisible to callers who start from `Default`.
+
+## Testing
+
+**`-sys` layout tests** (`crates/mango-option-sys/tests/layout.rs`): `offset_of!`
+for every field of every new struct, plus `size_of` equality with the C
+`static_assert`s.
+
+**Safe-crate integration tests** (`crates/mango-option/tests/`):
+
+1. **Build + IV round-trip (continuous).** Build a small fixed-grid B-spline
+   solver (PUT). Price a known option with the v1 FDM `price_american` at a
+   target σ in-grid, feed that price as `market_price`, recover σ within a
+   tolerance (e.g. 1e-3). Contrast with a different σ to ensure the recovered
+   value tracks input.
+2. **Price table queries.** Build a `PriceTable`, query `price`/`vega` and all
+   four Greeks via `PricingParams`; assert finite, signs sane (PUT delta < 0),
+   and `price` ≈ FDM price within interpolation tolerance.
+3. **`PriceTable::iv_solver`.** Derive a solver from a built table and solve;
+   assert it matches a solver built directly from the same config.
+4. **Batch solve with a deliberate failure.** A batch of queries where one has
+   an arbitrage-violating market price; assert `failed == 1`, the bad slot is
+   `Err` with `ErrorKind::Arbitrage` (or the mapped category), the rest `Ok`.
+5. **Adaptive grid build.** Build with `adaptive = Some(AdaptiveGridParams{
+   target_iv_error: 1e-3, max_iter: 2, .. })` (small, fast) and solve one query
+   successfully.
+6. **Discrete-dividend build.** Build with `discrete_dividends = Some(...)` (one
+   dividend) and explicit `K_refs`; solve and recover a σ. Mirrors the v1 FDM
+   discrete-dividend round-trip.
+7. **Validation errors.** Empty `maturity_grid` and a non-finite `spot` each
+   return `Err(ErrorKind::Validation)` from `new`.
+8. **`Send + Sync` smoke test.** Move a solver into two threads (`std::thread`)
+   and solve concurrently; assert both succeed (exercises the immutability
+   guarantee).
+
+**Bazel**: new tests wired into `crates/mango-option/BUILD.bazel` and
+`crates/mango-option-sys/BUILD.bazel`; reuse the v1 link plumbing (the
+`mango_c_api` cc_library + cpuinfo/libstdc++ deps already propagate through the
+`-sys` crate). The new shim functions live in the existing `mango_c_api` target,
+so no new C++ targets are needed.
+
+## File-by-file change list
+
+- `src/ffi/mango_c_api.h` — new POD structs, opaque handles, 13 fn decls,
+  `static_assert` ABI guards.
+- `src/ffi/mango_c_api.cpp` — config translation, pre-validation, 13 fn impls,
+  error mapping (reusing v1 helpers).
+- `crates/mango-option-sys/src/lib.rs` — `repr(C)` mirrors + `extern "C"` decls.
+- `crates/mango-option-sys/tests/layout.rs` — `offset_of!`/`size_of` asserts.
+- `crates/mango-option/src/interp.rs` — `FactoryConfig` family + `InterpIvSolver`.
+- `crates/mango-option/src/table.rs` — `PriceTable`.
+- `crates/mango-option/src/lib.rs` — module decls + re-exports.
+- `crates/mango-option/tests/interpolation.rs` — integration tests above.
+- `crates/mango-option/BUILD.bazel`, `crates/mango-option-sys/BUILD.bazel` —
+  wire new test sources.
+- `docs/RUST_GUIDE.md` — add an interpolation-path section.
+
+## Risks
+
+- **Offset drift**: mitigated by bidirectional ABI guards (build fails on
+  mismatch; layout test fails on mismatch).
+- **Adaptive-grid build time in tests**: keep `max_iter` small and grids tiny so
+  CI stays fast; adaptive runs extra PDE solves per validation sample.
+- **Batch error detail loss**: accepted and documented; single-solve path is the
+  escape hatch.

--- a/docs/plans/2026-06-05-rust-interpolation-binding-design.md
+++ b/docs/plans/2026-06-05-rust-interpolation-binding-design.md
@@ -58,12 +58,15 @@ type-erased pimpl handles, move-only results) **plus** a large nested config
   `price(spot,strike,tau,sigma,rate)`). Rust uses the type-erased
   `AnyPriceTable` (which queries via `PricingParams`), matching the Python
   surface.
-- **Bounds accessors and pre-query bounds validation.** The type-erased
-  `AnyPriceTable` does not expose grid bounds; `price()`/`vega()` mirror the raw
-  C++ signature (return `f64`, no validation — out-of-domain queries
-  extrapolate). The extrapolation caveat is documented. (The Python layer adds a
-  bounds check using internals not on the type-erased handle; we do not
-  replicate it.)
+- **Bounds *accessors*** (`m_min`/`tau_min`/…). The type-erased `AnyPriceTable`
+  does not expose them. `price()`/`vega()` mirror the raw C++ signature (return
+  `f64`, no implicit validation — out-of-domain queries extrapolate); the
+  extrapolation caveat is documented. **Explicit bounds *validation* IS
+  exposed**, however: `AnyPriceTable::validate_pricing_params` exists
+  (`price_table_factory.hpp:30`), so the binding surfaces it as an opt-in
+  `PriceTable::validate(&params) -> Result<()>` rather than silently making
+  `price`/`vega` fallible. Callers who want the Python layer's safety call
+  `validate()` first.
 - **Surface serialization** (Parquet load/save) and `surface_type()` string
   accessor.
 - Publishing to crates.io. v2 ships in-tree via Bazel, like v1.
@@ -86,18 +89,35 @@ optionals (`adaptive`, `discrete_dividends`).
 
 Reused unchanged from v1: `MangoStatus`/`MANGO_ERR_*`, `MangoOptionType`,
 `MangoError`, `MangoDividend`, `MangoTenorPoint`, `MangoPricingParams`,
-`MangoIvQuery`, `MangoIvSuccess`.
+`MangoIvQuery`.
+
+**One shared-struct change**: `MangoIvSuccess` gains a trailing
+`int32_t used_rate_approximation` field. The interpolated solver sets
+`IVSuccess::used_rate_approximation` when a yield-curve query is collapsed to a
+flat rate (`iv_result.hpp:25`, `interpolated_iv_solver.hpp:536`) — dropping it
+would lose fidelity exactly on the path v2 adds. It slots into the existing tail
+padding (`has_vega` is `int32_t` at offset 32; the new field goes at offset 36),
+so **`sizeof(MangoIvSuccess)` stays 40 and no other v1 offset moves**. This
+touches v1's struct, its `static_assert`s, the `-sys` mirror, the v1 layout
+test, the safe `IvSuccess` (gains `pub used_rate_approximation: bool`), and the
+v1 `mango_solve_iv` mapping (sets the new field). It is an additive,
+non-reordering change.
 
 New POD config types (all sizes/offsets pinned by `static_assert`):
 
 ```c
-// InterpolatedIVSolverConfig (Newton config)
+// InterpolatedIVSolverConfig (Newton config). Fields applied VERBATIM (no
+// zero-means-default magic): vega_threshold == 0 is a *legal* value meaning
+// "disable the vega pre-check" (interpolated_iv_solver.hpp:55), so zero cannot
+// be overloaded as "unset". Raw C callers must fill every field; the safe Rust
+// layer always does, because InterpSolverConfig::default() carries the real
+// C++ defaults below.
 typedef struct {
-  uint64_t max_iter;        // size_t; 0 => library default (50)
-  double tolerance;         // 0 => default (1e-6)
-  double sigma_min;         // 0 => default (0.01)
-  double sigma_max;         // 0 => default (3.0)
-  double vega_threshold;    // 0 => default (1e-4)
+  uint64_t max_iter;        // 50
+  double tolerance;         // 1e-6
+  double sigma_min;         // 0.01
+  double sigma_max;         // 3.0
+  double vega_threshold;    // 1e-4 (0 disables the check)
 } MangoInterpSolverConfig;
 
 // AdaptiveGridParams (all 9 fields; passed only when non-null)
@@ -117,7 +137,7 @@ typedef struct {
 typedef struct {
   const double* K_refs;     // may be null when n_K_refs == 0 (auto mode)
   uint64_t      n_K_refs;
-  int32_t       K_ref_count;
+  int32_t       K_ref_count; // used iff K_refs empty; must be >= 1 (auto: 11)
   double        K_ref_span;
 } MangoMultiKRef;
 
@@ -171,6 +191,8 @@ void mango_interp_iv_solver_free(MangoInterpIvSolver* s);
 // Price table (type-erased AnyPriceTable)
 MangoStatus mango_make_price_table(const MangoIvFactoryConfig* cfg,
                                    MangoPriceTable** out, MangoError* err);
+MangoStatus mango_price_table_validate(const MangoPriceTable* t, const MangoPricingParams* p,
+                                       MangoError* err);  // bounds check (opt-in)
 double mango_price_table_price(const MangoPriceTable* t, const MangoPricingParams* p);
 double mango_price_table_vega (const MangoPriceTable* t, const MangoPricingParams* p);
 MangoStatus mango_price_table_delta(const MangoPriceTable* t, const MangoPricingParams* p,
@@ -194,11 +216,18 @@ void mango_price_table_free(MangoPriceTable* t);
 - **Config translation.** The shim reads the flat `MangoIvFactoryConfig` into a
   C++ `IVSolverFactoryConfig`: copies the three grid vectors and `maturity_grid`
   into `IVGrid` / `BSplineBackend{maturity_grid}`; sets `backend` to the
-  B-spline arm; applies `solver_config` (treating an all-zero
-  `MangoInterpSolverConfig` field as "use default" per-field — a zero
-  `tolerance`/`sigma_*`/`vega_threshold`/`max_iter` is never a valid user value);
+  B-spline arm; applies `solver_config` **verbatim** (no zero-means-default);
   sets `adaptive`/`discrete_dividends` only when the corresponding pointer is
-  non-null. `K_refs == null` (n=0) maps to auto K_ref selection.
+  non-null. `K_refs == null` (n=0) maps to auto K_ref selection; in that case a
+  `K_ref_count <= 0` is bumped to the C++ default (11) so a zero-initialized
+  `MangoMultiKRef` doesn't trip the factory's `K_ref_count >= 1` check
+  (`price_table_factory.cpp:149`).
+- **`maturity_grid` is not unconditionally required.** The discrete-dividend
+  B-spline path branches before consuming `BSplineBackend` and uses
+  `DiscreteDividendConfig::maturity` instead (`price_table_factory.cpp:228,332`).
+  The shim does **not** pre-reject an empty `maturity_grid`; it lets the C++
+  factory return `ValidationError` when the grid is actually needed (continuous
+  path) and absent.
 - **Pre-validation in the shim** (before calling into C++, matching v1's IV
   pre-validation): reject non-finite `spot`/`dividend_yield`; reject
   `option_type` not in {0,1}; reject any non-finite dividend amount/time in a
@@ -286,7 +315,8 @@ pub struct FactoryConfig {
     pub adaptive: Option<AdaptiveGridParams>,
     pub discrete_dividends: Option<DiscreteDividendConfig>,
 }
-// No blanket Default: maturity_grid has no sensible default; callers set it.
+// No blanket Default: maturity_grid (continuous path) / discrete_dividends
+// (segmented path) carry the surface maturity and callers must choose one.
 
 pub struct BatchResult {
     pub results: Vec<Result<IvSuccess, Error>>,
@@ -306,6 +336,8 @@ unsafe impl Sync for InterpIvSolver {}
 pub struct PriceTable { /* owns *mut sys::MangoPriceTable; Drop frees */ }
 impl PriceTable {
     pub fn new(cfg: &FactoryConfig) -> Result<Self, Error>;
+    /// Opt-in bounds check (out-of-domain => Err). price/vega do NOT call this.
+    pub fn validate(&self, params: &PricingParams) -> Result<(), Error>;
     pub fn price(&self, params: &PricingParams) -> f64;   // extrapolates out of domain
     pub fn vega(&self, params: &PricingParams) -> f64;
     pub fn delta(&self, params: &PricingParams) -> Result<f64, Error>;
@@ -333,12 +365,17 @@ per-kind message).
 1. **Batch loses per-query message detail** (category only). Single `solve()`
    keeps full fidelity. Documented in the rustdoc for `solve_batch`.
 2. **`price()`/`vega()` do not bounds-validate** and extrapolate out of domain;
-   documented on both methods.
-3. **`InterpSolverConfig` zero-means-default** at the C boundary: a literal
-   user value of `0.0` for `tolerance`/`sigma_*`/`vega_threshold` or `0` for
-   `max_iter` is indistinguishable from "unset" and yields the library default.
-   These are never meaningful user values, so the safe API's `Default` supplies
-   the real defaults and this is invisible to callers who start from `Default`.
+   documented on both methods. Callers wanting the Python layer's safety call
+   `PriceTable::validate(&params)` first.
+3. **No zero-means-default at the C boundary.** `MangoInterpSolverConfig` is
+   applied verbatim (a zero `vega_threshold` legitimately *disables* the vega
+   pre-check). The safe `InterpSolverConfig::default()` carries the real C++
+   defaults, so Rust callers starting from `Default` get correct behavior; raw C
+   callers must fill every field.
+4. **Interpolated IV may approximate a yield-curve rate.** The interpolated
+   solver collapses a `YieldCurve` query to a flat rate and flags it via
+   `used_rate_approximation` (now carried through `MangoIvSuccess` →
+   `IvSuccess::used_rate_approximation`). Surfaced, not hidden.
 
 ## Testing
 
@@ -355,7 +392,9 @@ for every field of every new struct, plus `size_of` equality with the C
    value tracks input.
 2. **Price table queries.** Build a `PriceTable`, query `price`/`vega` and all
    four Greeks via `PricingParams`; assert finite, signs sane (PUT delta < 0),
-   and `price` ≈ FDM price within interpolation tolerance.
+   and `price` ≈ FDM price within interpolation tolerance. Also assert
+   `validate(&in_domain_params)` is `Ok` and `validate(&out_of_domain_params)`
+   (e.g. σ far outside the grid) is `Err(ErrorKind::Validation)`.
 3. **`PriceTable::iv_solver`.** Derive a solver from a built table and solve;
    assert it matches a solver built directly from the same config.
 4. **Batch solve with a deliberate failure.** A batch of queries where one has
@@ -367,8 +406,11 @@ for every field of every new struct, plus `size_of` equality with the C
 6. **Discrete-dividend build.** Build with `discrete_dividends = Some(...)` (one
    dividend) and explicit `K_refs`; solve and recover a σ. Mirrors the v1 FDM
    discrete-dividend round-trip.
-7. **Validation errors.** Empty `maturity_grid` and a non-finite `spot` each
-   return `Err(ErrorKind::Validation)` from `new`.
+7. **Validation errors.** On the *continuous* path (no `discrete_dividends`),
+   an empty `maturity_grid` returns `Err(ErrorKind::Validation)` from `new` (the
+   C++ factory rejects it). A non-finite `spot` also returns
+   `Err(ErrorKind::Validation)`. (Do **not** assert empty `maturity_grid` fails
+   on the discrete path — it legitimately uses `DiscreteDividendConfig::maturity`.)
 8. **`Send + Sync` smoke test.** Move a solver into two threads (`std::thread`)
    and solve concurrently; assert both succeed (exercises the immutability
    guarantee).
@@ -381,12 +423,17 @@ so no new C++ targets are needed.
 
 ## File-by-file change list
 
-- `src/ffi/mango_c_api.h` — new POD structs, opaque handles, 13 fn decls,
-  `static_assert` ABI guards.
-- `src/ffi/mango_c_api.cpp` — config translation, pre-validation, 13 fn impls,
-  error mapping (reusing v1 helpers).
-- `crates/mango-option-sys/src/lib.rs` — `repr(C)` mirrors + `extern "C"` decls.
-- `crates/mango-option-sys/tests/layout.rs` — `offset_of!`/`size_of` asserts.
+- `src/ffi/mango_c_api.h` — new POD structs, opaque handles, 16 new fn decls,
+  `static_assert` ABI guards; **+`int32_t used_rate_approximation` appended to
+  `MangoIvSuccess`** (offset 36, sizeof stays 40; add an offset assert).
+- `src/ffi/mango_c_api.cpp` — config translation, pre-validation, 16 fn impls,
+  error mapping (reusing v1 helpers); set `used_rate_approximation` in the
+  existing `mango_solve_iv` mapping too.
+- `crates/mango-option-sys/src/lib.rs` — `repr(C)` mirrors + `extern "C"` decls;
+  add the new `MangoIvSuccess` field.
+- `crates/mango-option-sys/tests/layout.rs` — `offset_of!`/`size_of` asserts for
+  new structs + the new `MangoIvSuccess` field.
+- `crates/mango-option/src/iv.rs` — surface `IvSuccess::used_rate_approximation`.
 - `crates/mango-option/src/interp.rs` — `FactoryConfig` family + `InterpIvSolver`.
 - `crates/mango-option/src/table.rs` — `PriceTable`.
 - `crates/mango-option/src/lib.rs` — module decls + re-exports.

--- a/docs/plans/2026-06-05-rust-interpolation-binding-impl.md
+++ b/docs/plans/2026-06-05-rust-interpolation-binding-impl.md
@@ -1,0 +1,1613 @@
+# Rust Interpolation-Path Binding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a safe, idiomatic Rust binding for the mango-option interpolation
+path — the interpolated IV solver (`make_interpolated_iv_solver`) and the
+reusable B-spline price table (`make_price_table` / `AnyPriceTable`).
+
+**Architecture:** Extends the v1 binding (PR #430). New `extern "C"` shim
+functions in `src/ffi/mango_c_api.{h,cpp}` over a flat factory-config struct
+(B-spline backend only — no `std::variant` across the ABI), raw mirrors in
+`crates/mango-option-sys`, and a safe wrapper in `crates/mango-option`
+(`interp.rs`, `table.rs`). Opaque RAII handles (`Drop`), `Send + Sync` (immutable
+surfaces). Reuses v1 marshalling helpers and Bazel link plumbing.
+
+**Tech Stack:** C++23, Rust edition 2021, Bazel `rules_rust`, GoogleTest not used
+here (Rust `#[test]` + `-sys` layout tests).
+
+**Spec:** `docs/plans/2026-06-05-rust-interpolation-binding-design.md`
+
+**Reference patterns (read these first, do not re-derive):**
+- `src/ffi/mango_c_api.h` / `.cpp` — existing structs, `set_err`,
+  `validate_option_type`, `build_rate`, `build_dividends`, `map_iv_error`,
+  `format_iv_error`, `format_validation_error`, opaque-handle + `new`/`free`.
+- `crates/mango-option-sys/src/lib.rs` + `tests/layout.rs` — `repr(C)` mirrors,
+  `offset_of!`/`size_of` asserts.
+- `crates/mango-option/src/{pricing,iv,error,types}.rs` — marshalling helpers
+  (`tenor_array`, `dividend_array`, `ptr_or_null`, `div_ptr_or_null`,
+  `blank_error`), `Error::from_c`, RAII `Drop`, `OptionType::to_c`.
+- C++ entry points: `src/option/interpolated_iv_solver.hpp`
+  (`make_interpolated_iv_solver`, `AnyInterpIVSolver::{solve,solve_batch}`,
+  `IVSolverFactoryConfig`, `IVGrid`, `BSplineBackend`, `InterpolatedIVSolverConfig`,
+  `AdaptiveGridParams`, `DiscreteDividendConfig`), `src/option/price_table_factory.hpp`
+  (`make_price_table`, `AnyPriceTable`), `src/option/grid_spec_types.hpp`
+  (`MultiKRefConfig`), `src/option/table/greek_types.hpp` (`GreekError`).
+
+**Computed ABI offsets** (x86-64 SysV, 8-byte alignment; pin these exactly):
+
+| Struct | size | field offsets |
+|---|---|---|
+| `MangoIvSuccess` (modified) | 40 | …`has_vega`@32, `used_rate_approximation`@36 |
+| `MangoInterpSolverConfig` | 40 | `max_iter`@0, `tolerance`@8, `sigma_min`@16, `sigma_max`@24, `vega_threshold`@32 |
+| `MangoAdaptiveGridParams` | 72 | `target_iv_error`@0, `max_iter`@8, `max_points_per_dim`@16, `min_moneyness_points`@24, `validation_samples`@32, `refinement_factor`@40, `lhs_seed`@48, `vega_floor`@56, `max_failure_rate`@64 |
+| `MangoMultiKRef` | 32 | `K_refs`@0, `n_K_refs`@8, `K_ref_count`@16, `K_ref_span`@24 |
+| `MangoDiscreteDividendConfig` | 56 | `maturity`@0, `dividends`@8, `n_dividends`@16, `kref_config`@24 |
+| `MangoIvFactoryConfig` | 144 | `option_type`@0, `spot`@8, `dividend_yield`@16, `moneyness`@24, `n_moneyness`@32, `vol`@40, `n_vol`@48, `rate`@56, `n_rate`@64, `maturity_grid`@72, `n_maturity`@80, `solver_config`@88, `adaptive`@128, `discrete_dividends`@136 |
+| `MangoIvBatchSlot` | 48 | `status`@0, `success`@8 |
+
+---
+
+## Task 1: Extend `MangoIvSuccess` with `used_rate_approximation`
+
+The interpolated solver sets `IVSuccess::used_rate_approximation`; the field
+slots into existing tail padding so `sizeof` stays 40 and no v1 offset moves.
+
+**Files:**
+- Modify: `src/ffi/mango_c_api.h` (struct + static_asserts)
+- Modify: `src/ffi/mango_c_api.cpp` (add `fill_iv_success` helper, use in `mango_solve_iv`)
+- Modify: `crates/mango-option-sys/src/lib.rs`
+- Modify: `crates/mango-option-sys/tests/layout.rs`
+- Modify: `crates/mango-option/src/iv.rs`
+
+- [ ] **Step 1: Update the `-sys` layout test first (must fail to compile/run)**
+
+In `crates/mango-option-sys/tests/layout.rs`, extend `small_struct_layouts`:
+
+```rust
+    assert_eq!(size_of::<MangoIvSuccess>(), 40);
+    assert_eq!(offset_of!(MangoIvSuccess, has_vega), 32);
+    assert_eq!(offset_of!(MangoIvSuccess, used_rate_approximation), 36);
+```
+
+- [ ] **Step 2: Run the layout test — expect a COMPILE error**
+
+Run: `bazel test //crates/mango-option-sys:layout_test`
+Expected: FAIL — `no field used_rate_approximation on MangoIvSuccess`.
+
+- [ ] **Step 3: Add the field to the `-sys` struct**
+
+In `crates/mango-option-sys/src/lib.rs`, `MangoIvSuccess`:
+
+```rust
+#[repr(C)]
+pub struct MangoIvSuccess {
+    pub implied_vol: f64,
+    pub iterations: u64,
+    pub final_error: f64,
+    pub vega: f64,
+    pub has_vega: i32,
+    pub used_rate_approximation: i32,
+}
+```
+
+- [ ] **Step 4: Add the field + static_asserts to the C header**
+
+In `src/ffi/mango_c_api.h`, `MangoIvSuccess`:
+
+```c
+typedef struct {
+  double implied_vol;
+  uint64_t iterations;
+  double final_error;
+  double vega;
+  int32_t has_vega;
+  int32_t used_rate_approximation;
+} MangoIvSuccess;
+```
+
+Update BOTH the `__cplusplus` and `_Static_assert` guard blocks: keep
+`sizeof(MangoIvSuccess) == 40` and `offsetof(..., has_vega) == 32`, and ADD
+`offsetof(MangoIvSuccess, used_rate_approximation) == 36`.
+
+- [ ] **Step 5: Add `fill_iv_success` helper and use it in `mango_solve_iv`**
+
+In `src/ffi/mango_c_api.cpp`, add to the anonymous namespace:
+
+```cpp
+void fill_iv_success(MangoIvSuccess* out, const mango::IVSuccess& s) {
+  out->implied_vol = s.implied_vol;
+  out->iterations = static_cast<uint64_t>(s.iterations);
+  out->final_error = s.final_error;
+  out->vega = s.vega.value_or(0.0);
+  out->has_vega = s.vega.has_value() ? 1 : 0;
+  out->used_rate_approximation = s.used_rate_approximation ? 1 : 0;
+}
+```
+
+Replace the five `out_success->… = s.…;` lines in `mango_solve_iv` with:
+`fill_iv_success(out_success, s);`
+
+- [ ] **Step 6: Surface the field on the safe `IvSuccess`**
+
+In `crates/mango-option/src/iv.rs`, add to `IvSuccess`:
+
+```rust
+#[derive(Debug)]
+pub struct IvSuccess {
+    pub implied_vol: f64,
+    pub iterations: usize,
+    pub final_error: f64,
+    pub vega: Option<f64>,
+    pub used_rate_approximation: bool,
+}
+```
+
+And in `solve_iv`'s success arm, add the field:
+
+```rust
+        Ok(IvSuccess {
+            implied_vol: out.implied_vol,
+            iterations: out.iterations as usize,
+            final_error: out.final_error,
+            vega: if out.has_vega != 0 { Some(out.vega) } else { None },
+            used_rate_approximation: out.used_rate_approximation != 0,
+        })
+```
+
+- [ ] **Step 7: Build the shim + run all v1 tests**
+
+Run: `bazel test //crates/mango-option-sys:layout_test //crates/mango-option:integration_test`
+Expected: PASS (FDM path still green; new offset asserted).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ffi/mango_c_api.h src/ffi/mango_c_api.cpp \
+        crates/mango-option-sys/src/lib.rs crates/mango-option-sys/tests/layout.rs \
+        crates/mango-option/src/iv.rs
+git commit -m "Carry used_rate_approximation through MangoIvSuccess"
+```
+
+---
+
+## Task 2: Add interpolation C structs, handles, and decls (header + `-sys` + layout test)
+
+ABI types land together with their bidirectional guards, but NO shim
+implementation yet (the `.cpp` library still compiles — undefined `extern "C"`
+decls are fine until a consumer links them; the layout test references only types).
+
+**Files:**
+- Modify: `src/ffi/mango_c_api.h`
+- Modify: `crates/mango-option-sys/src/lib.rs`
+- Modify: `crates/mango-option-sys/tests/layout.rs`
+
+- [ ] **Step 1: Write the layout asserts first**
+
+Append to `crates/mango-option-sys/tests/layout.rs`:
+
+```rust
+#[test]
+fn interp_solver_config_layout() {
+    assert_eq!(size_of::<MangoInterpSolverConfig>(), 40);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, max_iter), 0);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, tolerance), 8);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, sigma_min), 16);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, sigma_max), 24);
+    assert_eq!(offset_of!(MangoInterpSolverConfig, vega_threshold), 32);
+}
+
+#[test]
+fn adaptive_grid_params_layout() {
+    assert_eq!(size_of::<MangoAdaptiveGridParams>(), 72);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, target_iv_error), 0);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, max_iter), 8);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, max_points_per_dim), 16);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, min_moneyness_points), 24);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, validation_samples), 32);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, refinement_factor), 40);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, lhs_seed), 48);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, vega_floor), 56);
+    assert_eq!(offset_of!(MangoAdaptiveGridParams, max_failure_rate), 64);
+}
+
+#[test]
+fn multi_kref_layout() {
+    assert_eq!(size_of::<MangoMultiKRef>(), 32);
+    assert_eq!(offset_of!(MangoMultiKRef, K_refs), 0);
+    assert_eq!(offset_of!(MangoMultiKRef, n_K_refs), 8);
+    assert_eq!(offset_of!(MangoMultiKRef, K_ref_count), 16);
+    assert_eq!(offset_of!(MangoMultiKRef, K_ref_span), 24);
+}
+
+#[test]
+fn discrete_dividend_config_layout() {
+    assert_eq!(size_of::<MangoDiscreteDividendConfig>(), 56);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, maturity), 0);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, dividends), 8);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, n_dividends), 16);
+    assert_eq!(offset_of!(MangoDiscreteDividendConfig, kref_config), 24);
+}
+
+#[test]
+fn iv_factory_config_layout() {
+    assert_eq!(size_of::<MangoIvFactoryConfig>(), 144);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, option_type), 0);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, spot), 8);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, dividend_yield), 16);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, moneyness), 24);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_moneyness), 32);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, vol), 40);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_vol), 48);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, rate), 56);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_rate), 64);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, maturity_grid), 72);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, n_maturity), 80);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, solver_config), 88);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, adaptive), 128);
+    assert_eq!(offset_of!(MangoIvFactoryConfig, discrete_dividends), 136);
+}
+
+#[test]
+fn iv_batch_slot_layout() {
+    assert_eq!(size_of::<MangoIvBatchSlot>(), 48);
+    assert_eq!(offset_of!(MangoIvBatchSlot, status), 0);
+    assert_eq!(offset_of!(MangoIvBatchSlot, success), 8);
+}
+```
+
+- [ ] **Step 2: Run — expect compile failure (types undefined)**
+
+Run: `bazel test //crates/mango-option-sys:layout_test`
+Expected: FAIL — unknown types `MangoInterpSolverConfig`, etc.
+
+- [ ] **Step 3: Add the C structs + handles + decls to the header**
+
+In `src/ffi/mango_c_api.h`, before the ABI-guard block, add the structs from the
+spec's "C ABI" section (`MangoInterpSolverConfig`, `MangoAdaptiveGridParams`,
+`MangoMultiKRef`, `MangoDiscreteDividendConfig`, `MangoIvFactoryConfig`,
+`MangoIvBatchSlot`, opaque `MangoInterpIvSolver`/`MangoPriceTable`) and the 16
+function declarations. Use `uint64_t` for `size_t`-typed fields. Then add, to
+BOTH guard blocks, `static_assert`/`_Static_assert` for every size + offset in
+the "Computed ABI offsets" table.
+
+- [ ] **Step 4: Mirror in `-sys` `lib.rs`**
+
+In `crates/mango-option-sys/src/lib.rs`, add `#[repr(C)]` structs mirroring the
+header (derive `Clone, Copy` on the POD config structs;
+`MangoInterpIvSolver`/`MangoPriceTable` as opaque `_private: [u8; 0]`), and the
+16 `extern "C"` function declarations. Field names/types EXACTLY match the
+header. Example for the factory config:
+
+```rust
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MangoIvFactoryConfig {
+    pub option_type: MangoOptionType,
+    pub spot: f64,
+    pub dividend_yield: f64,
+    pub moneyness: *const f64,
+    pub n_moneyness: u64,
+    pub vol: *const f64,
+    pub n_vol: u64,
+    pub rate: *const f64,
+    pub n_rate: u64,
+    pub maturity_grid: *const f64,
+    pub n_maturity: u64,
+    pub solver_config: MangoInterpSolverConfig,
+    pub adaptive: *const MangoAdaptiveGridParams,
+    pub discrete_dividends: *const MangoDiscreteDividendConfig,
+}
+```
+
+Declarations (full set):
+
+```rust
+extern "C" {
+    pub fn mango_make_interp_iv_solver(
+        cfg: *const MangoIvFactoryConfig,
+        out: *mut *mut MangoInterpIvSolver,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_interp_iv_solve(
+        s: *const MangoInterpIvSolver,
+        q: *const MangoIvQuery,
+        out: *mut MangoIvSuccess,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_interp_iv_solve_batch(
+        s: *const MangoInterpIvSolver,
+        queries: *const MangoIvQuery,
+        n: u64,
+        out_slots: *mut MangoIvBatchSlot,
+        out_failed_count: *mut u64,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_interp_iv_solver_free(s: *mut MangoInterpIvSolver);
+
+    pub fn mango_make_price_table(
+        cfg: *const MangoIvFactoryConfig,
+        out: *mut *mut MangoPriceTable,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_validate(
+        t: *const MangoPriceTable,
+        p: *const MangoPricingParams,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_price(t: *const MangoPriceTable, p: *const MangoPricingParams) -> f64;
+    pub fn mango_price_table_vega(t: *const MangoPriceTable, p: *const MangoPricingParams) -> f64;
+    pub fn mango_price_table_delta(t: *const MangoPriceTable, p: *const MangoPricingParams, out: *mut f64, err: *mut MangoError) -> MangoStatus;
+    pub fn mango_price_table_gamma(t: *const MangoPriceTable, p: *const MangoPricingParams, out: *mut f64, err: *mut MangoError) -> MangoStatus;
+    pub fn mango_price_table_theta(t: *const MangoPriceTable, p: *const MangoPricingParams, out: *mut f64, err: *mut MangoError) -> MangoStatus;
+    pub fn mango_price_table_rho(t: *const MangoPriceTable, p: *const MangoPricingParams, out: *mut f64, err: *mut MangoError) -> MangoStatus;
+    pub fn mango_price_table_option_type(t: *const MangoPriceTable) -> MangoOptionType;
+    pub fn mango_price_table_dividend_yield(t: *const MangoPriceTable) -> f64;
+    pub fn mango_price_table_make_iv_solver(
+        t: *const MangoPriceTable,
+        cfg: *const MangoInterpSolverConfig,
+        out: *mut *mut MangoInterpIvSolver,
+        err: *mut MangoError,
+    ) -> MangoStatus;
+    pub fn mango_price_table_free(t: *mut MangoPriceTable);
+}
+```
+
+> Note: `K_refs`/`K_ref_count`/`n_K_refs` keep their C capitalization; add
+> `#![allow(non_snake_case)]` is unnecessary because these are struct fields, not
+> idents that trip `non_snake_case` for fns — but if the linter warns, allow it
+> at the struct or crate level (`#![allow(non_snake_case)]` already paired with
+> the crate's existing `#![allow(non_camel_case_types)]`).
+
+- [ ] **Step 5: Build header static_asserts + run layout test**
+
+Run: `bazel build //src/ffi:mango_c_api && bazel test //crates/mango-option-sys:layout_test`
+Expected: PASS — header compiles (static_asserts hold), all layout tests green.
+If a `static_assert` fires, the offset table is the source of truth; fix the
+struct, not the assert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ffi/mango_c_api.h crates/mango-option-sys/src/lib.rs crates/mango-option-sys/tests/layout.rs
+git commit -m "Add interpolation-path C ABI structs and declarations"
+```
+
+---
+
+## Task 3: Implement the interpolated IV solver shim
+
+**Files:**
+- Modify: `src/ffi/mango_c_api.cpp`
+- Modify: `src/ffi/BUILD.bazel` (add interpolation dep)
+
+- [ ] **Step 1: Add includes + dep**
+
+In `mango_c_api.cpp` add:
+```cpp
+#include "mango/option/interpolated_iv_solver.hpp"
+#include "mango/option/price_table_factory.hpp"
+```
+In `src/ffi/BUILD.bazel`, add to `mango_c_api`'s `deps`:
+```python
+        "//src/option:interpolated_iv_solver",
+        "//src/option:price_table_factory",
+```
+
+- [ ] **Step 2: Add config/query translation helpers (anonymous namespace)**
+
+```cpp
+std::vector<double> to_vec(const double* p, uint64_t n) {
+  if (n == 0 || p == nullptr) return {};
+  return std::vector<double>(p, p + n);
+}
+
+MangoStatus map_greek_error(mango::GreekError e) {
+  return e == mango::GreekError::OutOfDomain ? MANGO_ERR_VALIDATION
+                                             : MANGO_ERR_SOLVER;
+}
+const char* greek_error_msg(mango::GreekError e) {
+  return e == mango::GreekError::OutOfDomain
+             ? "greek query point outside surface domain"
+             : "greek numerical computation failed";
+}
+
+// Build a C++ IVQuery from the C struct (rate + dividends + option type).
+bool build_iv_query(const MangoIvQuery* q, mango::IVQuery& out, MangoError* err) {
+  mango::OptionSpec spec;
+  spec.spot = q->spot; spec.strike = q->strike;
+  spec.maturity = q->maturity; spec.dividend_yield = q->dividend_yield;
+  if (!validate_option_type(q->option_type, err, spec.option_type)) return false;
+  if (!build_rate(q->rate_const, q->tenor_points, q->n_tenor_points, spec.rate, err))
+    return false;
+  out = mango::IVQuery(spec, q->market_price);
+  if (!build_dividends(q->dividends, q->n_dividends, out.discrete_dividends, err))
+    return false;
+  return true;
+}
+
+// Translate the flat factory config into the C++ IVSolverFactoryConfig.
+bool build_factory_config(const MangoIvFactoryConfig* c,
+                          mango::IVSolverFactoryConfig& out, MangoError* err) {
+  if (!validate_option_type(c->option_type, err, out.option_type)) return false;
+  if (!std::isfinite(c->spot)) {
+    set_err(err, MANGO_ERR_VALIDATION, "spot must be finite"); return false;
+  }
+  if (!std::isfinite(c->dividend_yield)) {
+    set_err(err, MANGO_ERR_VALIDATION, "dividend_yield must be finite"); return false;
+  }
+  out.spot = c->spot;
+  out.dividend_yield = c->dividend_yield;
+  out.grid.moneyness = to_vec(c->moneyness, c->n_moneyness);
+  out.grid.vol = to_vec(c->vol, c->n_vol);
+  out.grid.rate = to_vec(c->rate, c->n_rate);
+  out.backend = mango::BSplineBackend{to_vec(c->maturity_grid, c->n_maturity)};
+  out.solver_config.max_iter = static_cast<std::size_t>(c->solver_config.max_iter);
+  out.solver_config.tolerance = c->solver_config.tolerance;
+  out.solver_config.sigma_min = c->solver_config.sigma_min;
+  out.solver_config.sigma_max = c->solver_config.sigma_max;
+  out.solver_config.vega_threshold = c->solver_config.vega_threshold;
+  if (c->adaptive) {
+    mango::AdaptiveGridParams a;
+    a.target_iv_error = c->adaptive->target_iv_error;
+    a.max_iter = static_cast<std::size_t>(c->adaptive->max_iter);
+    a.max_points_per_dim = static_cast<std::size_t>(c->adaptive->max_points_per_dim);
+    a.min_moneyness_points = static_cast<std::size_t>(c->adaptive->min_moneyness_points);
+    a.validation_samples = static_cast<std::size_t>(c->adaptive->validation_samples);
+    a.refinement_factor = c->adaptive->refinement_factor;
+    a.lhs_seed = c->adaptive->lhs_seed;
+    a.vega_floor = c->adaptive->vega_floor;
+    a.max_failure_rate = c->adaptive->max_failure_rate;
+    out.adaptive = a;
+  }
+  if (c->discrete_dividends) {
+    const auto* d = c->discrete_dividends;
+    mango::DiscreteDividendConfig dd;
+    dd.maturity = d->maturity;
+    if (!build_dividends(d->dividends, d->n_dividends, dd.discrete_dividends, err))
+      return false;
+    dd.kref_config.K_refs = to_vec(d->kref_config.K_refs, d->kref_config.n_K_refs);
+    dd.kref_config.K_ref_count =
+        (d->kref_config.n_K_refs == 0 && d->kref_config.K_ref_count <= 0)
+            ? 11 : d->kref_config.K_ref_count;
+    dd.kref_config.K_ref_span = d->kref_config.K_ref_span;
+    out.discrete_dividends = dd;
+  }
+  return true;
+}
+```
+
+- [ ] **Step 3: Add the opaque wrapper structs (after `MangoAmericanResult`)**
+
+```cpp
+struct MangoInterpIvSolver { mango::AnyInterpIVSolver solver; };
+struct MangoPriceTable { mango::AnyPriceTable table; };
+```
+
+- [ ] **Step 4: Implement solver functions inside `extern "C"`**
+
+```cpp
+MangoStatus mango_make_interp_iv_solver(const MangoIvFactoryConfig* cfg,
+                                        MangoInterpIvSolver** out,
+                                        MangoError* err) {
+  if (!cfg || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null cfg or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  *out = nullptr;
+  try {
+    mango::IVSolverFactoryConfig fc;
+    if (!build_factory_config(cfg, fc, err)) return MANGO_ERR_VALIDATION;
+    auto result = mango::make_interpolated_iv_solver(fc);
+    if (!result) {
+      std::string msg = format_validation_error(result.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    *out = new MangoInterpIvSolver{std::move(result.value())};
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+MangoStatus mango_interp_iv_solve(const MangoInterpIvSolver* s,
+                                  const MangoIvQuery* q,
+                                  MangoIvSuccess* out, MangoError* err) {
+  if (!s || !q || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null solver, query, or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    mango::IVQuery query;
+    if (!build_iv_query(q, query, err)) return MANGO_ERR_VALIDATION;
+    auto result = s->solver.solve(query);
+    if (!result) {
+      auto code = map_iv_error(result.error());
+      std::string msg = format_iv_error(result.error());
+      set_err(err, code, msg.c_str());
+      return code;
+    }
+    fill_iv_success(out, result.value());
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+MangoStatus mango_interp_iv_solve_batch(const MangoInterpIvSolver* s,
+                                        const MangoIvQuery* queries, uint64_t n,
+                                        MangoIvBatchSlot* out_slots,
+                                        uint64_t* out_failed_count,
+                                        MangoError* err) {
+  if (!s || (!queries && n > 0) || (!out_slots && n > 0)) {
+    set_err(err, MANGO_ERR_VALIDATION, "null solver, queries, or out_slots");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    std::vector<mango::IVQuery> qs;
+    qs.reserve(n);
+    for (uint64_t i = 0; i < n; ++i) {
+      mango::IVQuery query;
+      if (!build_iv_query(&queries[i], query, err)) return MANGO_ERR_VALIDATION;
+      qs.push_back(std::move(query));
+    }
+    auto batch = s->solver.solve_batch(qs);  // noexcept
+    for (uint64_t i = 0; i < n; ++i) {
+      const auto& r = batch.results[i];
+      if (r.has_value()) {
+        out_slots[i].status = MANGO_OK;
+        fill_iv_success(&out_slots[i].success, r.value());
+      } else {
+        out_slots[i].status = map_iv_error(r.error());
+        out_slots[i].success = MangoIvSuccess{};
+      }
+    }
+    if (out_failed_count) *out_failed_count = batch.failed_count;
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+void mango_interp_iv_solver_free(MangoInterpIvSolver* s) { delete s; }
+```
+
+- [ ] **Step 5: Build the shim**
+
+Run: `bazel build //src/ffi:mango_c_api`
+Expected: PASS. (Confirms `AnyInterpIVSolver`/`BatchIVResult`/`solve_batch` field
+names — if `batch.results`/`batch.failed_count` mismatch, check
+`interpolated_iv_solver.hpp` for the real `BatchIVResult` member names and fix.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ffi/mango_c_api.cpp src/ffi/BUILD.bazel
+git commit -m "Implement interpolated IV solver C shim"
+```
+
+---
+
+## Task 4: Implement the price-table shim
+
+**Files:**
+- Modify: `src/ffi/mango_c_api.cpp`
+
+- [ ] **Step 1: Add a `PricingParams` builder helper (anonymous namespace)**
+
+```cpp
+bool build_pricing_params(const MangoPricingParams* p, mango::PricingParams& out,
+                          MangoError* err) {
+  out.spot = p->spot; out.strike = p->strike;
+  out.maturity = p->maturity; out.dividend_yield = p->dividend_yield;
+  out.volatility = p->volatility;
+  if (!validate_option_type(p->option_type, err, out.option_type)) return false;
+  if (!build_rate(p->rate_const, p->tenor_points, p->n_tenor_points, out.rate, err))
+    return false;
+  if (!build_dividends(p->dividends, p->n_dividends, out.discrete_dividends, err))
+    return false;
+  return true;
+}
+```
+(Requires `#include "mango/option/american_option.hpp"` for `mango::PricingParams`
+— already pulled in transitively; add the include if compilation complains.)
+
+- [ ] **Step 2: Implement the price-table functions inside `extern "C"`**
+
+```cpp
+MangoStatus mango_make_price_table(const MangoIvFactoryConfig* cfg,
+                                   MangoPriceTable** out, MangoError* err) {
+  if (!cfg || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null cfg or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  *out = nullptr;
+  try {
+    mango::IVSolverFactoryConfig fc;
+    if (!build_factory_config(cfg, fc, err)) return MANGO_ERR_VALIDATION;
+    auto result = mango::make_price_table(fc);
+    if (!result) {
+      std::string msg = format_validation_error(result.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    *out = new MangoPriceTable{std::move(result.value())};
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+MangoStatus mango_price_table_validate(const MangoPriceTable* t,
+                                       const MangoPricingParams* p,
+                                       MangoError* err) {
+  if (!t || !p) {
+    set_err(err, MANGO_ERR_VALIDATION, "null table or params");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, err)) return MANGO_ERR_VALIDATION;
+    auto v = t->table.validate_pricing_params(pp);
+    if (!v) {
+      std::string msg = format_validation_error(v.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+// price/vega: infallible f64; nan on null/build failure (extrapolates in domain).
+double mango_price_table_price(const MangoPriceTable* t, const MangoPricingParams* p) {
+  if (!t || !p) return std::nan("");
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, nullptr)) return std::nan("");
+    return t->table.price(pp);
+  } catch (...) { return std::nan(""); }
+}
+double mango_price_table_vega(const MangoPriceTable* t, const MangoPricingParams* p) {
+  if (!t || !p) return std::nan("");
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, nullptr)) return std::nan("");
+    return t->table.vega(pp);
+  } catch (...) { return std::nan(""); }
+}
+```
+
+For the four Greeks, write a macro-free helper to avoid repetition:
+
+```cpp
+namespace {
+template <typename Fn>
+MangoStatus greek_call(const MangoPriceTable* t, const MangoPricingParams* p,
+                       double* out, MangoError* err, Fn&& fn) {
+  if (!t || !p || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null table, params, or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, err)) return MANGO_ERR_VALIDATION;
+    auto r = fn(t->table, pp);
+    if (!r) {
+      set_err(err, map_greek_error(r.error()), greek_error_msg(r.error()));
+      return map_greek_error(r.error());
+    }
+    *out = r.value();
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+}  // namespace
+```
+
+> Note: this template helper must be declared in the anonymous namespace BEFORE
+> the `extern "C"` block. Then:
+
+```cpp
+MangoStatus mango_price_table_delta(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err) {
+  return greek_call(t, p, out, err,
+                    [](const mango::AnyPriceTable& tb, const mango::PricingParams& pp) {
+                      return tb.delta(pp);
+                    });
+}
+// gamma, theta, rho: identical, calling tb.gamma / tb.theta / tb.rho.
+
+MangoOptionType mango_price_table_option_type(const MangoPriceTable* t) {
+  if (!t) return MANGO_PUT;  // arbitrary default on null; callers null-check handles
+  return t->table.option_type() == mango::OptionType::CALL ? MANGO_CALL : MANGO_PUT;
+}
+double mango_price_table_dividend_yield(const MangoPriceTable* t) {
+  return t ? t->table.dividend_yield() : std::nan("");
+}
+
+MangoStatus mango_price_table_make_iv_solver(const MangoPriceTable* t,
+                                             const MangoInterpSolverConfig* cfg,
+                                             MangoInterpIvSolver** out,
+                                             MangoError* err) {
+  if (!t || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null table or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  *out = nullptr;
+  try {
+    mango::InterpolatedIVSolverConfig sc;  // defaults
+    if (cfg) {
+      sc.max_iter = static_cast<std::size_t>(cfg->max_iter);
+      sc.tolerance = cfg->tolerance;
+      sc.sigma_min = cfg->sigma_min;
+      sc.sigma_max = cfg->sigma_max;
+      sc.vega_threshold = cfg->vega_threshold;
+    }
+    auto result = t->table.make_iv_solver(sc);
+    if (!result) {
+      std::string msg = format_validation_error(result.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    *out = new MangoInterpIvSolver{std::move(result.value())};
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+void mango_price_table_free(MangoPriceTable* t) { delete t; }
+```
+
+- [ ] **Step 3: Build the shim**
+
+Run: `bazel build //src/ffi:mango_c_api`
+Expected: PASS. (Confirms `AnyPriceTable::{price,vega,delta,…,validate_pricing_params,make_iv_solver}`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ffi/mango_c_api.cpp
+git commit -m "Implement price-table C shim"
+```
+
+---
+
+## Task 5: Safe Rust `interp.rs` (factory config + interpolated IV solver)
+
+**Files:**
+- Create: `crates/mango-option/src/interp.rs`
+- Modify: `crates/mango-option/src/lib.rs`
+- Modify: `crates/mango-option/src/pricing.rs` (make `dividend_array` reusable — already `pub(crate)`)
+- Create: `crates/mango-option/tests/interpolation.rs`
+- Modify: `crates/mango-option/BUILD.bazel`
+
+- [ ] **Step 1: Write `interp.rs`**
+
+```rust
+// SPDX-License-Identifier: MIT
+use crate::error::{Error, ErrorKind};
+use crate::iv::{IvQuery, IvSuccess};
+use crate::pricing::{blank_error, div_ptr_or_null, dividend_array, ptr_or_null, tenor_array};
+use crate::types::{Dividend, OptionType, Rate};
+use mango_option_sys as sys;
+
+/// IV grid axes (S/K moneyness, NOT log). Default mirrors the C++ IVGrid.
+#[derive(Debug, Clone)]
+pub struct IvGrid {
+    pub moneyness: Vec<f64>,
+    pub vol: Vec<f64>,
+    pub rate: Vec<f64>,
+}
+impl Default for IvGrid {
+    fn default() -> Self {
+        IvGrid {
+            moneyness: vec![0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3],
+            vol: vec![0.05, 0.10, 0.20, 0.30, 0.50],
+            rate: vec![0.01, 0.03, 0.05, 0.10],
+        }
+    }
+}
+
+/// Newton config for the interpolated solver. Default mirrors C++ defaults.
+#[derive(Debug, Clone, Copy)]
+pub struct InterpSolverConfig {
+    pub max_iter: usize,
+    pub tolerance: f64,
+    pub sigma_min: f64,
+    pub sigma_max: f64,
+    pub vega_threshold: f64,
+}
+impl Default for InterpSolverConfig {
+    fn default() -> Self {
+        InterpSolverConfig {
+            max_iter: 50,
+            tolerance: 1e-6,
+            sigma_min: 0.01,
+            sigma_max: 3.0,
+            vega_threshold: 1e-4,
+        }
+    }
+}
+impl InterpSolverConfig {
+    fn to_c(self) -> sys::MangoInterpSolverConfig {
+        sys::MangoInterpSolverConfig {
+            max_iter: self.max_iter as u64,
+            tolerance: self.tolerance,
+            sigma_min: self.sigma_min,
+            sigma_max: self.sigma_max,
+            vega_threshold: self.vega_threshold,
+        }
+    }
+}
+
+/// Adaptive grid refinement params. Default mirrors C++ defaults.
+#[derive(Debug, Clone, Copy)]
+pub struct AdaptiveGridParams {
+    pub target_iv_error: f64,
+    pub max_iter: usize,
+    pub max_points_per_dim: usize,
+    pub min_moneyness_points: usize,
+    pub validation_samples: usize,
+    pub refinement_factor: f64,
+    pub lhs_seed: u64,
+    pub vega_floor: f64,
+    pub max_failure_rate: f64,
+}
+impl Default for AdaptiveGridParams {
+    fn default() -> Self {
+        AdaptiveGridParams {
+            target_iv_error: 2e-5,
+            max_iter: 5,
+            max_points_per_dim: 160,
+            min_moneyness_points: 60,
+            validation_samples: 64,
+            refinement_factor: 1.3,
+            lhs_seed: 42,
+            vega_floor: 1e-4,
+            max_failure_rate: 0.5,
+        }
+    }
+}
+impl AdaptiveGridParams {
+    fn to_c(&self) -> sys::MangoAdaptiveGridParams {
+        sys::MangoAdaptiveGridParams {
+            target_iv_error: self.target_iv_error,
+            max_iter: self.max_iter as u64,
+            max_points_per_dim: self.max_points_per_dim as u64,
+            min_moneyness_points: self.min_moneyness_points as u64,
+            validation_samples: self.validation_samples as u64,
+            refinement_factor: self.refinement_factor,
+            lhs_seed: self.lhs_seed,
+            vega_floor: self.vega_floor,
+            max_failure_rate: self.max_failure_rate,
+        }
+    }
+}
+
+/// Multi reference-strike config for the discrete-dividend path.
+#[derive(Debug, Clone)]
+pub struct MultiKRef {
+    pub k_refs: Vec<f64>,
+    pub k_ref_count: i32,
+    pub k_ref_span: f64,
+}
+impl Default for MultiKRef {
+    fn default() -> Self {
+        MultiKRef { k_refs: Vec::new(), k_ref_count: 11, k_ref_span: 0.3 }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscreteDividendConfig {
+    pub maturity: f64,
+    pub dividends: Vec<Dividend>,
+    pub kref_config: MultiKRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactoryConfig {
+    pub option_type: OptionType,
+    pub spot: f64,
+    pub dividend_yield: f64,
+    pub grid: IvGrid,
+    pub maturity_grid: Vec<f64>,
+    pub solver: InterpSolverConfig,
+    pub adaptive: Option<AdaptiveGridParams>,
+    pub discrete_dividends: Option<DiscreteDividendConfig>,
+}
+
+/// Result of a batch solve: per-query results plus the failure count.
+#[derive(Debug)]
+pub struct BatchResult {
+    pub results: Vec<Result<IvSuccess, Error>>,
+    pub failed: usize,
+}
+
+/// Interpolated IV solver over a pre-built B-spline surface. Thread-safe to
+/// query concurrently (immutable surface).
+pub struct InterpIvSolver {
+    handle: *mut sys::MangoInterpIvSolver,
+}
+// SAFETY: the C++ AnyInterpIVSolver wraps an immutable surface; solve()/
+// solve_batch() are const and documented thread-safe.
+unsafe impl Send for InterpIvSolver {}
+unsafe impl Sync for InterpIvSolver {}
+
+impl core::fmt::Debug for InterpIvSolver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "InterpIvSolver({:p})", self.handle)
+    }
+}
+
+impl InterpIvSolver {
+    pub fn new(cfg: &FactoryConfig) -> Result<Self, Error> {
+        let mut handle: *mut sys::MangoInterpIvSolver = core::ptr::null_mut();
+        let h = with_c_config(cfg, |c, err| unsafe {
+            (sys::mango_make_interp_iv_solver(c, &mut handle, err), handle)
+        })?;
+        Ok(InterpIvSolver { handle: h })
+    }
+
+    pub fn solve(&self, query: &IvQuery) -> Result<IvSuccess, Error> {
+        let (c, _keep) = iv_query_to_c(query)?;
+        let mut out = blank_iv_success();
+        let mut err = blank_error();
+        let status =
+            unsafe { sys::mango_interp_iv_solve(self.handle, &c, &mut out, &mut err) };
+        if status == sys::MANGO_OK {
+            Ok(iv_success_from_c(&out))
+        } else {
+            Err(Error::from_c(status, &err))
+        }
+    }
+
+    pub fn solve_batch(&self, queries: &[IvQuery]) -> BatchResult {
+        // Build C queries; keep their backing arrays alive until the call returns.
+        let mut c_queries = Vec::with_capacity(queries.len());
+        let mut keepalive = Vec::with_capacity(queries.len());
+        for q in queries {
+            match iv_query_to_c(q) {
+                Ok((c, keep)) => {
+                    c_queries.push(c);
+                    keepalive.push(keep);
+                }
+                Err(e) => {
+                    // A structurally-invalid query fails the whole batch up front,
+                    // mirroring the shim's per-query build validation.
+                    return BatchResult {
+                        results: queries.iter().map(|_| Err(e.clone())).collect(),
+                        failed: queries.len(),
+                    };
+                }
+            }
+        }
+        let n = c_queries.len() as u64;
+        let mut slots: Vec<sys::MangoIvBatchSlot> = (0..c_queries.len())
+            .map(|_| sys::MangoIvBatchSlot { status: 0, success: blank_iv_success() })
+            .collect();
+        let mut failed: u64 = 0;
+        let mut err = blank_error();
+        let status = unsafe {
+            sys::mango_interp_iv_solve_batch(
+                self.handle,
+                if c_queries.is_empty() { core::ptr::null() } else { c_queries.as_ptr() },
+                n,
+                if slots.is_empty() { core::ptr::null_mut() } else { slots.as_mut_ptr() },
+                &mut failed,
+                &mut err,
+            )
+        };
+        if status != sys::MANGO_OK {
+            let e = Error::from_c(status, &err);
+            return BatchResult {
+                results: queries.iter().map(|_| Err(e.clone())).collect(),
+                failed: queries.len(),
+            };
+        }
+        let results = slots
+            .iter()
+            .map(|s| {
+                if s.status == sys::MANGO_OK {
+                    Ok(iv_success_from_c(&s.success))
+                } else {
+                    Err(Error { kind: ErrorKind::from_status(s.status),
+                                message: batch_error_message(s.status) })
+                }
+            })
+            .collect();
+        BatchResult { results, failed: failed as usize }
+    }
+}
+
+impl Drop for InterpIvSolver {
+    fn drop(&mut self) {
+        unsafe { sys::mango_interp_iv_solver_free(self.handle) }
+    }
+}
+
+// --- shared helpers used by interp.rs and table.rs ---
+
+pub(crate) fn blank_iv_success() -> sys::MangoIvSuccess {
+    sys::MangoIvSuccess {
+        implied_vol: 0.0, iterations: 0, final_error: 0.0,
+        vega: 0.0, has_vega: 0, used_rate_approximation: 0,
+    }
+}
+
+pub(crate) fn iv_success_from_c(out: &sys::MangoIvSuccess) -> IvSuccess {
+    IvSuccess {
+        implied_vol: out.implied_vol,
+        iterations: out.iterations as usize,
+        final_error: out.final_error,
+        vega: if out.has_vega != 0 { Some(out.vega) } else { None },
+        used_rate_approximation: out.used_rate_approximation != 0,
+    }
+}
+
+fn batch_error_message(status: i32) -> String {
+    format!("interpolated IV solve failed ({})", ErrorKind::from_status(status))
+}
+
+// Backing arrays that must outlive an FFI call referencing their pointers.
+pub(crate) struct IvQueryKeepalive {
+    _tenors: Vec<sys::MangoTenorPoint>,
+    _divs: Vec<sys::MangoDividend>,
+}
+
+pub(crate) fn iv_query_to_c(
+    query: &IvQuery,
+) -> Result<(sys::MangoIvQuery, IvQueryKeepalive), Error> {
+    if matches!(&query.spec.rate, Rate::Curve(v) if v.is_empty()) {
+        return Err(Error { kind: ErrorKind::Validation,
+                           message: "yield curve has no tenor points".to_string() });
+    }
+    let tenors = tenor_array(&query.spec.rate);
+    let divs = dividend_array(&query.spec.discrete_dividends);
+    let rate_const = match query.spec.rate {
+        Rate::Const(r) => r,
+        Rate::Curve(_) => 0.0,
+    };
+    let c = sys::MangoIvQuery {
+        spot: query.spec.spot,
+        strike: query.spec.strike,
+        maturity: query.spec.maturity,
+        dividend_yield: query.spec.dividend_yield,
+        market_price: query.market_price,
+        rate_const,
+        tenor_points: ptr_or_null(&tenors),
+        n_tenor_points: tenors.len() as u64,
+        dividends: div_ptr_or_null(&divs),
+        n_dividends: divs.len() as u64,
+        option_type: query.spec.option_type.to_c(),
+    };
+    Ok((c, IvQueryKeepalive { _tenors: tenors, _divs: divs }))
+}
+
+// Build the C factory config, keeping every Vec alive across the FFI call,
+// then invoke `f` with a pointer to the config and the error out-param.
+fn with_c_config<T>(
+    cfg: &FactoryConfig,
+    f: impl FnOnce(*const sys::MangoIvFactoryConfig, *mut sys::MangoError) -> (i32, T),
+) -> Result<T, Error> {
+    let moneyness = cfg.grid.moneyness.clone();
+    let vol = cfg.grid.vol.clone();
+    let rate = cfg.grid.rate.clone();
+    let maturity = cfg.maturity_grid.clone();
+
+    let adaptive_c = cfg.adaptive.as_ref().map(|a| a.to_c());
+    // Discrete-dividend sub-config: keep its Vecs alive too.
+    let dd = cfg.discrete_dividends.as_ref().map(|d| {
+        let divs = dividend_array(&d.dividends);
+        let krefs = d.kref_config.k_refs.clone();
+        let c = sys::MangoDiscreteDividendConfig {
+            maturity: d.maturity,
+            dividends: div_ptr_or_null(&divs),
+            n_dividends: divs.len() as u64,
+            kref_config: sys::MangoMultiKRef {
+                K_refs: if krefs.is_empty() { core::ptr::null() } else { krefs.as_ptr() },
+                n_K_refs: krefs.len() as u64,
+                K_ref_count: d.kref_config.k_ref_count,
+                K_ref_span: d.kref_config.k_ref_span,
+            },
+        };
+        (c, divs, krefs)
+    });
+
+    let f64_ptr = |v: &[f64]| if v.is_empty() { core::ptr::null() } else { v.as_ptr() };
+
+    let c = sys::MangoIvFactoryConfig {
+        option_type: cfg.option_type.to_c(),
+        spot: cfg.spot,
+        dividend_yield: cfg.dividend_yield,
+        moneyness: f64_ptr(&moneyness),
+        n_moneyness: moneyness.len() as u64,
+        vol: f64_ptr(&vol),
+        n_vol: vol.len() as u64,
+        rate: f64_ptr(&rate),
+        n_rate: rate.len() as u64,
+        maturity_grid: f64_ptr(&maturity),
+        n_maturity: maturity.len() as u64,
+        solver_config: cfg.solver.to_c(),
+        adaptive: adaptive_c.as_ref().map_or(core::ptr::null(), |a| a as *const _),
+        discrete_dividends: dd.as_ref().map_or(core::ptr::null(), |(c, _, _)| c as *const _),
+    };
+
+    let mut err = blank_error();
+    let (status, value) = f(&c, &mut err);
+    // keepalive: moneyness/vol/rate/maturity/adaptive_c/dd live until here.
+    let _ = (&moneyness, &vol, &rate, &maturity, &adaptive_c, &dd);
+    if status == sys::MANGO_OK {
+        Ok(value)
+    } else {
+        Err(Error::from_c(status, &err))
+    }
+}
+
+pub(crate) fn make_factory_handle(
+    cfg: &FactoryConfig,
+) -> Result<*mut sys::MangoInterpIvSolver, Error> {
+    let mut handle: *mut sys::MangoInterpIvSolver = core::ptr::null_mut();
+    with_c_config(cfg, |c, err| unsafe {
+        (sys::mango_make_interp_iv_solver(c, &mut handle, err), handle)
+    })
+}
+```
+
+> Implementer note: `InterpIvSolver::new` above calls `with_c_config` returning
+> the handle. Ensure `with_c_config` is `pub(crate)` so `table.rs` can reuse it
+> for `mango_make_price_table`. Adjust visibility accordingly (mark
+> `with_c_config` `pub(crate)`).
+
+- [ ] **Step 2: Wire `lib.rs` exports**
+
+```rust
+mod interp;
+mod table;   // added in Task 6
+pub use interp::{
+    AdaptiveGridParams, BatchResult, DiscreteDividendConfig, FactoryConfig, InterpIvSolver,
+    InterpSolverConfig, IvGrid, MultiKRef,
+};
+```
+(Add `table` re-exports in Task 6.)
+
+- [ ] **Step 3: Wire `BUILD.bazel`**
+
+Add `"src/interp.rs"` (and `"src/table.rs"` in Task 6) to `rust_library`
+`srcs`, and add a `rust_test` for the new integration file:
+
+```python
+rust_test(
+    name = "interpolation_test",
+    srcs = ["tests/interpolation.rs"],
+    edition = "2021",
+    deps = [":mango_option"],
+)
+```
+
+- [ ] **Step 4: Write the solver integration tests (`tests/interpolation.rs`)**
+
+```rust
+// SPDX-License-Identifier: MIT
+use mango_option::{
+    price_american, AdaptiveGridParams, DiscreteDividendConfig, Dividend, FactoryConfig,
+    InterpIvSolver, InterpSolverConfig, IvGrid, IvQuery, MultiKRef, OptionSpec, OptionType, Rate,
+};
+
+fn base_config() -> FactoryConfig {
+    FactoryConfig {
+        option_type: OptionType::Put,
+        spot: 100.0,
+        dividend_yield: 0.0,
+        grid: IvGrid {
+            moneyness: vec![0.8, 0.9, 1.0, 1.1, 1.2],
+            vol: vec![0.10, 0.20, 0.30, 0.40],
+            rate: vec![0.01, 0.03, 0.05],
+        },
+        maturity_grid: vec![0.25, 0.5, 1.0],
+        solver: InterpSolverConfig::default(),
+        adaptive: None,
+        discrete_dividends: None,
+    }
+}
+
+fn put_spec(sigma: f64) -> (OptionSpec, f64) {
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(0.03), discrete_dividends: vec![], option_type: OptionType::Put,
+    };
+    (spec, sigma)
+}
+
+#[test]
+fn iv_round_trip_continuous() {
+    let solver = InterpIvSolver::new(&base_config()).expect("build solver");
+    let (spec, sigma) = put_spec(0.25);
+    // Reference price from the FDM path at the true sigma.
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let q = IvQuery { spec, market_price: price };
+    let r = solver.solve(&q).expect("solve iv");
+    assert!((r.implied_vol - sigma).abs() < 1e-2, "iv={} sigma={}", r.implied_vol, sigma);
+}
+
+#[test]
+fn batch_with_one_failure() {
+    let solver = InterpIvSolver::new(&base_config()).unwrap();
+    let (spec, sigma) = put_spec(0.25);
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let good_price = price_american(&pp).unwrap().value();
+    let good = IvQuery { spec: spec.clone(), market_price: good_price };
+    // Arbitrage-violating price (above strike for a put) => solve failure.
+    let bad = IvQuery { spec, market_price: 1_000.0 };
+    let batch = solver.solve_batch(&[good, bad]);
+    assert_eq!(batch.failed, 1);
+    assert!(batch.results[0].is_ok());
+    assert!(batch.results[1].is_err());
+}
+
+#[test]
+fn adaptive_build_solves() {
+    let mut cfg = base_config();
+    cfg.adaptive = Some(AdaptiveGridParams {
+        target_iv_error: 1e-3, max_iter: 2, validation_samples: 16,
+        min_moneyness_points: 20, ..AdaptiveGridParams::default()
+    });
+    let solver = InterpIvSolver::new(&cfg).expect("adaptive build");
+    let (spec, sigma) = put_spec(0.25);
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let r = solver.solve(&IvQuery { spec, market_price: price }).expect("solve");
+    assert!((r.implied_vol - sigma).abs() < 2e-2);
+}
+
+#[test]
+fn discrete_dividend_build_solves() {
+    let mut cfg = base_config();
+    cfg.discrete_dividends = Some(DiscreteDividendConfig {
+        maturity: 1.0,
+        dividends: vec![Dividend { calendar_time: 0.5, amount: 2.0 }],
+        kref_config: MultiKRef { k_refs: vec![90.0, 100.0, 110.0], ..MultiKRef::default() },
+    });
+    let solver = InterpIvSolver::new(&cfg).expect("discrete build");
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(0.03),
+        discrete_dividends: vec![Dividend { calendar_time: 0.5, amount: 2.0 }],
+        option_type: OptionType::Put,
+    };
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: 0.25 };
+    let price = price_american(&pp).unwrap().value();
+    let r = solver.solve(&IvQuery { spec, market_price: price }).expect("solve");
+    assert!((r.implied_vol - 0.25).abs() < 3e-2, "iv={}", r.implied_vol);
+}
+
+#[test]
+fn empty_maturity_grid_continuous_is_validation_error() {
+    let mut cfg = base_config();
+    cfg.maturity_grid = vec![];
+    let err = InterpIvSolver::new(&cfg).unwrap_err();
+    assert_eq!(err.kind, mango_option::ErrorKind::Validation);
+}
+
+#[test]
+fn non_finite_spot_is_validation_error() {
+    let mut cfg = base_config();
+    cfg.spot = f64::NAN;
+    let err = InterpIvSolver::new(&cfg).unwrap_err();
+    assert_eq!(err.kind, mango_option::ErrorKind::Validation);
+}
+
+#[test]
+fn solver_is_send_sync() {
+    let solver = InterpIvSolver::new(&base_config()).unwrap();
+    let (spec, sigma) = put_spec(0.25);
+    let pp = mango_option::PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let s = std::sync::Arc::new(solver);
+    let handles: Vec<_> = (0..2).map(|_| {
+        let s = s.clone();
+        let spec = spec.clone();
+        std::thread::spawn(move || {
+            s.solve(&IvQuery { spec, market_price: price }).map(|r| r.implied_vol)
+        })
+    }).collect();
+    for h in handles { assert!(h.join().unwrap().is_ok()); }
+}
+```
+
+> Implementer note: `lib.rs` must also re-export `PricingParams`, `Dividend`,
+> `OptionSpec`, `Rate`, `OptionType`, `ErrorKind`, `price_american`, `IvQuery`
+> for these tests — most already are. Add any missing re-export.
+
+- [ ] **Step 5: Build + run**
+
+Run: `bazel test //crates/mango-option-sys:layout_test //crates/mango-option:interpolation_test //crates/mango-option:integration_test`
+Expected: PASS (all of the above; v1 tests still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mango-option/src/interp.rs crates/mango-option/src/lib.rs \
+        crates/mango-option/tests/interpolation.rs crates/mango-option/BUILD.bazel
+git commit -m "Add safe Rust interpolated IV solver"
+```
+
+---
+
+## Task 6: Safe Rust `table.rs` (price table)
+
+**Files:**
+- Create: `crates/mango-option/src/table.rs`
+- Modify: `crates/mango-option/src/lib.rs` (re-exports)
+- Modify: `crates/mango-option/tests/interpolation.rs` (table tests)
+- Modify: `crates/mango-option/BUILD.bazel` (add `src/table.rs` to srcs)
+
+- [ ] **Step 1: Write `table.rs`**
+
+```rust
+// SPDX-License-Identifier: MIT
+use crate::error::Error;
+use crate::interp::{make_price_table_handle, with_c_config, FactoryConfig, InterpIvSolver,
+                    InterpSolverConfig};
+use crate::pricing::{blank_error, pricing_params_to_c, PricingParams};
+use crate::types::OptionType;
+use mango_option_sys as sys;
+
+/// A reusable, immutable B-spline price surface. Thread-safe to query.
+pub struct PriceTable {
+    handle: *mut sys::MangoPriceTable,
+}
+// SAFETY: the C++ AnyPriceTable wraps an immutable surface; all query methods
+// are const and documented thread-safe.
+unsafe impl Send for PriceTable {}
+unsafe impl Sync for PriceTable {}
+
+impl core::fmt::Debug for PriceTable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "PriceTable({:p})", self.handle)
+    }
+}
+
+impl PriceTable {
+    pub fn new(cfg: &FactoryConfig) -> Result<Self, Error> {
+        Ok(PriceTable { handle: make_price_table_handle(cfg)? })
+    }
+
+    /// Opt-in bounds check; out-of-domain params => Err. `price`/`vega` do NOT
+    /// call this and will extrapolate.
+    pub fn validate(&self, params: &PricingParams) -> Result<(), Error> {
+        let (c, _keep) = pricing_params_to_c(params)?;
+        let mut err = blank_error();
+        let status = unsafe { sys::mango_price_table_validate(self.handle, &c, &mut err) };
+        if status == sys::MANGO_OK { Ok(()) } else { Err(Error::from_c(status, &err)) }
+    }
+
+    /// Interpolated price. Extrapolates out of the surface domain; returns NaN
+    /// only on an internal failure. Call `validate` first if you need bounds.
+    pub fn price(&self, params: &PricingParams) -> f64 {
+        match pricing_params_to_c(params) {
+            Ok((c, _keep)) => unsafe { sys::mango_price_table_price(self.handle, &c) },
+            Err(_) => f64::NAN,
+        }
+    }
+    pub fn vega(&self, params: &PricingParams) -> f64 {
+        match pricing_params_to_c(params) {
+            Ok((c, _keep)) => unsafe { sys::mango_price_table_vega(self.handle, &c) },
+            Err(_) => f64::NAN,
+        }
+    }
+
+    pub fn delta(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_delta)
+    }
+    pub fn gamma(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_gamma)
+    }
+    pub fn theta(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_theta)
+    }
+    pub fn rho(&self, params: &PricingParams) -> Result<f64, Error> {
+        self.greek(params, sys::mango_price_table_rho)
+    }
+
+    fn greek(
+        &self,
+        params: &PricingParams,
+        f: unsafe extern "C" fn(*const sys::MangoPriceTable, *const sys::MangoPricingParams,
+                                *mut f64, *mut sys::MangoError) -> sys::MangoStatus,
+    ) -> Result<f64, Error> {
+        let (c, _keep) = pricing_params_to_c(params)?;
+        let mut out = 0.0;
+        let mut err = blank_error();
+        let status = unsafe { f(self.handle, &c, &mut out, &mut err) };
+        if status == sys::MANGO_OK { Ok(out) } else { Err(Error::from_c(status, &err)) }
+    }
+
+    pub fn option_type(&self) -> OptionType {
+        let t = unsafe { sys::mango_price_table_option_type(self.handle) };
+        if t == sys::MANGO_CALL { OptionType::Call } else { OptionType::Put }
+    }
+    pub fn dividend_yield(&self) -> f64 {
+        unsafe { sys::mango_price_table_dividend_yield(self.handle) }
+    }
+
+    /// Derive an IV solver from this already-built surface (no rebuild).
+    pub fn iv_solver(&self, cfg: Option<&InterpSolverConfig>) -> Result<InterpIvSolver, Error> {
+        let c = cfg.map(|c| c.to_c());
+        let mut handle: *mut sys::MangoInterpIvSolver = core::ptr::null_mut();
+        let mut err = blank_error();
+        let status = unsafe {
+            sys::mango_price_table_make_iv_solver(
+                self.handle,
+                c.as_ref().map_or(core::ptr::null(), |c| c as *const _),
+                &mut handle,
+                &mut err,
+            )
+        };
+        if status == sys::MANGO_OK {
+            Ok(InterpIvSolver::from_raw(handle))
+        } else {
+            Err(Error::from_c(status, &err))
+        }
+    }
+}
+
+impl Drop for PriceTable {
+    fn drop(&mut self) {
+        unsafe { sys::mango_price_table_free(self.handle) }
+    }
+}
+```
+
+> Implementer notes (small refactors required to make the above compile):
+> 1. In `interp.rs`, add `make_price_table_handle(cfg) -> Result<*mut sys::MangoPriceTable, Error>`
+>    (analogous to `make_factory_handle`, calling `mango_make_price_table`), make
+>    `with_c_config` and `InterpSolverConfig::to_c` `pub(crate)`, and add
+>    `InterpIvSolver::from_raw(handle) -> Self` (a `pub(crate)` constructor).
+> 2. In `pricing.rs`, factor the existing `MangoPricingParams` construction in
+>    `price_american` into a `pub(crate) fn pricing_params_to_c(&PricingParams)
+>    -> Result<(sys::MangoPricingParams, PricingKeepalive), Error>` (mirroring
+>    `iv_query_to_c`), where `PricingKeepalive` owns the tenor/dividend Vecs.
+>    Update `price_american` to use it. Keep behavior identical (the empty-curve
+>    guard moves into the helper).
+
+- [ ] **Step 2: Add table re-exports to `lib.rs`**
+
+```rust
+pub use table::PriceTable;
+```
+
+- [ ] **Step 3: Add `src/table.rs` to BUILD srcs** (already declared `mod table` in Task 5).
+
+- [ ] **Step 4: Append table tests to `tests/interpolation.rs`**
+
+```rust
+use mango_option::{PriceTable, PricingParams};
+
+#[test]
+fn price_table_queries() {
+    let table = PriceTable::new(&base_config()).expect("build table");
+    let spec = OptionSpec {
+        spot: 100.0, strike: 100.0, maturity: 1.0, dividend_yield: 0.0,
+        rate: Rate::Const(0.03), discrete_dividends: vec![], option_type: OptionType::Put,
+    };
+    let pp = PricingParams { spec: spec.clone(), volatility: 0.25 };
+    let price = table.price(&pp);
+    assert!(price.is_finite() && price > 0.0);
+    assert!(table.vega(&pp).is_finite());
+    let delta = table.delta(&pp).expect("delta");
+    assert!(delta < 0.0, "put delta should be negative: {}", delta);
+    assert!(table.gamma(&pp).is_ok());
+    assert!(table.theta(&pp).is_ok());
+    assert!(table.rho(&pp).is_ok());
+    assert_eq!(table.option_type(), OptionType::Put);
+
+    // Reference FDM price for sanity (interpolation tolerance is loose).
+    let fdm = price_american(&pp).unwrap().value();
+    assert!((price - fdm).abs() < 0.5, "interp {} vs fdm {}", price, fdm);
+
+    // Opt-in validation.
+    assert!(table.validate(&pp).is_ok());
+    let oob = PricingParams { spec, volatility: 5.0 }; // far outside vol grid
+    assert!(table.validate(&oob).is_err());
+}
+
+#[test]
+fn price_table_derives_iv_solver() {
+    let table = PriceTable::new(&base_config()).unwrap();
+    let solver = table.iv_solver(None).expect("derive solver");
+    let (spec, sigma) = put_spec(0.25);
+    let pp = PricingParams { spec: spec.clone(), volatility: sigma };
+    let price = price_american(&pp).unwrap().value();
+    let r = solver.solve(&IvQuery { spec, market_price: price }).expect("solve");
+    assert!((r.implied_vol - sigma).abs() < 1e-2);
+}
+```
+
+- [ ] **Step 5: Build + run all**
+
+Run: `bazel test //crates/mango-option:interpolation_test //crates/mango-option:integration_test //crates/mango-option-sys:layout_test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mango-option/src/table.rs crates/mango-option/src/lib.rs \
+        crates/mango-option/src/pricing.rs crates/mango-option/src/interp.rs \
+        crates/mango-option/tests/interpolation.rs crates/mango-option/BUILD.bazel
+git commit -m "Add safe Rust price table"
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+- Modify: `docs/RUST_GUIDE.md`
+
+- [ ] **Step 1: Add an "Interpolation path" section**
+
+Document, with a worked example each: building an `InterpIvSolver` from a
+`FactoryConfig` (continuous), `solve`/`solve_batch`, building a `PriceTable` and
+querying `price`/`vega`/greeks via `PricingParams`, `validate` (and the
+extrapolation caveat on `price`/`vega`), deriving a solver with
+`PriceTable::iv_solver`, and the adaptive + discrete-dividend config options.
+Note the batch error-category limitation and `used_rate_approximation`. Mirror
+the structure/tone of the existing FDM section.
+
+- [ ] **Step 2: Verify the doc examples compile mentally against the public API**
+
+(No build step; this is prose. Ensure type/method names match `lib.rs` exports.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/RUST_GUIDE.md
+git commit -m "Document the Rust interpolation-path binding"
+```
+
+---
+
+## Final verification (before holistic review)
+
+Run the full suite the CI gate checks:
+
+```bash
+bazel test //crates/... //tests:iv_solver_test
+bazel build //src/python:mango_option   # ensure the shared shim still builds Python
+```
+Expected: all PASS. Then proceed to holistic review → push → PR → pre-merge review.

--- a/src/ffi/BUILD.bazel
+++ b/src/ffi/BUILD.bazel
@@ -76,8 +76,10 @@ cc_library(
     ],
     deps = [
         "//src/option:american_option",
+        "//src/option:interpolated_iv_solver",
         "//src/option:iv_solver",
         "//src/option:option_spec",
+        "//src/option:price_table_factory",
         "//src/option:yield_curve",
     ],
     visibility = ["//visibility:public"],

--- a/src/ffi/mango_c_api.cpp
+++ b/src/ffi/mango_c_api.cpp
@@ -118,6 +118,15 @@ MangoStatus map_iv_error(const mango::IVError& e) {
   }
 }
 
+void fill_iv_success(MangoIvSuccess* out, const mango::IVSuccess& s) {
+  out->implied_vol = s.implied_vol;
+  out->iterations = static_cast<uint64_t>(s.iterations);
+  out->final_error = s.final_error;
+  out->vega = s.vega.value_or(0.0);
+  out->has_vega = s.vega.has_value() ? 1 : 0;
+  out->used_rate_approximation = s.used_rate_approximation ? 1 : 0;
+}
+
 }  // namespace
 
 struct MangoAmericanResult {
@@ -277,11 +286,7 @@ MangoStatus mango_solve_iv(const MangoIvQuery* query,
       return code;
     }
     const auto& s = result.value();
-    out_success->implied_vol = s.implied_vol;
-    out_success->iterations = static_cast<uint64_t>(s.iterations);
-    out_success->final_error = s.final_error;
-    out_success->vega = s.vega.value_or(0.0);
-    out_success->has_vega = s.vega.has_value() ? 1 : 0;
+    fill_iv_success(out_success, s);
     return MANGO_OK;
   } catch (const std::exception& ex) {
     set_err(out_err, MANGO_ERR_SOLVER, ex.what());

--- a/src/ffi/mango_c_api.cpp
+++ b/src/ffi/mango_c_api.cpp
@@ -129,7 +129,13 @@ MangoStatus map_iv_error(const mango::IVError& e) {
     case mango::IVErrorCode::NegativeSpot:
     case mango::IVErrorCode::NegativeStrike:
     case mango::IVErrorCode::NegativeMaturity:
-    case mango::IVErrorCode::NegativeMarketPrice: return MANGO_ERR_VALIDATION;
+    case mango::IVErrorCode::NegativeMarketPrice:
+    // Validation-category codes produced by the interpolated solver. Without
+    // these explicit arms they fall through to MANGO_ERR_SOLVER, so Rust
+    // callers see ErrorKind::Solver for what are really bad-input errors.
+    case mango::IVErrorCode::InvalidGridConfig:
+    case mango::IVErrorCode::OptionTypeMismatch:
+    case mango::IVErrorCode::DividendYieldMismatch: return MANGO_ERR_VALIDATION;
     default: return MANGO_ERR_SOLVER;
   }
 }
@@ -166,6 +172,27 @@ bool build_iv_query(const MangoIvQuery* q, mango::IVQuery& out, MangoError* err)
   if (!validate_option_type(q->option_type, err, spec.option_type)) return false;
   if (!build_rate(q->rate_const, q->tenor_points, q->n_tenor_points, spec.rate, err))
     return false;
+  // Pre-validate non-finite rate/dividend inputs so they surface as a
+  // validation error. The IV path otherwise maps invalid rate/dividend to
+  // ArbitrageViolation, which would mislead Rust callers (mirrors the FDM
+  // pre-validation in mango_solve_iv).
+  if (!std::isfinite(q->dividend_yield)) {
+    set_err(err, MANGO_ERR_VALIDATION, "dividend_yield must be finite");
+    return false;
+  }
+  if (q->n_tenor_points == 0 && !std::isfinite(q->rate_const)) {
+    set_err(err, MANGO_ERR_VALIDATION, "rate must be finite");
+    return false;
+  }
+  for (uint64_t i = 0; i < q->n_dividends; ++i) {
+    double ct = q->dividends[i].calendar_time;
+    double amt = q->dividends[i].amount;
+    if (!std::isfinite(ct) || ct < 0.0 || ct > q->maturity ||
+        !std::isfinite(amt) || amt < 0.0) {
+      set_err(err, MANGO_ERR_VALIDATION, "invalid discrete dividend");
+      return false;
+    }
+  }
   out = mango::IVQuery(spec, q->market_price);
   if (!build_dividends(q->dividends, q->n_dividends, out.discrete_dividends, err))
     return false;
@@ -248,6 +275,15 @@ MangoStatus greek_call(const MangoPriceTable* t, const MangoPricingParams* p,
   try {
     mango::PricingParams pp;
     if (!build_pricing_params(p, pp, err)) return MANGO_ERR_VALIDATION;
+    // Greeks are documented as fallible (unlike the intentionally-extrapolating
+    // price/vega). The B-spline evaluator clamps/extrapolates and can return a
+    // value for out-of-domain inputs without surfacing GreekError::OutOfDomain,
+    // so validate bounds first to honor that contract.
+    if (auto v = t->table.validate_pricing_params(pp); !v) {
+      std::string msg = format_validation_error(v.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
     auto r = fn(t->table, pp);
     if (!r) {
       set_err(err, map_greek_error(r.error()), greek_error_msg(r.error()));

--- a/src/ffi/mango_c_api.cpp
+++ b/src/ffi/mango_c_api.cpp
@@ -2,8 +2,10 @@
 #include "mango/ffi/mango_c_api.h"
 
 #include "mango/option/american_option.hpp"
+#include "mango/option/interpolated_iv_solver.hpp"
 #include "mango/option/iv_solver.hpp"
 #include "mango/option/option_spec.hpp"
+#include "mango/option/price_table_factory.hpp"
 #include "mango/option/yield_curve.hpp"
 #include "mango/support/error_types.hpp"
 
@@ -127,6 +129,85 @@ void fill_iv_success(MangoIvSuccess* out, const mango::IVSuccess& s) {
   out->used_rate_approximation = s.used_rate_approximation ? 1 : 0;
 }
 
+std::vector<double> to_vec(const double* p, uint64_t n) {
+  if (n == 0 || p == nullptr) return {};
+  return std::vector<double>(p, p + n);
+}
+
+[[maybe_unused]] MangoStatus map_greek_error(mango::GreekError e) {
+  return e == mango::GreekError::OutOfDomain ? MANGO_ERR_VALIDATION
+                                             : MANGO_ERR_SOLVER;
+}
+[[maybe_unused]] const char* greek_error_msg(mango::GreekError e) {
+  return e == mango::GreekError::OutOfDomain
+             ? "greek query point outside surface domain"
+             : "greek numerical computation failed";
+}
+
+// Build a C++ IVQuery from the C struct (rate + dividends + option type).
+bool build_iv_query(const MangoIvQuery* q, mango::IVQuery& out, MangoError* err) {
+  mango::OptionSpec spec;
+  spec.spot = q->spot; spec.strike = q->strike;
+  spec.maturity = q->maturity; spec.dividend_yield = q->dividend_yield;
+  if (!validate_option_type(q->option_type, err, spec.option_type)) return false;
+  if (!build_rate(q->rate_const, q->tenor_points, q->n_tenor_points, spec.rate, err))
+    return false;
+  out = mango::IVQuery(spec, q->market_price);
+  if (!build_dividends(q->dividends, q->n_dividends, out.discrete_dividends, err))
+    return false;
+  return true;
+}
+
+// Translate the flat factory config into the C++ IVSolverFactoryConfig.
+bool build_factory_config(const MangoIvFactoryConfig* c,
+                          mango::IVSolverFactoryConfig& out, MangoError* err) {
+  if (!validate_option_type(c->option_type, err, out.option_type)) return false;
+  if (!std::isfinite(c->spot)) {
+    set_err(err, MANGO_ERR_VALIDATION, "spot must be finite"); return false;
+  }
+  if (!std::isfinite(c->dividend_yield)) {
+    set_err(err, MANGO_ERR_VALIDATION, "dividend_yield must be finite"); return false;
+  }
+  out.spot = c->spot;
+  out.dividend_yield = c->dividend_yield;
+  out.grid.moneyness = to_vec(c->moneyness, c->n_moneyness);
+  out.grid.vol = to_vec(c->vol, c->n_vol);
+  out.grid.rate = to_vec(c->rate, c->n_rate);
+  out.backend = mango::BSplineBackend{to_vec(c->maturity_grid, c->n_maturity)};
+  out.solver_config.max_iter = static_cast<std::size_t>(c->solver_config.max_iter);
+  out.solver_config.tolerance = c->solver_config.tolerance;
+  out.solver_config.sigma_min = c->solver_config.sigma_min;
+  out.solver_config.sigma_max = c->solver_config.sigma_max;
+  out.solver_config.vega_threshold = c->solver_config.vega_threshold;
+  if (c->adaptive) {
+    mango::AdaptiveGridParams a;
+    a.target_iv_error = c->adaptive->target_iv_error;
+    a.max_iter = static_cast<std::size_t>(c->adaptive->max_iter);
+    a.max_points_per_dim = static_cast<std::size_t>(c->adaptive->max_points_per_dim);
+    a.min_moneyness_points = static_cast<std::size_t>(c->adaptive->min_moneyness_points);
+    a.validation_samples = static_cast<std::size_t>(c->adaptive->validation_samples);
+    a.refinement_factor = c->adaptive->refinement_factor;
+    a.lhs_seed = c->adaptive->lhs_seed;
+    a.vega_floor = c->adaptive->vega_floor;
+    a.max_failure_rate = c->adaptive->max_failure_rate;
+    out.adaptive = a;
+  }
+  if (c->discrete_dividends) {
+    const auto* d = c->discrete_dividends;
+    mango::DiscreteDividendConfig dd;
+    dd.maturity = d->maturity;
+    if (!build_dividends(d->dividends, d->n_dividends, dd.discrete_dividends, err))
+      return false;
+    dd.kref_config.K_refs = to_vec(d->kref_config.K_refs, d->kref_config.n_K_refs);
+    dd.kref_config.K_ref_count =
+        (d->kref_config.n_K_refs == 0 && d->kref_config.K_ref_count <= 0)
+            ? 11 : d->kref_config.K_ref_count;
+    dd.kref_config.K_ref_span = d->kref_config.K_ref_span;
+    out.discrete_dividends = dd;
+  }
+  return true;
+}
+
 }  // namespace
 
 struct MangoAmericanResult {
@@ -136,6 +217,9 @@ struct MangoAmericanResult {
   double gamma;
   double theta;
 };
+
+struct MangoInterpIvSolver { mango::AnyInterpIVSolver solver; };
+struct MangoPriceTable { mango::AnyPriceTable table; };
 
 extern "C" {
 
@@ -296,5 +380,102 @@ MangoStatus mango_solve_iv(const MangoIvQuery* query,
     return MANGO_ERR_SOLVER;
   }
 }
+
+MangoStatus mango_make_interp_iv_solver(const MangoIvFactoryConfig* cfg,
+                                        MangoInterpIvSolver** out,
+                                        MangoError* err) {
+  if (!cfg || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null cfg or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  *out = nullptr;
+  try {
+    mango::IVSolverFactoryConfig fc;
+    if (!build_factory_config(cfg, fc, err)) return MANGO_ERR_VALIDATION;
+    auto result = mango::make_interpolated_iv_solver(fc);
+    if (!result) {
+      std::string msg = format_validation_error(result.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    *out = new MangoInterpIvSolver{std::move(result.value())};
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+MangoStatus mango_interp_iv_solve(const MangoInterpIvSolver* s,
+                                  const MangoIvQuery* q,
+                                  MangoIvSuccess* out, MangoError* err) {
+  if (!s || !q || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null solver, query, or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    mango::IVQuery query;
+    if (!build_iv_query(q, query, err)) return MANGO_ERR_VALIDATION;
+    auto result = s->solver.solve(query);
+    if (!result) {
+      auto code = map_iv_error(result.error());
+      std::string msg = format_iv_error(result.error());
+      set_err(err, code, msg.c_str());
+      return code;
+    }
+    fill_iv_success(out, result.value());
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+MangoStatus mango_interp_iv_solve_batch(const MangoInterpIvSolver* s,
+                                        const MangoIvQuery* queries, uint64_t n,
+                                        MangoIvBatchSlot* out_slots,
+                                        uint64_t* out_failed_count,
+                                        MangoError* err) {
+  if (!s || (!queries && n > 0) || (!out_slots && n > 0)) {
+    set_err(err, MANGO_ERR_VALIDATION, "null solver, queries, or out_slots");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    std::vector<mango::IVQuery> qs;
+    qs.reserve(n);
+    for (uint64_t i = 0; i < n; ++i) {
+      mango::IVQuery query;
+      if (!build_iv_query(&queries[i], query, err)) return MANGO_ERR_VALIDATION;
+      qs.push_back(std::move(query));
+    }
+    auto batch = s->solver.solve_batch(qs);  // noexcept
+    for (uint64_t i = 0; i < n; ++i) {
+      const auto& r = batch.results[i];
+      if (r.has_value()) {
+        out_slots[i].status = MANGO_OK;
+        fill_iv_success(&out_slots[i].success, r.value());
+      } else {
+        out_slots[i].status = map_iv_error(r.error());
+        out_slots[i].success = MangoIvSuccess{};
+      }
+    }
+    if (out_failed_count) *out_failed_count = batch.failed_count;
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+void mango_interp_iv_solver_free(MangoInterpIvSolver* s) { delete s; }
 
 }  // extern "C"

--- a/src/ffi/mango_c_api.cpp
+++ b/src/ffi/mango_c_api.cpp
@@ -77,6 +77,20 @@ bool build_dividends(const MangoDividend* divs, uint64_t n,
   return true;
 }
 
+// Build a C++ PricingParams from the C struct (rate + dividends + option type).
+bool build_pricing_params(const MangoPricingParams* p, mango::PricingParams& out,
+                          MangoError* err) {
+  out.spot = p->spot; out.strike = p->strike;
+  out.maturity = p->maturity; out.dividend_yield = p->dividend_yield;
+  out.volatility = p->volatility;
+  if (!validate_option_type(p->option_type, err, out.option_type)) return false;
+  if (!build_rate(p->rate_const, p->tenor_points, p->n_tenor_points, out.rate, err))
+    return false;
+  if (!build_dividends(p->dividends, p->n_dividends, out.discrete_dividends, err))
+    return false;
+  return true;
+}
+
 MangoStatus map_solver_error(const mango::SolverError& e) {
   if (e.code == mango::SolverErrorCode::ConvergenceFailure)
     return MANGO_ERR_NO_CONVERGENCE;
@@ -134,11 +148,11 @@ std::vector<double> to_vec(const double* p, uint64_t n) {
   return std::vector<double>(p, p + n);
 }
 
-[[maybe_unused]] MangoStatus map_greek_error(mango::GreekError e) {
+MangoStatus map_greek_error(mango::GreekError e) {
   return e == mango::GreekError::OutOfDomain ? MANGO_ERR_VALIDATION
                                              : MANGO_ERR_SOLVER;
 }
-[[maybe_unused]] const char* greek_error_msg(mango::GreekError e) {
+const char* greek_error_msg(mango::GreekError e) {
   return e == mango::GreekError::OutOfDomain
              ? "greek query point outside surface domain"
              : "greek numerical computation failed";
@@ -220,6 +234,36 @@ struct MangoAmericanResult {
 
 struct MangoInterpIvSolver { mango::AnyInterpIVSolver solver; };
 struct MangoPriceTable { mango::AnyPriceTable table; };
+
+namespace {
+// Shared body for the four fallible Greeks. `fn` returns a
+// std::expected<double, GreekError> from the wrapped AnyPriceTable.
+template <typename Fn>
+MangoStatus greek_call(const MangoPriceTable* t, const MangoPricingParams* p,
+                       double* out, MangoError* err, Fn&& fn) {
+  if (!t || !p || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null table, params, or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, err)) return MANGO_ERR_VALIDATION;
+    auto r = fn(t->table, pp);
+    if (!r) {
+      set_err(err, map_greek_error(r.error()), greek_error_msg(r.error()));
+      return map_greek_error(r.error());
+    }
+    *out = r.value();
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+}  // namespace
 
 extern "C" {
 
@@ -477,5 +521,155 @@ MangoStatus mango_interp_iv_solve_batch(const MangoInterpIvSolver* s,
 }
 
 void mango_interp_iv_solver_free(MangoInterpIvSolver* s) { delete s; }
+
+MangoStatus mango_make_price_table(const MangoIvFactoryConfig* cfg,
+                                   MangoPriceTable** out, MangoError* err) {
+  if (!cfg || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null cfg or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  *out = nullptr;
+  try {
+    mango::IVSolverFactoryConfig fc;
+    if (!build_factory_config(cfg, fc, err)) return MANGO_ERR_VALIDATION;
+    auto result = mango::make_price_table(fc);
+    if (!result) {
+      std::string msg = format_validation_error(result.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    *out = new MangoPriceTable{std::move(result.value())};
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+MangoStatus mango_price_table_validate(const MangoPriceTable* t,
+                                       const MangoPricingParams* p,
+                                       MangoError* err) {
+  if (!t || !p) {
+    set_err(err, MANGO_ERR_VALIDATION, "null table or params");
+    return MANGO_ERR_VALIDATION;
+  }
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, err)) return MANGO_ERR_VALIDATION;
+    auto v = t->table.validate_pricing_params(pp);
+    if (!v) {
+      std::string msg = format_validation_error(v.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+// price/vega: infallible f64; nan on null/build failure (extrapolates in domain).
+double mango_price_table_price(const MangoPriceTable* t, const MangoPricingParams* p) {
+  if (!t || !p) return std::nan("");
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, nullptr)) return std::nan("");
+    return t->table.price(pp);
+  } catch (...) { return std::nan(""); }
+}
+
+double mango_price_table_vega(const MangoPriceTable* t, const MangoPricingParams* p) {
+  if (!t || !p) return std::nan("");
+  try {
+    mango::PricingParams pp;
+    if (!build_pricing_params(p, pp, nullptr)) return std::nan("");
+    return t->table.vega(pp);
+  } catch (...) { return std::nan(""); }
+}
+
+MangoStatus mango_price_table_delta(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err) {
+  return greek_call(t, p, out, err,
+                    [](const mango::AnyPriceTable& tb, const mango::PricingParams& pp) {
+                      return tb.delta(pp);
+                    });
+}
+
+MangoStatus mango_price_table_gamma(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err) {
+  return greek_call(t, p, out, err,
+                    [](const mango::AnyPriceTable& tb, const mango::PricingParams& pp) {
+                      return tb.gamma(pp);
+                    });
+}
+
+MangoStatus mango_price_table_theta(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err) {
+  return greek_call(t, p, out, err,
+                    [](const mango::AnyPriceTable& tb, const mango::PricingParams& pp) {
+                      return tb.theta(pp);
+                    });
+}
+
+MangoStatus mango_price_table_rho(const MangoPriceTable* t, const MangoPricingParams* p,
+                                  double* out, MangoError* err) {
+  return greek_call(t, p, out, err,
+                    [](const mango::AnyPriceTable& tb, const mango::PricingParams& pp) {
+                      return tb.rho(pp);
+                    });
+}
+
+MangoOptionType mango_price_table_option_type(const MangoPriceTable* t) {
+  if (!t) return MANGO_PUT;  // arbitrary default on null; callers null-check handles
+  return t->table.option_type() == mango::OptionType::CALL ? MANGO_CALL : MANGO_PUT;
+}
+
+double mango_price_table_dividend_yield(const MangoPriceTable* t) {
+  return t ? t->table.dividend_yield() : std::nan("");
+}
+
+MangoStatus mango_price_table_make_iv_solver(const MangoPriceTable* t,
+                                             const MangoInterpSolverConfig* cfg,
+                                             MangoInterpIvSolver** out,
+                                             MangoError* err) {
+  if (!t || !out) {
+    set_err(err, MANGO_ERR_VALIDATION, "null table or out");
+    return MANGO_ERR_VALIDATION;
+  }
+  *out = nullptr;
+  try {
+    mango::InterpolatedIVSolverConfig sc;  // defaults
+    if (cfg) {
+      sc.max_iter = static_cast<std::size_t>(cfg->max_iter);
+      sc.tolerance = cfg->tolerance;
+      sc.sigma_min = cfg->sigma_min;
+      sc.sigma_max = cfg->sigma_max;
+      sc.vega_threshold = cfg->vega_threshold;
+    }
+    auto result = t->table.make_iv_solver(sc);
+    if (!result) {
+      std::string msg = format_validation_error(result.error());
+      set_err(err, MANGO_ERR_VALIDATION, msg.c_str());
+      return MANGO_ERR_VALIDATION;
+    }
+    *out = new MangoInterpIvSolver{std::move(result.value())};
+    return MANGO_OK;
+  } catch (const std::exception& ex) {
+    set_err(err, MANGO_ERR_SOLVER, ex.what());
+    return MANGO_ERR_SOLVER;
+  } catch (...) {
+    set_err(err, MANGO_ERR_SOLVER, "unknown error");
+    return MANGO_ERR_SOLVER;
+  }
+}
+
+void mango_price_table_free(MangoPriceTable* t) { delete t; }
 
 }  // extern "C"

--- a/src/ffi/mango_c_api.cpp
+++ b/src/ffi/mango_c_api.cpp
@@ -172,6 +172,12 @@ bool build_iv_query(const MangoIvQuery* q, mango::IVQuery& out, MangoError* err)
   if (!validate_option_type(q->option_type, err, spec.option_type)) return false;
   if (!build_rate(q->rate_const, q->tenor_points, q->n_tenor_points, spec.rate, err))
     return false;
+  out = mango::IVQuery(spec, q->market_price);
+  // build_dividends null-checks (dividends == null && n_dividends > 0); run it
+  // before the finite-check loop below so that loop never dereferences a null
+  // dividend pointer.
+  if (!build_dividends(q->dividends, q->n_dividends, out.discrete_dividends, err))
+    return false;
   // Pre-validate non-finite rate/dividend inputs so they surface as a
   // validation error. The IV path otherwise maps invalid rate/dividend to
   // ArbitrageViolation, which would mislead Rust callers (mirrors the FDM
@@ -193,9 +199,6 @@ bool build_iv_query(const MangoIvQuery* q, mango::IVQuery& out, MangoError* err)
       return false;
     }
   }
-  out = mango::IVQuery(spec, q->market_price);
-  if (!build_dividends(q->dividends, q->n_dividends, out.discrete_dividends, err))
-    return false;
   return true;
 }
 
@@ -527,16 +530,27 @@ MangoStatus mango_interp_iv_solve_batch(const MangoInterpIvSolver* s,
     return MANGO_ERR_VALIDATION;
   }
   try {
+    // First pass: build/validate each query. A per-query build failure is
+    // recorded in that query's slot as a validation error; the remaining
+    // queries still solve (per-slot failure contract, not whole-batch abort).
     std::vector<mango::IVQuery> qs;
+    std::vector<uint64_t> valid_idx;  // original index for each entry in qs
     qs.reserve(n);
+    valid_idx.reserve(n);
     for (uint64_t i = 0; i < n; ++i) {
       mango::IVQuery query;
-      if (!build_iv_query(&queries[i], query, err)) return MANGO_ERR_VALIDATION;
-      qs.push_back(std::move(query));
+      if (build_iv_query(&queries[i], query, nullptr)) {
+        qs.push_back(std::move(query));
+        valid_idx.push_back(i);
+      } else {
+        out_slots[i].status = MANGO_ERR_VALIDATION;
+        out_slots[i].success = MangoIvSuccess{};
+      }
     }
     auto batch = s->solver.solve_batch(qs);  // noexcept
-    for (uint64_t i = 0; i < n; ++i) {
-      const auto& r = batch.results[i];
+    for (size_t k = 0; k < valid_idx.size(); ++k) {
+      uint64_t i = valid_idx[k];
+      const auto& r = batch.results[k];
       if (r.has_value()) {
         out_slots[i].status = MANGO_OK;
         fill_iv_success(&out_slots[i].success, r.value());
@@ -545,7 +559,12 @@ MangoStatus mango_interp_iv_solve_batch(const MangoInterpIvSolver* s,
         out_slots[i].success = MangoIvSuccess{};
       }
     }
-    if (out_failed_count) *out_failed_count = batch.failed_count;
+    if (out_failed_count) {
+      uint64_t failed = 0;
+      for (uint64_t i = 0; i < n; ++i)
+        if (out_slots[i].status != MANGO_OK) ++failed;
+      *out_failed_count = failed;
+    }
     return MANGO_OK;
   } catch (const std::exception& ex) {
     set_err(err, MANGO_ERR_SOLVER, ex.what());

--- a/src/ffi/mango_c_api.h
+++ b/src/ffi/mango_c_api.h
@@ -63,6 +63,7 @@ typedef struct {
   double final_error;
   double vega;
   int32_t has_vega;
+  int32_t used_rate_approximation;
 } MangoIvSuccess;
 
 typedef struct { double brent_tol_abs; int32_t max_iter; } MangoIvConfig;  // 0 => default
@@ -110,6 +111,7 @@ static_assert(sizeof(MangoError) == 260, "MangoError size");
 static_assert(offsetof(MangoError, message) == 4, "message off");
 static_assert(sizeof(MangoIvSuccess) == 40, "MangoIvSuccess size");
 static_assert(offsetof(MangoIvSuccess, has_vega) == 32, "has_vega off");
+static_assert(offsetof(MangoIvSuccess, used_rate_approximation) == 36, "used_rate_approximation off");
 static_assert(sizeof(MangoIvConfig) == 16, "MangoIvConfig size");
 static_assert(offsetof(MangoIvConfig, max_iter) == 8, "max_iter off");
 #else
@@ -131,6 +133,7 @@ _Static_assert(sizeof(MangoError) == 260, "MangoError size");
 _Static_assert(offsetof(MangoError, message) == 4, "message off");
 _Static_assert(sizeof(MangoIvSuccess) == 40, "MangoIvSuccess size");
 _Static_assert(offsetof(MangoIvSuccess, has_vega) == 32, "has_vega off");
+_Static_assert(offsetof(MangoIvSuccess, used_rate_approximation) == 36, "used_rate_approximation off");
 _Static_assert(sizeof(MangoIvConfig) == 16, "MangoIvConfig size");
 _Static_assert(offsetof(MangoIvConfig, max_iter) == 8, "max_iter off");
 #endif

--- a/src/ffi/mango_c_api.h
+++ b/src/ffi/mango_c_api.h
@@ -68,6 +68,74 @@ typedef struct {
 
 typedef struct { double brent_tol_abs; int32_t max_iter; } MangoIvConfig;  // 0 => default
 
+// --- Interpolation path (B-spline backend) ---
+
+// InterpolatedIVSolverConfig (Newton config). Fields applied VERBATIM: a
+// vega_threshold of 0 disables the vega pre-check, so zero cannot mean "unset".
+typedef struct {
+  uint64_t max_iter;
+  double tolerance;
+  double sigma_min;
+  double sigma_max;
+  double vega_threshold;
+} MangoInterpSolverConfig;
+
+// AdaptiveGridParams (all 9 fields; passed only when non-null).
+typedef struct {
+  double target_iv_error;
+  uint64_t max_iter;
+  uint64_t max_points_per_dim;
+  uint64_t min_moneyness_points;
+  uint64_t validation_samples;
+  double refinement_factor;
+  uint64_t lhs_seed;
+  double vega_floor;
+  double max_failure_rate;
+} MangoAdaptiveGridParams;
+
+// MultiKRefConfig.
+typedef struct {
+  const double* K_refs;       // may be null when n_K_refs == 0 (auto mode)
+  uint64_t n_K_refs;
+  int32_t K_ref_count;        // used iff K_refs empty; must be >= 1 (auto: 11)
+  double K_ref_span;
+} MangoMultiKRef;
+
+// DiscreteDividendConfig.
+typedef struct {
+  double maturity;
+  const MangoDividend* dividends;   // may be null when n_dividends == 0
+  uint64_t n_dividends;
+  MangoMultiKRef kref_config;
+} MangoDiscreteDividendConfig;
+
+// IVSolverFactoryConfig (B-spline backend only).
+typedef struct {
+  MangoOptionType option_type;
+  double spot;
+  double dividend_yield;
+  const double* moneyness;
+  uint64_t n_moneyness;
+  const double* vol;
+  uint64_t n_vol;
+  const double* rate;
+  uint64_t n_rate;
+  const double* maturity_grid;
+  uint64_t n_maturity;
+  MangoInterpSolverConfig solver_config;
+  const MangoAdaptiveGridParams* adaptive;              // null => fixed grid
+  const MangoDiscreteDividendConfig* discrete_dividends; // null => continuous
+} MangoIvFactoryConfig;
+
+// Per-query batch result slot (caller-allocated array of length n).
+typedef struct {
+  int32_t status;          // MangoStatus: MANGO_OK or an error category
+  MangoIvSuccess success;  // valid iff status == MANGO_OK
+} MangoIvBatchSlot;
+
+typedef struct MangoInterpIvSolver MangoInterpIvSolver;  // opaque
+typedef struct MangoPriceTable MangoPriceTable;          // opaque
+
 typedef struct MangoAmericanResult MangoAmericanResult;  // opaque
 
 MangoStatus mango_price_american(const MangoPricingParams* params,
@@ -85,6 +153,40 @@ MangoStatus mango_solve_iv(const MangoIvQuery* query,
                            const MangoIvConfig* config,   // nullable => defaults
                            MangoIvSuccess* out_success,
                            MangoError* out_err);
+
+// Interpolated IV solver.
+MangoStatus mango_make_interp_iv_solver(const MangoIvFactoryConfig* cfg,
+                                        MangoInterpIvSolver** out, MangoError* err);
+MangoStatus mango_interp_iv_solve(const MangoInterpIvSolver* s,
+                                  const MangoIvQuery* q,
+                                  MangoIvSuccess* out, MangoError* err);
+MangoStatus mango_interp_iv_solve_batch(const MangoInterpIvSolver* s,
+                                        const MangoIvQuery* queries, uint64_t n,
+                                        MangoIvBatchSlot* out_slots,
+                                        uint64_t* out_failed_count, MangoError* err);
+void mango_interp_iv_solver_free(MangoInterpIvSolver* s);
+
+// Price table (type-erased AnyPriceTable).
+MangoStatus mango_make_price_table(const MangoIvFactoryConfig* cfg,
+                                   MangoPriceTable** out, MangoError* err);
+MangoStatus mango_price_table_validate(const MangoPriceTable* t,
+                                       const MangoPricingParams* p, MangoError* err);
+double mango_price_table_price(const MangoPriceTable* t, const MangoPricingParams* p);
+double mango_price_table_vega(const MangoPriceTable* t, const MangoPricingParams* p);
+MangoStatus mango_price_table_delta(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err);
+MangoStatus mango_price_table_gamma(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err);
+MangoStatus mango_price_table_theta(const MangoPriceTable* t, const MangoPricingParams* p,
+                                    double* out, MangoError* err);
+MangoStatus mango_price_table_rho(const MangoPriceTable* t, const MangoPricingParams* p,
+                                  double* out, MangoError* err);
+MangoOptionType mango_price_table_option_type(const MangoPriceTable* t);
+double mango_price_table_dividend_yield(const MangoPriceTable* t);
+MangoStatus mango_price_table_make_iv_solver(const MangoPriceTable* t,
+                                             const MangoInterpSolverConfig* cfg,
+                                             MangoInterpIvSolver** out, MangoError* err);
+void mango_price_table_free(MangoPriceTable* t);
 
 #ifdef __cplusplus
 }  // extern "C"
@@ -114,6 +216,50 @@ static_assert(offsetof(MangoIvSuccess, has_vega) == 32, "has_vega off");
 static_assert(offsetof(MangoIvSuccess, used_rate_approximation) == 36, "used_rate_approximation off");
 static_assert(sizeof(MangoIvConfig) == 16, "MangoIvConfig size");
 static_assert(offsetof(MangoIvConfig, max_iter) == 8, "max_iter off");
+static_assert(sizeof(MangoInterpSolverConfig) == 40, "MangoInterpSolverConfig size");
+static_assert(offsetof(MangoInterpSolverConfig, max_iter) == 0, "interp max_iter off");
+static_assert(offsetof(MangoInterpSolverConfig, tolerance) == 8, "interp tolerance off");
+static_assert(offsetof(MangoInterpSolverConfig, sigma_min) == 16, "interp sigma_min off");
+static_assert(offsetof(MangoInterpSolverConfig, sigma_max) == 24, "interp sigma_max off");
+static_assert(offsetof(MangoInterpSolverConfig, vega_threshold) == 32, "interp vega_threshold off");
+static_assert(sizeof(MangoAdaptiveGridParams) == 72, "MangoAdaptiveGridParams size");
+static_assert(offsetof(MangoAdaptiveGridParams, target_iv_error) == 0, "adaptive target_iv_error off");
+static_assert(offsetof(MangoAdaptiveGridParams, max_iter) == 8, "adaptive max_iter off");
+static_assert(offsetof(MangoAdaptiveGridParams, max_points_per_dim) == 16, "adaptive max_points_per_dim off");
+static_assert(offsetof(MangoAdaptiveGridParams, min_moneyness_points) == 24, "adaptive min_moneyness_points off");
+static_assert(offsetof(MangoAdaptiveGridParams, validation_samples) == 32, "adaptive validation_samples off");
+static_assert(offsetof(MangoAdaptiveGridParams, refinement_factor) == 40, "adaptive refinement_factor off");
+static_assert(offsetof(MangoAdaptiveGridParams, lhs_seed) == 48, "adaptive lhs_seed off");
+static_assert(offsetof(MangoAdaptiveGridParams, vega_floor) == 56, "adaptive vega_floor off");
+static_assert(offsetof(MangoAdaptiveGridParams, max_failure_rate) == 64, "adaptive max_failure_rate off");
+static_assert(sizeof(MangoMultiKRef) == 32, "MangoMultiKRef size");
+static_assert(offsetof(MangoMultiKRef, K_refs) == 0, "K_refs off");
+static_assert(offsetof(MangoMultiKRef, n_K_refs) == 8, "n_K_refs off");
+static_assert(offsetof(MangoMultiKRef, K_ref_count) == 16, "K_ref_count off");
+static_assert(offsetof(MangoMultiKRef, K_ref_span) == 24, "K_ref_span off");
+static_assert(sizeof(MangoDiscreteDividendConfig) == 56, "MangoDiscreteDividendConfig size");
+static_assert(offsetof(MangoDiscreteDividendConfig, maturity) == 0, "dd maturity off");
+static_assert(offsetof(MangoDiscreteDividendConfig, dividends) == 8, "dd dividends off");
+static_assert(offsetof(MangoDiscreteDividendConfig, n_dividends) == 16, "dd n_dividends off");
+static_assert(offsetof(MangoDiscreteDividendConfig, kref_config) == 24, "dd kref_config off");
+static_assert(sizeof(MangoIvFactoryConfig) == 144, "MangoIvFactoryConfig size");
+static_assert(offsetof(MangoIvFactoryConfig, option_type) == 0, "fc option_type off");
+static_assert(offsetof(MangoIvFactoryConfig, spot) == 8, "fc spot off");
+static_assert(offsetof(MangoIvFactoryConfig, dividend_yield) == 16, "fc dividend_yield off");
+static_assert(offsetof(MangoIvFactoryConfig, moneyness) == 24, "fc moneyness off");
+static_assert(offsetof(MangoIvFactoryConfig, n_moneyness) == 32, "fc n_moneyness off");
+static_assert(offsetof(MangoIvFactoryConfig, vol) == 40, "fc vol off");
+static_assert(offsetof(MangoIvFactoryConfig, n_vol) == 48, "fc n_vol off");
+static_assert(offsetof(MangoIvFactoryConfig, rate) == 56, "fc rate off");
+static_assert(offsetof(MangoIvFactoryConfig, n_rate) == 64, "fc n_rate off");
+static_assert(offsetof(MangoIvFactoryConfig, maturity_grid) == 72, "fc maturity_grid off");
+static_assert(offsetof(MangoIvFactoryConfig, n_maturity) == 80, "fc n_maturity off");
+static_assert(offsetof(MangoIvFactoryConfig, solver_config) == 88, "fc solver_config off");
+static_assert(offsetof(MangoIvFactoryConfig, adaptive) == 128, "fc adaptive off");
+static_assert(offsetof(MangoIvFactoryConfig, discrete_dividends) == 136, "fc discrete_dividends off");
+static_assert(sizeof(MangoIvBatchSlot) == 48, "MangoIvBatchSlot size");
+static_assert(offsetof(MangoIvBatchSlot, status) == 0, "batch status off");
+static_assert(offsetof(MangoIvBatchSlot, success) == 8, "batch success off");
 #else
 _Static_assert(sizeof(MangoPricingParams) == 88, "MangoPricingParams size");
 _Static_assert(offsetof(MangoPricingParams, rate_const) == 40, "rate_const off");
@@ -136,6 +282,50 @@ _Static_assert(offsetof(MangoIvSuccess, has_vega) == 32, "has_vega off");
 _Static_assert(offsetof(MangoIvSuccess, used_rate_approximation) == 36, "used_rate_approximation off");
 _Static_assert(sizeof(MangoIvConfig) == 16, "MangoIvConfig size");
 _Static_assert(offsetof(MangoIvConfig, max_iter) == 8, "max_iter off");
+_Static_assert(sizeof(MangoInterpSolverConfig) == 40, "MangoInterpSolverConfig size");
+_Static_assert(offsetof(MangoInterpSolverConfig, max_iter) == 0, "interp max_iter off");
+_Static_assert(offsetof(MangoInterpSolverConfig, tolerance) == 8, "interp tolerance off");
+_Static_assert(offsetof(MangoInterpSolverConfig, sigma_min) == 16, "interp sigma_min off");
+_Static_assert(offsetof(MangoInterpSolverConfig, sigma_max) == 24, "interp sigma_max off");
+_Static_assert(offsetof(MangoInterpSolverConfig, vega_threshold) == 32, "interp vega_threshold off");
+_Static_assert(sizeof(MangoAdaptiveGridParams) == 72, "MangoAdaptiveGridParams size");
+_Static_assert(offsetof(MangoAdaptiveGridParams, target_iv_error) == 0, "adaptive target_iv_error off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, max_iter) == 8, "adaptive max_iter off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, max_points_per_dim) == 16, "adaptive max_points_per_dim off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, min_moneyness_points) == 24, "adaptive min_moneyness_points off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, validation_samples) == 32, "adaptive validation_samples off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, refinement_factor) == 40, "adaptive refinement_factor off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, lhs_seed) == 48, "adaptive lhs_seed off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, vega_floor) == 56, "adaptive vega_floor off");
+_Static_assert(offsetof(MangoAdaptiveGridParams, max_failure_rate) == 64, "adaptive max_failure_rate off");
+_Static_assert(sizeof(MangoMultiKRef) == 32, "MangoMultiKRef size");
+_Static_assert(offsetof(MangoMultiKRef, K_refs) == 0, "K_refs off");
+_Static_assert(offsetof(MangoMultiKRef, n_K_refs) == 8, "n_K_refs off");
+_Static_assert(offsetof(MangoMultiKRef, K_ref_count) == 16, "K_ref_count off");
+_Static_assert(offsetof(MangoMultiKRef, K_ref_span) == 24, "K_ref_span off");
+_Static_assert(sizeof(MangoDiscreteDividendConfig) == 56, "MangoDiscreteDividendConfig size");
+_Static_assert(offsetof(MangoDiscreteDividendConfig, maturity) == 0, "dd maturity off");
+_Static_assert(offsetof(MangoDiscreteDividendConfig, dividends) == 8, "dd dividends off");
+_Static_assert(offsetof(MangoDiscreteDividendConfig, n_dividends) == 16, "dd n_dividends off");
+_Static_assert(offsetof(MangoDiscreteDividendConfig, kref_config) == 24, "dd kref_config off");
+_Static_assert(sizeof(MangoIvFactoryConfig) == 144, "MangoIvFactoryConfig size");
+_Static_assert(offsetof(MangoIvFactoryConfig, option_type) == 0, "fc option_type off");
+_Static_assert(offsetof(MangoIvFactoryConfig, spot) == 8, "fc spot off");
+_Static_assert(offsetof(MangoIvFactoryConfig, dividend_yield) == 16, "fc dividend_yield off");
+_Static_assert(offsetof(MangoIvFactoryConfig, moneyness) == 24, "fc moneyness off");
+_Static_assert(offsetof(MangoIvFactoryConfig, n_moneyness) == 32, "fc n_moneyness off");
+_Static_assert(offsetof(MangoIvFactoryConfig, vol) == 40, "fc vol off");
+_Static_assert(offsetof(MangoIvFactoryConfig, n_vol) == 48, "fc n_vol off");
+_Static_assert(offsetof(MangoIvFactoryConfig, rate) == 56, "fc rate off");
+_Static_assert(offsetof(MangoIvFactoryConfig, n_rate) == 64, "fc n_rate off");
+_Static_assert(offsetof(MangoIvFactoryConfig, maturity_grid) == 72, "fc maturity_grid off");
+_Static_assert(offsetof(MangoIvFactoryConfig, n_maturity) == 80, "fc n_maturity off");
+_Static_assert(offsetof(MangoIvFactoryConfig, solver_config) == 88, "fc solver_config off");
+_Static_assert(offsetof(MangoIvFactoryConfig, adaptive) == 128, "fc adaptive off");
+_Static_assert(offsetof(MangoIvFactoryConfig, discrete_dividends) == 136, "fc discrete_dividends off");
+_Static_assert(sizeof(MangoIvBatchSlot) == 48, "MangoIvBatchSlot size");
+_Static_assert(offsetof(MangoIvBatchSlot, status) == 0, "batch status off");
+_Static_assert(offsetof(MangoIvBatchSlot, success) == 8, "batch success off");
 #endif
 
 #endif  // MANGO_C_API_H


### PR DESCRIPTION
## Summary

Extends the v1 Rust binding (#430, FDM pricing + implied vol) to cover the
**interpolation path**: a pre-computed B-spline price surface and the fast
interpolated IV solver (~3.5 µs/query vs ~8 ms FDM). Mirrors the scope of the
Python parity API (#427).

Two safe, idiomatic entry points (zero `unsafe` for callers):

- `InterpIvSolver` — `new(&FactoryConfig)`, `solve(&IvQuery)`, `solve_batch(&[IvQuery])`
- `PriceTable` — `new(&FactoryConfig)`, `price`/`vega`/`delta`/`gamma`/`theta`/`rho`
  (via `PricingParams`), `validate`, `option_type`, `dividend_yield`, and
  `iv_solver(...)` to derive a solver from an already-built surface.

Full B-spline config fidelity: `IVGrid` axes, `maturity_grid`, Newton
`solver_config`, optional **adaptive-grid** refinement, optional **discrete
dividends** (schedule + multi-K_ref), and OpenMP **batch** solve.

## Changes

- **C ABI shim** (`src/ffi/mango_c_api.{h,cpp}`): flat `MangoIvFactoryConfig`
  (B-spline backend only — no `std::variant` across the ABI), opaque
  `MangoInterpIvSolver`/`MangoPriceTable` handles, 16 new functions. Reuses the
  v1 marshalling/error helpers. `MangoIvSuccess` gains
  `used_rate_approximation` (set by the interpolated solver when a yield-curve
  query is collapsed to a flat rate) — slots into existing tail padding, so the
  v1 ABI offset/size are unchanged.
- **`-sys` crate**: `repr(C)` mirrors + `extern "C"` decls, guarded by
  bidirectional ABI layout tests (`static_assert(offsetof)` ↔ `offset_of!`).
- **Safe crate**: new `interp.rs` (`FactoryConfig` family + `InterpIvSolver`)
  and `table.rs` (`PriceTable`); `pricing.rs` factored to share
  `pricing_params_to_c`. RAII `Drop`; `Send + Sync` (immutable surfaces, const
  query methods).
- **Docs**: interpolation-path section in `docs/RUST_GUIDE.md`.

## Design notes / tradeoffs (in the design doc)

- **B-spline backend only.** Chebyshev/Dimensionless arms are out of scope
  (deferred; additive to add later).
- **Batch loses per-query message detail** — failed slots carry an error
  *category* (`ErrorKind`), not the full message; use single `solve` for detail.
- **`price`/`vega` extrapolate out of domain** (mirror the raw C++ signature);
  call `PriceTable::validate(&params)` first for an explicit bounds error.
- Grid axes need **≥4 points each** (cubic B-spline minimum).

## Testing

- `bazel test //crates/...` — layout tests + v1 integration + new interpolation
  integration (continuous IV round-trip, batch-with-failure, adaptive build,
  discrete-dividend build, validation errors, `Send + Sync` threaded smoke).
- `bazel test //tests:iv_solver_test`, `bazel build //src/python:mango_option
  //benchmarks/...` — all green (shared `MangoIvSuccess` change does not affect
  the pybind11 path).

Spec-driven: design doc + Codex design review (gate 1), per-task
spec+quality reviews, holistic branch review, and Codex pre-merge review (gate 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)