### PR TITLE
Fix deep-ITM lock clamping continuation value to intrinsic

### DIFF
--- a/docs/MATHEMATICAL_FOUNDATIONS.md
+++ b/docs/MATHEMATICAL_FOUNDATIONS.md
@@ -252,9 +252,11 @@ For M-matrices, the off-diagonal elements are non-positive, so increasing $u_{i+
 
 One practical detail: for nodes deep in-the-money where $\psi$ is close to the maximum intrinsic value, numerical diffusion can erroneously lift the solution above intrinsic. We prevent this by converting deep ITM nodes to Dirichlet constraints:
 
-$$\text{if } \psi_i > 0.95 \cdot \psi_\max \text{ and } u_i \approx \psi_i\text{: lock } u_i = \psi_i$$
+$$\text{if } \psi_i > 0.95 \cdot \psi_\max \text{ and } u_i \approx \psi_i \text{ and } L(\psi)_i < 0 \text{: lock } u_i = \psi_i$$
 
-This ensures, for example, that a deep ITM put with intrinsic value 99.75 prices at 99.75 rather than being lifted to 115.97 by diffusion.
+The third condition checks that the payoff is a strict subsolution at the node — holding it loses value, so exercise is genuinely optimal and the LCP solution is $u = \psi$ there. For Black-Scholes this reduces to $qS < rK$ for puts and $qS > rK$ for calls. Without it, the lock would clamp nodes whose true solution lifts off the obstacle (a zero-rate deep-ITM put, or a no-dividend call, both of which must price at the European value). All three conditions are re-evaluated every stage, so a lock releases as soon as it stops being justified.
+
+This ensures, for example, that a deep ITM put with intrinsic value 99.75 prices at 99.75 rather than being lifted to 115.97 by diffusion, while a no-dividend American call at $S = 2K$ retains its full continuation value.
 
 ### The Early Exercise Boundary
 

--- a/src/pde/internal/pde_solver.hpp
+++ b/src/pde/internal/pde_solver.hpp
@@ -610,44 +610,56 @@ private:
         // This ELIMINATES the tridiagonal coupling for those nodes, preventing diffusion
         // from affecting them. The equation becomes simply: u[i] = ψ[i].
         //
-        // **Threshold Selection:**
-        // - Lock only if ψ > 0.95 (95% of strike in normalized units)
-        // - For American puts: ψ = max(1 - exp(x), 0), so:
-        //     ψ > 0.95  ⟺  1 - exp(x) > 0.95  ⟺  exp(x) < 0.05  ⟺  x < -3.0
-        // - This is ~3 log-moneyness units deep ITM, well separated from ATM (x=0)
-        // - ATM/near-ATM nodes (where time value exists) remain free to solve via LCP
-        //
-        // **Why 0.95 and not 0.99 or 1.0?**
-        // - 0.99 would only lock the extreme boundary (x → -∞)
-        // - 0.95 captures the entire region where exercise is definitively optimal
-        // - Empirically verified: S=0.25, K=100 has ψ ≈ 0.9975 at spot, needs locking
+        // **Lock criterion** (all three must hold):
+        // 1. Deep in payoff, relative to the obstacle's own scale:
+        //      ψ[i] > 0.95·max(ψ). The payoff scale differs by option type —
+        //    puts are bounded (ψ ≤ 1, so 0.95·ψ_max ≈ x < -3) while calls are
+        //    unbounded (ψ = eˣ - 1). An absolute threshold of 0.95 locked
+        //    calls from S > 1.95K, clamping continuation-valued nodes to
+        //    intrinsic and pricing below intrinsic (issue #432).
+        // 2. On obstacle: u[i] - ψ[i] < 1e-8 (solution already at intrinsic).
+        //    Prevents locking nodes that legitimately carry time value.
+        // 3. Exercise is actually optimal there: L(ψ)[i] < 0, i.e. the payoff
+        //    is a strict subsolution — holding it loses value, so the LCP
+        //    solution is u = ψ. For Black-Scholes this is qS < rK (puts) /
+        //    qS > rK (calls). Without this check the lock ratchets: u = ψ
+        //    makes condition 2 true forever, even where the true solution
+        //    lifts off the obstacle (e.g. r=0 puts, no-dividend calls).
+        // Conditions 1+3 are re-evaluated every stage, so a lock releases as
+        // soon as it stops being justified.
         //
         // **Implementation:** Convert Jacobian row to identity:
         //   Before: [a_lower[i], a_diag[i], a_upper[i]] · [u[i-1], u[i], u[i+1]]ᵀ = rhs[i]
         //   After:  [0, 1, 0] · [u[i-1], u[i], u[i+1]]ᵀ = ψ[i]
         //   Result: u[i] = ψ[i] (Dirichlet constraint)
-        constexpr double deep_itm_threshold = 0.95;  // Lock if ψ > 95% of strike
+        constexpr double deep_itm_fraction = 0.95;   // Lock if ψ > 95% of max(ψ)
         constexpr double exercise_tolerance = 1e-8;  // Tolerance for "on obstacle"
 
-        for (size_t i = 1; i < n_ - 1; ++i) {
-            // Check both conditions:
-            // 1. Deep ITM: ψ[i] > 0.95 (far from ATM where time value matters)
-            // 2. On obstacle: u[i] - ψ[i] < 1e-8 (solution already at intrinsic)
-            //
-            // The second condition prevents locking nodes that legitimately have
-            // time value > 0 (e.g., at earlier times before convergence to payoff).
-            bool deep_itm = (psi[i] > deep_itm_threshold);
-            bool at_obstacle = (u[i] - psi[i] < exercise_tolerance);
+        const double psi_max = *std::max_element(psi.begin(), psi.end());
+        if (psi_max > 0.0) {
+            // L(ψ): newton_u_old is free here — it is only used by the
+            // Newton path (solve_implicit_stage), never by this projected
+            // path. Boundary entries of L(ψ) are zeroed by
+            // apply_spatial_operator; the loop below is interior-only.
+            auto lpsi = workspace_.newton_u_old();
+            apply_spatial_operator(t, psi, lpsi);
 
-            if (deep_itm && at_obstacle) {
-                // Convert row i to Dirichlet constraint: u[i] = ψ[i]
-                // Jacobian row: [0, 1, 0] (identity row)
-                // RHS: ψ[i] (intrinsic value)
-                auto jac = workspace_.jacobian();
-                if (i > 0) jac.lower()[i-1] = 0.0;  // Zero lower diagonal
-                jac.diag()[i] = 1.0;                 // Set diagonal to 1
-                if (i < n_ - 1) jac.upper()[i] = 0.0; // Zero upper diagonal
-                rhs_with_bc[i] = psi[i];                 // RHS = intrinsic value
+            const double deep_itm_threshold = deep_itm_fraction * psi_max;
+            for (size_t i = 1; i < n_ - 1; ++i) {
+                bool deep_itm = (psi[i] > deep_itm_threshold);
+                bool at_obstacle = (u[i] - psi[i] < exercise_tolerance);
+                bool payoff_subsolution = (lpsi[i] < 0.0);
+
+                if (deep_itm && at_obstacle && payoff_subsolution) {
+                    // Convert row i to Dirichlet constraint: u[i] = ψ[i]
+                    // Jacobian row: [0, 1, 0] (identity row)
+                    // RHS: ψ[i] (intrinsic value)
+                    auto jac = workspace_.jacobian();
+                    jac.lower()[i-1] = 0.0;   // Zero lower diagonal
+                    jac.diag()[i] = 1.0;      // Set diagonal to 1
+                    jac.upper()[i] = 0.0;     // Zero upper diagonal
+                    rhs_with_bc[i] = psi[i];  // RHS = intrinsic value
+                }
             }
         }
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -544,6 +544,7 @@ cc_test(
     deps = [
         "//src/option:american_option",
         "//src/option:american_option_batch",
+        "//src/option:european_option",
         "@googletest//:gtest_main",
     ],
     copts = [

--- a/tests/american_option_test.cc
+++ b/tests/american_option_test.cc
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include "mango/option/american_option.hpp"
 #include "mango/option/american_option_batch.hpp"
+#include "mango/option/european_option.hpp"
 
 #include <gtest/gtest.h>
 #include <cmath>
@@ -378,6 +379,55 @@ TEST(AmericanOptionTest, PriceIndependentOfThreadWorkspaceHistory) {
     EXPECT_EQ(clean_price, dirty_price)
         << "identical solve returned a different price depending on "
            "thread-local workspace history (stale jacobian.lower()[n-2])";
+}
+
+// Regression: no-dividend American call must equal the European price and
+// never fall below intrinsic (issue #432).
+// Bug: the deep-ITM lock used an absolute threshold psi > 0.95, derived for
+// the bounded put payoff (psi <= 1  =>  x < -3). The call payoff e^x - 1 is
+// unbounded and crosses 0.95 at S > 1.95K, so moderately ITM calls had
+// continuation-valued nodes permanently ratcheted to intrinsic — the price
+// came out below intrinsic (arbitrage violation).
+TEST(AmericanOptionTest, NoDividendCallEqualsEuropean) {
+    for (double spot : {150.0, 200.0, 300.0}) {
+        PricingParams params(
+            OptionSpec{.spot = spot, .strike = 100.0, .maturity = 1.0,
+                       .rate = 0.05, .dividend_yield = 0.0,
+                       .option_type = OptionType::CALL},
+            0.20);
+
+        auto result = solve_american_option(params);
+        ASSERT_TRUE(result.has_value()) << "spot=" << spot;
+
+        const double american = result->value_at(spot);
+        const double european = EuropeanOptionResult(params).value();
+        const double intrinsic = spot - params.strike;
+
+        EXPECT_GE(american, intrinsic - 1e-6) << "spot=" << spot;
+        EXPECT_NEAR(american, european, 0.05) << "spot=" << spot;
+    }
+}
+
+// Regression: with r=0 early exercise of a put is never optimal, so the
+// American put equals the European put — even deep ITM (issue #432).
+// Bug: the deep-ITM lock clamped every node with psi > 0.95 to intrinsic
+// regardless of whether holding the payoff loses value (L(psi) <= 0), so a
+// zero-rate deep-ITM put lost its continuation value.
+TEST(AmericanOptionTest, ZeroRateDeepITMPutEqualsEuropean) {
+    PricingParams params(
+        OptionSpec{.spot = 4.0, .strike = 100.0, .maturity = 1.0,
+                   .rate = 0.0, .dividend_yield = 0.04,
+                   .option_type = OptionType::PUT},
+        0.20);
+
+    auto result = solve_american_option(params);
+    ASSERT_TRUE(result.has_value());
+
+    const double american = result->value_at(params.spot);
+    const double european = EuropeanOptionResult(params).value();
+
+    EXPECT_GE(american, european - 0.05);
+    EXPECT_NEAR(american, european, 0.05);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Fixes #432: the deep-ITM obstacle lock misprices American calls (below intrinsic — an arbitrage violation) and zero-rate deep-ITM puts, by permanently clamping continuation-valued nodes to intrinsic.

## Root cause
The lock criterion `psi > 0.95` (absolute) was derived for the bounded put payoff (ψ ≤ 1 ⟹ x < −3, per the PR #200 design docs, which hardcoded `AmericanPutObstacle`). The call payoff eˣ−1 is unbounded and crosses 0.95 at just S > 1.95K. Worse, the lock ratcheted: locking sets u = ψ, which keeps the "at obstacle" condition true on every later stage, so a node once locked never lifted off — even where the true solution has continuation value (no-dividend calls, r=0 puts).

## Fix
Lock criterion is now the design-documented relative threshold plus the LCP optimality condition:
- `psi[i] > 0.95·max(psi)` — deep relative to the payoff's own scale
- `u[i] − psi[i] < 1e-8` — already on the obstacle
- `L(psi)[i] < 0` — the payoff is a strict subsolution (holding it loses value ⟹ exercise genuinely optimal ⟹ LCP solution is u = ψ). For Black-Scholes this reduces to qS < rK (puts) / qS > rK (calls).

All three re-evaluate every stage, so locks release when no longer justified. `L(ψ)` is computed numerically with one extra operator application per implicit stage (O(n), no allocation — reuses the `newton_u_old` buffer, which the projected path never touches).

`docs/MATHEMATICAL_FOUNDATIONS.md` "Deep ITM Locking" updated to match.

## Before / after
| Case | Before | After |
|------|--------|-------|
| CALL S=200, K=100, r=5%, q=0, σ=0.2, T=1 (European = American = 104.878) | 99.936 (< intrinsic 100) | ≈ European ✓ |
| PUT S=4, K=100, r=0, q=4% (American = European = 96.107) | 96.000 (intrinsic) | ≈ European ✓ |
| PUT S=0.25, K=100, r=5% (PR #200 motivating case) | intrinsic ✓ | intrinsic ✓ (still locks) |

## Testing
- New regression tests `NoDividendCallEqualsEuropean` (S ∈ {150, 200, 300}, price ≥ intrinsic and ≈ European) and `ZeroRateDeepITMPutEqualsEuropean` — both fail before the fix, pass after.
- 134/134 `bazel test //...` including the QuantLib comparison suite and `PutImmediateExerciseAtBoundary`.
- `bazel build //benchmarks/...` and `//src/python:mango_option` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)