### PR TITLE
Compute L(psi) lazily in the deep-ITM lock

### DIFF
--- a/src/pde/internal/pde_solver.hpp
+++ b/src/pde/internal/pde_solver.hpp
@@ -637,28 +637,44 @@ private:
 
         const double psi_max = *std::max_element(psi.begin(), psi.end());
         if (psi_max > 0.0) {
-            // L(ψ): newton_u_old is free here — it is only used by the
-            // Newton path (solve_implicit_stage), never by this projected
-            // path. Boundary entries of L(ψ) are zeroed by
-            // apply_spatial_operator; the loop below is interior-only.
-            auto lpsi = workspace_.newton_u_old();
-            apply_spatial_operator(t, psi, lpsi);
-
             const double deep_itm_threshold = deep_itm_fraction * psi_max;
-            for (size_t i = 1; i < n_ - 1; ++i) {
-                bool deep_itm = (psi[i] > deep_itm_threshold);
-                bool at_obstacle = (u[i] - psi[i] < exercise_tolerance);
-                bool payoff_subsolution = (lpsi[i] < 0.0);
 
-                if (deep_itm && at_obstacle && payoff_subsolution) {
-                    // Convert row i to Dirichlet constraint: u[i] = ψ[i]
-                    // Jacobian row: [0, 1, 0] (identity row)
-                    // RHS: ψ[i] (intrinsic value)
-                    auto jac = workspace_.jacobian();
-                    jac.lower()[i-1] = 0.0;   // Zero lower diagonal
-                    jac.diag()[i] = 1.0;      // Set diagonal to 1
-                    jac.upper()[i] = 0.0;     // Zero upper diagonal
-                    rhs_with_bc[i] = psi[i];  // RHS = intrinsic value
+            // Cheap pre-scan: find the first node satisfying conditions 1+2.
+            // Only if one exists do we pay for the L(ψ) operator sweep
+            // (condition 3). ATM-centered grids — the common case in price
+            // table builds — have no deep candidates, so they skip it.
+            size_t first_candidate = n_ - 1;
+            for (size_t i = 1; i < n_ - 1; ++i) {
+                if (psi[i] > deep_itm_threshold &&
+                    u[i] - psi[i] < exercise_tolerance) {
+                    first_candidate = i;
+                    break;
+                }
+            }
+
+            if (first_candidate < n_ - 1) {
+                // L(ψ): newton_u_old is free here — it is only used by the
+                // Newton path (solve_implicit_stage), never by this projected
+                // path. Boundary entries of L(ψ) are zeroed by
+                // apply_spatial_operator; the loop below is interior-only.
+                auto lpsi = workspace_.newton_u_old();
+                apply_spatial_operator(t, psi, lpsi);
+
+                for (size_t i = first_candidate; i < n_ - 1; ++i) {
+                    bool deep_itm = (psi[i] > deep_itm_threshold);
+                    bool at_obstacle = (u[i] - psi[i] < exercise_tolerance);
+                    bool payoff_subsolution = (lpsi[i] < 0.0);
+
+                    if (deep_itm && at_obstacle && payoff_subsolution) {
+                        // Convert row i to Dirichlet constraint: u[i] = ψ[i]
+                        // Jacobian row: [0, 1, 0] (identity row)
+                        // RHS: ψ[i] (intrinsic value)
+                        auto jac = workspace_.jacobian();
+                        jac.lower()[i-1] = 0.0;   // Zero lower diagonal
+                        jac.diag()[i] = 1.0;      // Set diagonal to 1
+                        jac.upper()[i] = 0.0;     // Zero upper diagonal
+                        rhs_with_bc[i] = psi[i];  // RHS = intrinsic value
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Follow-up to #446. The lock criterion evaluates L(ψ) via a full spatial-operator sweep on every implicit stage; this PR makes that sweep conditional on a cheap O(n) pre-scan for lock candidates (`ψ > 0.95·ψ_max && u ≈ ψ`).

## Rationale
- The sweep only matters when a candidate node exists; otherwise its result is never read.
- Grids whose deep nodes carry time value (e.g. no-dividend calls once the solution lifts off the payoff) skip the sweep on every subsequent stage.
- Workloads with a genuine locked exercise region (deep-ITM puts with r > 0) pay exactly the same cost as before.
- Strictly never-more-work; behavior is bit-identical — nodes skipped by the pre-scan fail the lock conditions regardless of L(ψ).

Local wall-clock benchmarking of the OpenMP-parallel adaptive test proved too noisy to quote (>2x run-to-run variance on identical binaries), so no speedup number is claimed — the change is justified structurally.

## Testing
- 134/134 `bazel test //...`
- `bazel build //benchmarks/...` and `//src/python:mango_option` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)