### PR TITLE
Zero jacobian.lower[n-2] in right-boundary Dirichlet/Neumann rows

### DIFF
--- a/src/pde/internal/pde_solver.hpp
+++ b/src/pde/internal/pde_solver.hpp
@@ -926,6 +926,7 @@ private:
         if constexpr (std::is_same_v<bc::boundary_tag_t<RightBCType>, bc::dirichlet_tag>) {
             // For Dirichlet: F(u) = u - g, so ∂F/∂u = 1
             jac.diag()[n_ - 1] = 1.0;
+            jac.lower()[n_ - 2] = 0.0;
         } else if constexpr (std::is_same_v<bc::boundary_tag_t<RightBCType>, bc::neumann_tag>) {
             // For Neumann: F(u) = u - rhs - coeff_dt·L(u)
             size_t i = n_ - 1;
@@ -934,6 +935,11 @@ private:
             double dLi_dui = (workspace_.reserved1()[i] - workspace_.lu()[i]) / eps;
             jac.diag()[i] = 1.0 - coeff_dt * dLi_dui;
             workspace_.u_stage()[i] = u[i];
+            // apply_spatial_operator zeroes Lu at the boundaries, so the
+            // FD coupling dLi/du[i-1] evaluates to exactly 0. Write it
+            // explicitly: lower[n-2] is not covered by the interior
+            // assembly loop and must never be left uninitialized.
+            jac.lower()[n_ - 2] = 0.0;
         }
     }
 

--- a/tests/american_option_test.cc
+++ b/tests/american_option_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <memory>
+#include <thread>
 #include <vector>
 
 namespace mango {
@@ -328,6 +329,55 @@ TEST(AmericanOptionTest, SolveAutoFromPrimaryHeader) {
     auto result = solve_american_option(params);
     ASSERT_TRUE(result.has_value());
     EXPECT_NEAR(result->value_at(100.0), 6.35, 0.5);
+}
+
+// ===========================================================================
+// Regression tests for bugs found during code review
+// ===========================================================================
+
+// Regression: Solver results must not depend on prior solves on the same
+// thread (issue #433).
+// Bug: build_jacobian_boundaries never wrote jacobian.lower()[n-2] for a
+// right Dirichlet BC, so the Thomas solve consumed stale bytes left in the
+// reused thread-local workspace arena by a previous solve with a different
+// grid size. A fresh thread's arena is zero-initialized (masking the bug),
+// so the same solve gave different prices depending on thread history.
+TEST(AmericanOptionTest, PriceIndependentOfThreadWorkspaceHistory) {
+    // A CALL on a narrow grid makes the bug visible: the right Dirichlet
+    // value g = e^x - e^{-r tau} is O(1) there (for a put it is ~0, so the
+    // stale sub-diagonal multiplies near-zero values and the error hides),
+    // and psi(x_max) = e^0.6 - 1 < 0.95 keeps deep-ITM locking from
+    // rewriting the rows adjacent to the boundary.
+    PricingParams params(
+        OptionSpec{.spot = 100.0, .strike = 100.0, .maturity = 1.0,
+                   .rate = 0.05, .dividend_yield = 0.0,
+                   .option_type = OptionType::CALL},
+        0.20);
+
+    auto solve_price = [&params](size_t n_space) {
+        PDEGridConfig grid{GridSpec<double>::uniform(-0.6, 0.6, n_space).value(), 200};
+        auto solver = AmericanOptionSolver::create(params, PDEGridSpec{grid});
+        EXPECT_TRUE(solver.has_value());
+        auto result = solver->solve();
+        EXPECT_TRUE(result.has_value());
+        return result->value_at(params.spot);
+    };
+
+    // Reference price from a fresh thread: zero-initialized TLS arena.
+    double clean_price = 0.0;
+    std::thread([&] { clean_price = solve_price(201); }).join();
+
+    // Same solve on another fresh thread, after a different-sized solve
+    // dirtied that thread's arena.
+    double dirty_price = 0.0;
+    std::thread([&] {
+        (void)solve_price(301);
+        dirty_price = solve_price(201);
+    }).join();
+
+    EXPECT_EQ(clean_price, dirty_price)
+        << "identical solve returned a different price depending on "
+           "thread-local workspace history (stale jacobian.lower()[n-2])";
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Fixes #433: the last Jacobian row's sub-diagonal (`lower[n-2]`) was never written under a right Dirichlet BC, so the Thomas solve consumed stale bytes from the reused thread-local workspace arena — the same option priced up to 1.98e-3 differently depending on what had previously been solved on that thread.

## Root cause
- Interior assembly writes `lower[i-1]` for i ∈ [1, n−2] (max index n−3); the right-Dirichlet branch set only `diag[n-1] = 1.0`.
- The zeroing line existed in the original implementation (PR #93) and its design spec (`docs/archive/designs/2025-11-04-newton-raphson-pde-solver.md`), and was dropped in the PR #94 refactor. It became observable when PR #200 switched the obstacle path to the direct solve `A·u = rhs`, whose last row multiplies `lower[n-2]` directly.
- Hidden from tests because fresh (OS-zeroed) thread-local memory happens to contain the correct value, 0.0.

## Changes
- Restore `jac.lower()[n_-2] = 0.0` in the right-Dirichlet branch of `build_jacobian_boundaries`.
- Same explicit write in the right-Neumann branch (its FD coupling evaluates to exactly 0 today; the slot must never stay uninitialized).
- Regression test `PriceIndependentOfThreadWorkspaceHistory`: prices a call on a fresh thread vs. on a thread whose arena was dirtied by a different-sized solve; requires bit-identical results. Fails pre-fix (10.4497618975 vs 10.4477797824), passes post-fix.

## Testing
- 134/134 `bazel test //...`
- `bazel build //benchmarks/...` and `//src/python:mango_option` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)